### PR TITLE
Upgrade the manual to docbook 5.0

### DIFF
--- a/mate-user-guide/C/glossary.xml
+++ b/mate-user-guide/C/glossary.xml
@@ -1,6 +1,11 @@
-<glossary id="glossary-1">
-  <title>Glossary</title>
-  <glossentry id="glossary-6">
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<glossary xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         version="5.0" xml:id="glossary-1" xml:lang="en">
+    <info><title>Glossary</title></info>
+  
+  <glossentry xml:id="glossary-6">
     <glossterm>applet</glossterm>
     <glossdef>
       <para>An applet is a small, interactive application that resides
@@ -9,20 +14,20 @@ applet has a simple user interface that you can operate with the mouse or
 keyboard. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-40">
+  <glossentry xml:id="glossary-40">
     <glossterm>desktop</glossterm>
     <glossdef>
       <para>The part of the MATE Desktop where there are no interface
 graphical items, such as panels and windows.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-31">
+  <glossentry xml:id="glossary-31">
     <glossterm>desktop background</glossterm>
     <glossdef>
       <para>The image or color that is applied to your desktop. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-9">
+  <glossentry xml:id="glossary-9">
     <glossterm>desktop object</glossterm>
     <glossdef>
       <para>An icon on your desktop that you can use to open your files,
@@ -30,27 +35,27 @@ folders, and applications. You can use desktop objects to provide convenient
 access to files, folders, and applications that you use frequently.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-20">
+  <glossentry xml:id="glossary-20">
     <glossterm>DNS name</glossterm>
     <glossdef>
       <para>A unique alphabetic identifier for a computer on a network.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-8">
+  <glossentry xml:id="glossary-8">
     <glossterm>drawer</glossterm>
     <glossdef>
       <para>A drawer is a sliding extension to a panel that you can open
 or close from a drawer icon. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-fileextension">
+  <glossentry xml:id="glossary-fileextension">
     <glossterm>file extension</glossterm>
     <glossdef>
       <para>The final portion of a file's name, after the last period (.) in the name. For example, the file extension of the file <filename>picture.jpeg</filename> is <filename>jpeg</filename>.</para>
       <para>The file extension can identify the type of file. <application>Caja</application> file manager uses this information when to determine what to do when you open a file. For more on this, see <xref linkend="caja-open-file"/>.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-23">
+  <glossentry xml:id="glossary-23">
     <glossterm>format</glossterm>
     <glossdef>
       <para>To format media is to prepare the media for use with a particular
@@ -58,7 +63,7 @@ file system. When you format media, you overwrite any existing information
 on the media. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-10">
+  <glossentry xml:id="glossary-10">
     <glossterm>MATE-compliant application</glossterm>
     <glossdef>
       <para>An application that uses the standard MATE programming libraries
@@ -66,34 +71,34 @@ is called a MATE-compliant application. For example, <application>Caja</applicat
 are MATE-compliant applications.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-21">
+  <glossentry xml:id="glossary-21">
     <glossterm>IP address</glossterm>
     <glossdef>
       <para>A unique numeric identifier for a computer on a network.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-25">
+  <glossentry xml:id="glossary-25">
     <glossterm>keyboard shortcut</glossterm>
     <glossdef>
       <para>A <firstterm>keyboard shortcut</firstterm> is a key or combination
 of keys that provides an alternative to standard ways of performing an action. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-3">
+  <glossentry xml:id="glossary-3">
     <glossterm>launcher</glossterm>
     <glossdef>
       <para>A launcher starts a particular application, executes a command,
 or opens a file. A launcher can reside in a panel or in a menu.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-11">
+  <glossentry xml:id="glossary-11">
     <glossterm>menubar</glossterm>
     <glossdef>
       <para>A menubar is a bar at the top of an application window that
 contains the menus for the application. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-27">
+  <glossentry xml:id="glossary-27">
     <glossterm>MIME type</glossterm>
     <glossdef>
       <para>A Multipurpose Internet Mail Extension (MIME) type identifies
@@ -103,7 +108,7 @@ MIME type to detect that a Portable Networks Graphic (PNG) file is attached
 to an email.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-24">
+  <glossentry xml:id="glossary-24">
     <glossterm>mount</glossterm>
     <glossdef>
       <para>To mount is to make a file system available for access. When
@@ -111,41 +116,41 @@ you mount a file system, the file system is attached as a subdirectory to
 your file system. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-4">
+  <glossentry xml:id="glossary-4">
     <glossterm>pane</glossterm>
     <glossdef>
       <para>A pane is a subdivision of a window. For example, the <application>Caja</application> window contains a side pane and a view pane. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-2">
+  <glossentry xml:id="glossary-2">
     <glossterm>preference tool</glossterm>
     <glossdef>
       <para>A dedicated software tool that controls a particular part
 of the behavior of the MATE Desktop.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-5">
+  <glossentry xml:id="glossary-5">
     <glossterm>shortcut keys</glossterm>
     <glossdef>
       <para>Shortcut keys are keystrokes that provide a quick way to perform
 an action. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-15">
+  <glossentry xml:id="glossary-15">
     <glossterm>stacking order</glossterm>
     <glossdef>
       <para>The stacking order is the order in which windows are stacked
 on top of each other on your screen. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-13">
+  <glossentry xml:id="glossary-13">
     <glossterm>statusbar</glossterm>
     <glossdef>
       <para>A statusbar is a bar at the bottom of a window that provides
 information about the current state of what you are viewing in the window. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-28">
+  <glossentry xml:id="glossary-28">
     <glossterm>symbolic link</glossterm>
     <glossdef>
       <para>A special type of file that points to another file or folder.
@@ -153,14 +158,14 @@ When you perform an action on a symbolic link, the action is performed on
 the file or folder to which the symbolic link points. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-12">
+  <glossentry xml:id="glossary-12">
     <glossterm>toolbar</glossterm>
     <glossdef>
       <para>A toolbar is a bar that contains buttons for the most commonly-used
 commands in an application. Typically, a toolbar appears under a menubar.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-29">
+  <glossentry xml:id="glossary-29">
     <glossterm>Uniform Resource Identifier</glossterm>
     <glossdef>
       <para>A Uniform Resource Identifier (URI) is a string that identifies
@@ -168,14 +173,14 @@ a particular location in a file system or on the Web. For example, the address
 of a web page is a URI.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-19">
+  <glossentry xml:id="glossary-19">
     <glossterm>Uniform Resource Locator</glossterm>
     <glossdef>
       <para>A Uniform Resource Locator (URL) is the address of a particular
 location on the Web.</para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-16">
+  <glossentry xml:id="glossary-16">
     <glossterm>view</glossterm>
     <glossdef>
       <para>A <application>Caja</application> component that enables
@@ -184,7 +189,7 @@ of a folder as icons. <application>Caja</application> also contains a
 list view which enables you to display the contents of a folder as a list. </para>
     </glossdef>
   </glossentry>
-  <glossentry id="glossary-7">
+  <glossentry xml:id="glossary-7">
     <glossterm>workspace</glossterm>
     <glossdef>
       <para>A workspace is a discrete area in the MATE Desktop in which

--- a/mate-user-guide/C/gosbasic.xml
+++ b/mate-user-guide/C/gosbasic.xml
@@ -1,22 +1,24 @@
-<!-- -*- indent-tabs-mode: nil -*- -->
-<chapter id="basic-skills">
-<title>Basic Skills</title>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         version="5.0" xml:id="basic-skills" xml:lang="en">
+    <info><title>Basic Skills</title></info>
 
 <!-- Maintained for 2.8 compatibility -->
-<anchor id="part1-1"/>
-<anchor id="gosbasic-1"/>
-<anchor id="gosbasic-46"/> <!-- was Using Windows -->
+<anchor xml:id="part1-1"/>
+<anchor xml:id="gosbasic-1"/>
+<anchor xml:id="gosbasic-46"/> <!-- was Using Windows -->
 
 <highlights>
   <para>This chapter introduces you to the basic skills that you
   need to work with the MATE Desktop.</para>
 </highlights>
 
-<section id="mouse-skills">
-  <title>Mouse Skills</title>
-
+<section xml:id="mouse-skills"><info><title>Mouse Skills</title></info>
+  
   <!-- Maintained for 2.8 compatibility -->
-  <anchor id="gosbasic-2"/>
+  <anchor xml:id="gosbasic-2"/>
 
   <indexterm>
     <primary>basic skills</primary>
@@ -45,12 +47,10 @@ a small arrow with which you point to objects on your screen. Pressing a mouse b
 action on the object over which your mouse pointer is situated, depending on which button you press.
     </para>
 
-  <section id="mouse-conventions">
-    <title>Mouse Button Conventions</title>
-    <titleabbrev>Buttons</titleabbrev>
-
+  <section xml:id="mouse-conventions"><info><title>Mouse Button Conventions</title><titleabbrev>Buttons</titleabbrev></info>
+    
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosgetstarted-44"/>
+    <anchor xml:id="gosgetstarted-44"/>
 
     <indexterm>
       <primary>mouse</primary>
@@ -100,13 +100,11 @@ action on the object over which your mouse pointer is situated, depending on whi
 
   </section>
 
-  <section id="mouse-actions">
-    <title>Mouse Actions</title>
-    <titleabbrev>Actions</titleabbrev>
-
+  <section xml:id="mouse-actions"><info><title>Mouse Actions</title><titleabbrev>Actions</titleabbrev></info>
+    
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosgetstarted-45"/>
-    <anchor id="gosbasic-6"/>
+    <anchor xml:id="gosgetstarted-45"/>
+    <anchor xml:id="gosbasic-6"/>
     
     <indexterm>
       <primary>mouse</primary>
@@ -293,12 +291,10 @@ action on the object over which your mouse pointer is situated, depending on whi
 
   </section>
 
-  <section id="mouse-pointers">
-    <title>Mouse Pointers</title>
-    <titleabbrev>Pointers</titleabbrev>
-
+  <section xml:id="mouse-pointers"><info><title>Mouse Pointers</title><titleabbrev>Pointers</titleabbrev></info>
+    
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosbasic-7"/>
+    <anchor xml:id="gosbasic-7"/>
 
     <indexterm>
       <primary>mouse</primary>
@@ -323,8 +319,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/normal_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/normal_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Normal pointer.</phrase>
@@ -339,8 +334,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/busy_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/busy_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Busy pointer.</phrase>
@@ -354,8 +348,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/resize_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/resize_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Resize pointer.</phrase>
@@ -372,8 +365,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/hyperlink_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/hyperlink_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Hand pointer</phrase>
@@ -390,8 +382,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/ibeam_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/ibeam_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>I-beam pointer</phrase>
@@ -413,8 +404,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/move_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/move_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Move pointer.</phrase>
@@ -430,8 +420,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/copy_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/copy_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Copy pointer.</phrase>
@@ -447,8 +436,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/link_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/link_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Symbolic link pointer.</phrase>
@@ -466,8 +454,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/ask_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/ask_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Ask pointer.</phrase>
@@ -484,8 +471,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/not_available_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/not_available_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Not available pointer.</phrase>
@@ -500,8 +486,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/move_panel_object_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/move_panel_object_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Move panel object pointer.</phrase>
@@ -517,8 +502,7 @@ action on the object over which your mouse pointer is situated, depending on whi
         <term>
           <inlinemediaobject>
             <imageobject>
-              <imagedata format="PNG"
-                         fileref="figures/movewindow_pointer.png"/>
+              <imagedata format="PNG" fileref="figures/movewindow_pointer.png"/>
             </imageobject>
             <textobject>
               <phrase>Move window pointer.</phrase>
@@ -534,11 +518,11 @@ action on the object over which your mouse pointer is situated, depending on whi
   </section>
 </section>
 
-<section id="keyboard-skills">
-  <title>Keyboard Skills</title>
+<section xml:id="keyboard-skills"><info><title>Keyboard Skills</title></info>
+  
 
   <!-- Maintained for 2.8 compatibility -->
-  <anchor id="gosbasic-51"/>
+  <anchor xml:id="gosbasic-51"/>
 
   <indexterm>
     <primary>basic skills</primary>
@@ -574,11 +558,11 @@ action on the object over which your mouse pointer is situated, depending on whi
   <para>The following sections describe the shortcut keys that you can use
   throughout the desktop and applications.</para>
 
-  <section id="shortcuts-global">
-    <title>Global Shortcut Keys</title>
+  <section xml:id="shortcuts-global"><info><title>Global Shortcut Keys</title></info>
+    
 
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosbasic-62"/>
+    <anchor xml:id="gosbasic-62"/>
 
     <indexterm>
       <primary>shortcut keys</primary>
@@ -703,11 +687,10 @@ action on the object over which your mouse pointer is situated, depending on whi
     </informaltable>
   </section>
 
-  <section id="shortcuts-window">
-    <title>Window Shortcut Keys</title>
-
+  <section xml:id="shortcuts-window"><info><title>Window Shortcut Keys</title></info>
+    
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosbasic-58"/>
+    <anchor xml:id="gosbasic-58"/>
 
     <indexterm>
       <primary>shortcut keys</primary>
@@ -842,12 +825,12 @@ action on the object over which your mouse pointer is situated, depending on whi
     </informaltable>
   </section>
 
-  <section id="shortcuts-apps">
-    <title>Application Keys</title>
+  <section xml:id="shortcuts-apps"><info><title>Application Keys</title></info>
+    
 
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosbasic-59"/>
-    <anchor id="gosbasic-61"/> <!-- was Panel Shortcut Keys -->
+    <anchor xml:id="gosbasic-59"/>
+    <anchor xml:id="gosbasic-61"/> <!-- was Panel Shortcut Keys -->
 
     <indexterm>
       <primary>shortcut keys</primary>
@@ -1016,11 +999,11 @@ action on the object over which your mouse pointer is situated, depending on whi
     </informaltable>
   </section>
 
-  <section id="shortcuts-access">
-    <title>Access Keys</title>
+  <section xml:id="shortcuts-access"><info><title>Access Keys</title></info>
+    
 
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosbasic-63"/>
+    <anchor xml:id="gosbasic-63"/>
 
     <indexterm>
       <primary>access keys</primary>

--- a/mate-user-guide/C/goscaja.xml
+++ b/mate-user-guide/C/goscaja.xml
@@ -1,50 +1,54 @@
-<chapter id="caja">
-  <title>Working with Files</title>
-
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         version="5.0" xml:id="caja" xml:lang="en">
+    <info><title>Working with Files</title></info>
+  
   <!-- ID tag preserved for 2.8 compatibility -->
-  <anchor id="goscaja-1"/>
+  <anchor xml:id="goscaja-1"/>
 
   <!-- Desktop Overview / File Manager -->
-  <anchor id="gosoverview-56"/>
+  <anchor xml:id="gosoverview-56"/>
 
   <!-- MOVE THIS ANCHOR -->
   <!-- Desktop Overview / File Manager / To Open Files -->
-  <anchor id="gosoverview-58"/>
+  <anchor xml:id="gosoverview-58"/>
 
   <!-- MOVE THIS ANCHOR -->
   <!-- Desktop Overview / File Manager / To Move Files -->
-  <anchor id="gosoverview-57"/>
+  <anchor xml:id="gosoverview-57"/>
 
   <!-- MOVE THESE ANCHORS -->
   <!-- Desktop Overview / Desktop -->
-  <anchor id="gosgetstarted-11"/>
+  <anchor xml:id="gosgetstarted-11"/>
   <!-- Desktop Overview / Desktop / To Open Desktop Objects -->
-  <anchor id="gosoverview-29"/>
+  <anchor xml:id="gosoverview-29"/>
   <!-- Desktop Overview / Desktop / To Add Objects-->
-  <anchor id="gosoverview-19"/>
+  <anchor xml:id="gosoverview-19"/>
   <!-- Using the Start Here Location -->
-  <anchor id="goscaja-445"/>
+  <anchor xml:id="goscaja-445"/>
   <!-- To Choose a View in Which to Display a File or Folder - (image/text view) -->
-  <anchor id="goscaja-100"/>
+  <anchor xml:id="goscaja-100"/>
   <!-- To Modify the Behavior of a View -->
-  <anchor id="goscaja-111"/>
+  <anchor xml:id="goscaja-111"/>
   <!-- To Resize an Icon in Icon View - (This can only be done on desktop now) -->
-  <anchor id="goscaja-103"/>
+  <anchor xml:id="goscaja-103"/>
   <!-- To Execute Other Actions When Displaying a File -->
-  <anchor id="goscaja-73"/>
+  <anchor xml:id="goscaja-73"/>
 
   <highlights>
     <para>This chapter describes how to use the <application>Caja</application> file manager.</para>
   </highlights>
 
-  <sect1 id="goscaja-21">
-    <title>Introduction</title>
+  <section xml:id="goscaja-21"><info><title>Introduction</title></info>
     <indexterm>
       <primary>file manager</primary>
       <secondary>introduction</secondary>
     </indexterm>
-    <sect2 id="goscaja-22">
-    <title>File Manager Functionality</title>
+
+    <section xml:id="goscaja-22"><info><title>File Manager Functionality</title></info>
     <para>The <application>Caja</application> file manager provides
 a simple and integrated way to manage your files and applications. You can use the
 file manager to do the following:</para>
@@ -65,14 +69,13 @@ is an active component of the way you use your computer.</para>
     <para>Every user has a Home Folder. The Home Folder contains all user's files. The desktop is another folder. The desktop contains special icons allowing easy access to the users Home Folder, Trash, and also removable media such as floppy disks, CDs and USB flash drives.</para>
     <para><application>Caja</application> is always running while you are using MATE. To open a new <application>Caja</application> window, double-click on an appropriate icon on the desktop such as <guimenuitem>Home</guimenuitem> or <guimenuitem>Computer</guimenuitem>, or choose an item from <link linkend="places-menu"><guimenuitem>Places</guimenuitem> menu</link> on the top panel.</para>
     <para>In MATE many things are files, such as word processor documents, spreadsheets, photos, movies, and music.</para>
+  </section>
 
-  </sect2>
-  <sect2 id="caja-presentation">
-    <title>File Manager Presentation</title>
+  <section xml:id="caja-presentation"><info><title>File Manager Presentation</title></info>
+    
     <para><application>Caja</application> provides two modes in which you can interact with your filesystem: spatial and browser mode. You may decide which method you prefer and set  <application>Caja</application> to always use this by selecting (or deselecting) <guilabel>Always open in browser windows</guilabel> in the <guilabel>Behavior</guilabel> tab of the <xref linkend="caja-preferences"/>.</para>
     <para>Browser mode is the default in MATE, but your distributor, vendor, or system administrator may have configured <application>Caja</application> to use spatial mode by default.</para>
-    <figure id="goscaja-FIG-naut-always-use-browser">
-      <title>Dconf-Editor showing the value of always-use-browser key for gsettings org.mate.caja.preferences schema</title>
+    <figure xml:id="goscaja-FIG-naut-always-use-browser"><info><title>Dconf-Editor showing the value of always-use-browser key for gsettings org.mate.caja.preferences schema</title></info>
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -92,8 +95,7 @@ is an active component of the way you use your computer.</para>
             <para>The file manager window represents a browser, which can display any location. Opening a folder updates the current file manager window to show the contents of the new folder.</para>
             <para>As well as the folder contents, the browser window displays a toolbar with common actions and locations, a location bar that shows the current location in the hierarchy of folders, and a sidebar that can hold different kinds of information.</para>
              <para>In Browser Mode, you typically have fewer file manager windows open at a time. For more information on using browser mode see <xref linkend="caja-browser-mode"/>.</para>
-          <figure id="goscaja-FIG-naut-browser-mode">
-            <title><application>Caja</application> in browser mode</title>
+          <figure xml:id="goscaja-FIG-naut-browser-mode"><info><title><application>Caja</application> in browser mode</title></info>
             <screenshot>
               <mediaobject>
                 <imageobject>
@@ -111,10 +113,9 @@ is an active component of the way you use your computer.</para>
           <term>Spatial mode: navigate your files and folders as objects </term>
           <listitem>
             <para>The file manager window represents a particular folder. Opening a folder opens the new window for that folder. Each time you open a particular folder, you will find its window displayed in the same place on the screen and the same size as the last time you viewed it (this is the reason for the name 'spatial mode').</para>
-            <para>Using spatial mode may lead to more open file manager windows on the screen. On the other hand, some users find that representing files and folders as though they were real physical objects with particular locations makes it easier to work with them. For more information on using spatial mode see <xref linkend="caja-spatial-mode" /></para>
+            <para>Using spatial mode may lead to more open file manager windows on the screen. On the other hand, some users find that representing files and folders as though they were real physical objects with particular locations makes it easier to work with them. For more information on using spatial mode see <xref linkend="caja-spatial-mode"/></para>
         
-            <figure id="goscaja-FIG-naut-spatial-mode">
-              <title>Three Folders Opened in Spatial Mode</title>
+            <figure xml:id="goscaja-FIG-naut-spatial-mode"><info><title>Three Folders Opened in Spatial Mode</title></info>
               <screenshot>
                 <mediaobject>
                   <imageobject>
@@ -132,22 +133,23 @@ is an active component of the way you use your computer.</para>
           </listitem>             
         </varlistentry>
      </variablelist>   
-  </sect2>
-  </sect1>
+  </section>
+  </section>
+
   <!-- ====================================================== Spatial mode -->  
-  <sect1 id="caja-spatial-mode">
-    <title>Spatial Mode</title>
-    <anchor id="goscaja-24"/>       
+  <section xml:id="caja-spatial-mode"><info><title>Spatial Mode</title></info>
+    <anchor xml:id="goscaja-24"/>
+
     <indexterm>
       <primary>file manager</primary>
       <secondary>navigating</secondary>
     </indexterm>
     <para>The following section describes how to browse your system using the <application>Caja</application> file manager when configured in spatial mode. In spatial mode, each <application>Caja</application> window corresponds to a single folder. When you open a folder its window appears at the same place on the screen as the last time you looked at it. This is the default behavior in <application>Caja</application>.</para>
-    <para>For a comparison of browser mode and spatial mode, see <xref linkend="caja-presentation"/>.</para>    
-    <sect2 id="goscaja-510">
-      <title>Spatial Windows</title>
+    <para>For a comparison of browser mode and spatial mode, see <xref linkend="caja-presentation"/>.</para>
+
+    <section xml:id="goscaja-510"><info><title>Spatial Windows</title></info>
       <para>A new spatial window opens each time you open a folder. To open a folder, do one of the following:</para>
-      <anchor id="goscaja-25"/><!-- removed id: Displaying Folder Contents -->
+      <anchor xml:id="goscaja-25"/><!-- removed id: Displaying Folder Contents -->
       <itemizedlist>
         <listitem><para>Double-click the folder's icon on the desktop or an existing window</para></listitem>
         <listitem><para>Select the folder, and press <keycombo><keycap>Ctrl</keycap><keycap>O</keycap></keycombo>.</para></listitem>
@@ -159,9 +161,8 @@ is an active component of the way you use your computer.</para>
 
       <para><xref linkend="goscaja-FIG-504"/> shows a spatial mode window
 that displays the contents of the Computer folder.</para>
-      <figure id="goscaja-FIG-504">
-        <title>Contents of a folder in a spatial mode.<indexterm><primary>file
-manager</primary><secondary>icon view</secondary><tertiary>illustration</tertiary></indexterm></title>
+      <figure xml:id="goscaja-FIG-504"><info><title>Contents of a folder in a spatial mode.<indexterm><primary>file
+manager</primary><secondary>icon view</secondary><tertiary>illustration</tertiary></indexterm></title></info>
         <screenshot>
           <mediaobject>
             <imageobject>
@@ -174,9 +175,8 @@ manager</primary><secondary>icon view</secondary><tertiary>illustration</tertiar
         </screenshot>
       </figure>
     <para>In spatial mode each open <application>Caja</application> windows shows only one location. Selecting a second location will open a second <application>Caja</application> window. Because each location remembers the previous position on screen in which it was opened it allows you to easily recognize folders when many of them are open at once.</para>
-    <para>Some people consider spatial mode better, particularly for moving files or folders to different location, others find the number of open windows daunting. <xref linkend="goscaja-FIG-naut-spatial-many-open" /> shows an example of spatial browsing with many open locations.</para>
-        <figure id="goscaja-FIG-naut-spatial-many-open">
-          <title>Three Folders Opened in Spatial Mode</title>
+    <para>Some people consider spatial mode better, particularly for moving files or folders to different location, others find the number of open windows daunting. <xref linkend="goscaja-FIG-naut-spatial-many-open"/> shows an example of spatial browsing with many open locations.</para>
+        <figure xml:id="goscaja-FIG-naut-spatial-many-open"><info><title>Three Folders Opened in Spatial Mode</title></info>
           <screenshot>
             <mediaobject>
               <imageobject>
@@ -191,13 +191,12 @@ manager</primary><secondary>icon view</secondary><tertiary>illustration</tertiar
 <note>
 <para>Because spatial mode will fill your screen with <application>Caja</application> windows, it is important to be able to reposition them effectively. By holding the <keycap>Alt</keycap> key and clicking anywhere within the bounds of a <application>Caja</application> window you may reposition it simply, instead of requiring that you reposition it by dragging its title bar.</para>
 </note>
-  </sect2>
-   <sect2 id="caja-spatial-components">
-      <title>Spatial Window Components</title>
+  </section>
+
+   <section xml:id="caja-spatial-components"><info><title>Spatial Window Components</title></info>
       <para><xref linkend="goscaja-TBL-85"/> describes the components of file
 object windows.</para>
-      <table frame="topbot" id="goscaja-TBL-85">
-        <title>The Spatial Window Components</title>
+      <table frame="topbot" xml:id="goscaja-TBL-85"><info><title>The Spatial Window Components</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="29.39*"/>
           <colspec colname="colspec1" colwidth="70.61*"/>
@@ -228,7 +227,7 @@ of items in the view pane.</para>
             </row>
             <row>
               <entry valign="top">
-		<anchor id="goscaja-components-view"/>
+		<anchor xml:id="goscaja-components-view"/>
                 <para>View pane</para>
               </entry>
               <entry valign="top">
@@ -272,9 +271,9 @@ of items in the view pane.</para>
           </tbody>
         </tgroup>
       </table>
-    </sect2>
-    <sect2 id="goscaja-4">
-      <title>Displaying Your Home Folder in a Spatial Window</title>
+    </section>
+
+    <section xml:id="goscaja-4"><info><title>Displaying Your Home Folder in a Spatial Window</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>Home location</secondary>
@@ -297,9 +296,9 @@ desktop.</para>
         <listitem><para>From the top panel menubar, choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Home Folder</guimenuitem></menuchoice>. </para></listitem>
       </itemizedlist>
       <para>The spatial window displays the contents of your Home Folder.</para>
-    </sect2>
-    <sect2 id="goscaja-511">
-      <title>Displaying a Parent Folder</title>
+    </section>
+
+    <section xml:id="goscaja-511"><info><title>Displaying a Parent Folder</title></info>
       <para>A parent folder is the folder that contains the current folder. To display the contents of your current folder's parent, do one of the following:</para>
       <itemizedlist>
         <listitem>
@@ -311,15 +310,15 @@ desktop.</para>
         <listitem><para>Choose from the parent folder selector at the bottom left of the window.</para></listitem>
       </itemizedlist>
       <para>To close the current folder while opening the parent, hold down <keycap>Shift</keycap> while choosing from the parent folder selector, or press <keycombo><keycap>Shift</keycap><keycap>Alt</keycap><keycap>up arrow</keycap></keycombo>.</para>
-    </sect2>
-    <sect2 id="goscaja-512">
-      <title>Closing Folders</title>
+    </section>
+
+    <section xml:id="goscaja-512"><info><title>Closing Folders</title></info>
       <para>To close folders you may simply click on the close window button, this however may not be the most efficient way to close many windows.
 If you would like to view only the current folder, and not the folders you opened to reach the current folder, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Close Parent Folders</guimenuitem></menuchoice>.
 If want to close all folders on the screen, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Close All Folders</guimenuitem></menuchoice>.</para>
-      </sect2>
-    <sect2 id="goscaja-501">
-      <title>Displaying a Folder in a Browser Window</title>
+    </section>
+
+    <section xml:id="goscaja-501"><info><title>Displaying a Folder in a Browser Window</title></info>
       <para>If you wish to display a single folder in browser mode, while otherwise continuing to work in spatial mode, perform the following steps:</para>
       <orderedlist>
         <listitem>
@@ -329,9 +328,9 @@ If want to close all folders on the screen, choose <menuchoice><guimenu>File</gu
           <para>Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Browse Folder</guimenuitem></menuchoice>. </para>
         </listitem>
       </orderedlist>
-    </sect2>
-    <sect2 id="caja-open-location">
-      <title>Opening a Location</title>
+    </section>
+
+    <section xml:id="caja-open-location"><info><title>Opening a Location</title></info>
       <para>You can open a folder or other location in spatial mode by typing its name.</para>
       <para>Choose <menuchoice>
 	<shortcut>
@@ -341,32 +340,30 @@ If want to close all folders on the screen, choose <menuchoice><guimenu>File</gu
 	<guimenuitem>Open Location</guimenuitem>
 </menuchoice>, and type the path or URI of the location you wish to open.
 </para>
-  
-    </sect2>
-  </sect1>
+    </section>
+  </section>
 
   <!-- ====================================================== Browser mode -->
-  <sect1 id="caja-browser-mode">
-    <title>Browser Mode</title>
+  <section xml:id="caja-browser-mode"><info><title>Browser Mode</title></info>
     <!-- Viewing Files in a File Browser Window -->
-    <anchor id="goscaja-210"/>   
-    <anchor id="goscaja-447"/>
+    <anchor xml:id="goscaja-210"/>   
+    <anchor xml:id="goscaja-447"/>
+
     <indexterm>
       <primary>file manager</primary>
       <secondary>windows</secondary>
     </indexterm>
     <para>The following section describes how to browse your system using the <application>Caja</application> file manager when configured in browser mode. In browser mode, opening a folder updates the current file manager to show the contents of the new folder.</para>
     <para>For a comparison of browser mode and spatial mode, see <xref linkend="caja-presentation"/>.</para>
-    <sect2 id="goscaja-492">
-      <title>The File Browser Window</title>
+
+    <section xml:id="goscaja-492"><info><title>The File Browser Window</title></info>
       <para>You can access the file browser in the following ways:
       <itemizedlist>
         <listitem><para>Choose <menuchoice><guimenu>Applications</guimenu><guimenuitem>System Tools</guimenuitem><guimenuitem>File Browser</guimenuitem></menuchoice>.</para></listitem>
         <listitem><para>While in spatial mode you may open a folder in browser mode by right clicking on that folder and choosing <guimenuitem>Browse Folder</guimenuitem>. A new file browser window will then open and display the contents of the selected folder.</para></listitem>
         <listitem><para>If <application>Caja</application> is set to always open browser windows, double clicking any folder will open a browser window, see <xref linkend="goscaja-56"/>.</para></listitem>
       </itemizedlist></para>
-      <figure id="goscaja-FIG-naut-home-browser-mode">
-        <title>Contents of a Folder in a File Browser Window</title>
+      <figure xml:id="goscaja-FIG-naut-home-browser-mode"><info><title>Contents of a Folder in a File Browser Window</title></info>
         <screenshot>
           <mediaobject>
             <imageobject>
@@ -381,12 +378,11 @@ If want to close all folders on the screen, choose <menuchoice><guimenu>File</gu
       <note>
         <para>In some distributions of the MATE Desktop, the <guibutton>Home</guibutton> toolbar button might have another designation, for example, <guibutton>Documents</guibutton>.</para>
       </note>
-      <sect3 id="goscaja-493">
-        <title>The File Browser Window Components</title>
+
+      <section xml:id="goscaja-493"><info><title>The File Browser Window Components</title></info>
         <para><xref linkend="goscaja-TBL-83"/> describes the components of a file
 browser window.</para>
-        <table frame="topbot" id="goscaja-TBL-83">
-          <title>File Browser Window Components</title>
+        <table frame="topbot" xml:id="goscaja-TBL-83"><info><title>File Browser Window Components</title></info>
           <tgroup cols="2" colsep="0" rowsep="0">
             <colspec colname="colspec0" colwidth="29.39*"/>
             <colspec colname="colspec1" colwidth="70.61*"/>
@@ -451,7 +447,7 @@ of items in the view pane.</para>
                   <para>Location bar</para>
                 </entry>
                 <entry colname="colspec1" valign="top">
-                  <para>The location bar is a very powerful tool for navigating your computer. It can appear in three different ways depending on your selection. For more on using the location bar see <xref linkend="caja-location-bar" />. In all three configurations the location bar always contains the following items.</para>
+                  <para>The location bar is a very powerful tool for navigating your computer. It can appear in three different ways depending on your selection. For more on using the location bar see <xref linkend="caja-location-bar"/>. In all three configurations the location bar always contains the following items.</para>
                   <itemizedlist>
                     <listitem>
                       <para><guimenu>Zoom</guimenu> buttons: Enable you to change the
@@ -466,7 +462,7 @@ choose how to show items in your view pane.</para>
               </row>
               <row>
                 <entry valign="top">
-              		<anchor id="goscaja-540"/>
+              		<anchor xml:id="goscaja-540"/>
                   <para>Side pane</para>
                 </entry>
                 <entry valign="top">
@@ -529,7 +525,7 @@ at the top right of the side pane.</para>
             </row>
             <row>
               <entry valign="top">
-		<anchor id="goscaja-53"/>
+		<anchor xml:id="goscaja-53"/>
                 <para>View pane</para>
               </entry>
               <entry valign="top">
@@ -564,16 +560,16 @@ at the top right of the side pane.</para>
           </tbody>
         </tgroup>
       </table>
-    </sect3>
-    </sect2>
-    <sect2 id="goscaja-18">
-      <title>Showing and Hiding File Browser Window Components</title>
+    </section>
+    </section>
+
+    <section xml:id="goscaja-18"><info><title>Showing and Hiding File Browser Window Components</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>window components, showing
 and hiding</secondary>
       </indexterm>
-      <para>To show or hide any of the components of the file browser described in <xref linkend="goscaja-TBL-83" /> select any of the following items from the menu:<!-- TODO clean this up, it's too robotic! --></para>
+      <para>To show or hide any of the components of the file browser described in <xref linkend="goscaja-TBL-83"/> select any of the following items from the menu:<!-- TODO clean this up, it's too robotic! --></para>
       <itemizedlist>
         <listitem>
           <para>To hide the side pane, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice>. To display the
@@ -592,9 +588,9 @@ the location bar again, choose <menuchoice><guimenu>View</guimenu><guimenuitem>L
 statusbar again, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice> again. </para>
         </listitem>
       </itemizedlist>
-    </sect2>
-    <sect2 id="caja-location-bar">
-      <title>Using the Location Bar</title>
+    </section>
+
+    <section xml:id="caja-location-bar"><info><title>Using the Location Bar</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>window components, showing
@@ -608,8 +604,7 @@ and hiding</secondary>
         <para><guilabel>Button bar</guilabel></para>
         <para>By default the button bar is shown. This shows a row of buttons representing the current location's hierarchy, with a button for each containing folder. Click on the button to jump between folders in the hierarchy. You can return to the original folder, which is shown as the last button in the row.</para>
         <para>You can also drag buttons, for example to another location, in order to copy a folder.</para>
-      <figure id="goscaja-FIG-903">
-      <title>The button bar</title>
+      <figure xml:id="goscaja-FIG-903"><info><title>The button bar</title></info>
         <screenshot>
           <mediaobject>
             <imageobject>
@@ -628,8 +623,7 @@ and hiding</secondary>
         <para>To go to a new location, type a new path or edit the current one, then press <keycap>Enter</keycap>. The path field automatically completes what you are typing when there is only one possibility. To accept the suggested completion, press <keycap>Tab</keycap>.</para>
       <para>To always use the text location bar, click on the toggle button at the left of the location bar.</para>
       <para>To quickly switch to the text location bar while using the button bar, press <keycombo><keycap>Ctrl</keycap><keycap>L</keycap></keycombo>, choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Location</guimenuitem></menuchoice>, or press <keycap>Leading Slash (/)</keycap> to type a path from the root directory. The location bar shows the location buttons again after you press <keycap>Enter</keycap> or cancel with <keycap>Escape</keycap>.</para>
-      <figure id="goscaja-FIG-902">
-      <title>The location bar</title>
+      <figure xml:id="goscaja-FIG-902"><info><title>The location bar</title></info>
         <screenshot>
           <mediaobject>
             <imageobject>
@@ -644,9 +638,8 @@ and hiding</secondary>
       </listitem>
       <listitem>
         <para><guilabel>Search bar</guilabel></para>
-        <para>By pressing <keycombo><keycap>Ctrl</keycap><keycap>F</keycap></keycombo> or selecting the <guibutton>Search</guibutton> toolbar button the search bar appears. For more information on searching see <xref linkend="caja-searching" />. The search bar is excellent for locating files of folders when you are not sure of their exact location.</para>
-      <figure id="goscaja-FIG-904">
-      <title>The search bar</title>
+        <para>By pressing <keycombo><keycap>Ctrl</keycap><keycap>F</keycap></keycombo> or selecting the <guibutton>Search</guibutton> toolbar button the search bar appears. For more information on searching see <xref linkend="caja-searching"/>. The search bar is excellent for locating files of folders when you are not sure of their exact location.</para>
+      <figure xml:id="goscaja-FIG-904"><info><title>The search bar</title></info>
         <screenshot>
           <mediaobject>
             <imageobject>
@@ -660,9 +653,9 @@ and hiding</secondary>
       </figure>
       </listitem>
 </itemizedlist>
-    </sect2>
-    <sect2 id="goscaja-499">
-      <title>Displaying Your Home Folder</title>
+    </section>
+
+    <section xml:id="goscaja-499"><info><title>Displaying Your Home Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>Home folder</secondary>
@@ -690,10 +683,10 @@ perform one of the following actions from a file browser window:</para>
         </listitem>
       </itemizedlist>
       <para>The file browser window displays the contents of your Home Folder.</para>
-    </sect2>
-    <sect2 id="goscaja-500">
-      <title>Displaying a Folder</title>
-      <para>The contents of a folder can be displayed in either list or icon view by selecting the appropriate item in the location bar <guilabel>View as</guilabel> menu. For more information on the list and icon view see <xref linkend="goscaja-7" /></para>
+    </section>
+
+    <section xml:id="goscaja-500"><info><title>Displaying a Folder</title></info>
+      <para>The contents of a folder can be displayed in either list or icon view by selecting the appropriate item in the location bar <guilabel>View as</guilabel> menu. For more information on the list and icon view see <xref linkend="goscaja-7"/></para>
       <itemizedlist>
         <listitem>
           <para>Double-click on the folder in the view pane.</para>
@@ -721,9 +714,9 @@ the name of the directory in the <guilabel>Location</guilabel> field.</para>
       <para>To change to the folder that is one level above the current folder,
 choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Up</guimenuitem></menuchoice>. Alternatively, click on the <guibutton>Up</guibutton> toolbar
 button.</para>
-    </sect2>
-    <sect2 id="goscaja-26">
-      <title>Displaying a Parent Folder</title>
+    </section>
+
+    <section xml:id="goscaja-26"><info><title>Displaying a Parent Folder</title></info>
       <para>The parent folder of the current folder which you are browsing is the one which exists, in a hierarchical representation, one level above the current. To display the contents of  parent folder, perform one of the
 following steps:</para>
       <itemizedlist>
@@ -737,9 +730,9 @@ following steps:</para>
           <para>Press the <keycap>Backspace</keycap> key.</para>
         </listitem>
       </itemizedlist>
-    </sect2>
-    <sect2 id="goscaja-27">
-      <title>Using the Tree From the Side Pane</title>
+    </section>
+
+    <section xml:id="goscaja-27"><info><title>Using the Tree From the Side Pane</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>Tree, using </secondary>
@@ -753,8 +746,7 @@ your file system. To display the <guilabel>Tree</guilabel> in the side pane, cho
       
       <para><xref linkend="goscaja-TBL-34"/> describes tasks you can
 perform with the <guilabel>Tree</guilabel>, and how to do so.</para>
-      <table frame="topbot" id="goscaja-TBL-34">
-        <title>Tree Tasks</title>
+      <table frame="topbot" xml:id="goscaja-TBL-34"><info><title>Tree Tasks</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="50*"/>
           <colspec colname="colspec1" colwidth="50*"/>
@@ -825,9 +817,9 @@ a folder in the view pane.</para>
       </table>
       <para>You can set your preferences so that the <guilabel>Tree</guilabel> does
 not display files. For more information, see <xref linkend="goscaja-438"/>. </para>
-    </sect2>
-    <sect2 id="goscaja-5">
-      <title>Using Your Navigation History</title>
+    </section>
+
+    <section xml:id="goscaja-5"><info><title>Using Your Navigation History</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>navigating history list</secondary>
@@ -837,12 +829,12 @@ list of files, folders, FTP sites, and URI locations you have recently visited. 
 list to navigate to quickly return to these places. Your history list contains the last ten items that
 you viewed.</para>
       <para>To clear your history list choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Clear History</guimenuitem></menuchoice>.</para>
-      <sect3 id="goscaja-77">
-        <title>Navigating Your History List Using the Go Menu</title>
+
+      <section xml:id="goscaja-77"><info><title>Navigating Your History List Using the Go Menu</title></info>
         <para>To display a list of previously-viewed items, choose the <guimenu>Go</guimenu> menu. Your history list is displayed in the lower part of the <guimenu>Go</guimenu> menu. To open an item in your history list, simply click on the item.</para>
-      </sect3>
-      <sect3 id="goscaja-78">
-        <title>Navigating Your History List Using the Toolbar</title>
+      </section>
+
+      <section xml:id="goscaja-78"><info><title>Navigating Your History List Using the Toolbar</title></info>
         <para>To use the toolbar to navigate your history list, perform one of the
 following actions:</para>
         <itemizedlist>
@@ -865,9 +857,9 @@ the current item, click on the down arrow to the right of the <guibutton>Forward
 on the item.</para>
           </listitem>
         </itemizedlist>
-      </sect3>
-      <sect3 id="goscaja-80">
-        <title>Navigating Your History List Using History in the Side Pane</title>
+      </section>
+
+      <section xml:id="goscaja-80"><info><title>Navigating Your History List Using History in the Side Pane</title></info>
         <indexterm>
           <primary>file manager</primary>
           <secondary>History</secondary>
@@ -876,16 +868,15 @@ on the item.</para>
 items.</para>
         <para>To display an item from your history list in the view pane, double-click on
 the item in the <guilabel>History</guilabel> list.</para>
-
-      </sect3>
-    </sect2>
-  </sect1>  
+      </section>
+    </section>
+  </section>  
   
-	<!-- ======================================================== Opening -->
-  <sect1 id="caja-open-file">
-    <title>Opening Files</title>
+  <!-- ======================================================== Opening -->
+  <section xml:id="caja-open-file"><info><title>Opening Files</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscaja-28"/>       
+    <anchor xml:id="goscaja-28"/>
+
     <indexterm>
       <primary>file manager</primary>
       <secondary>opening files</secondary>
@@ -897,8 +888,8 @@ action for that file type.</para>
 of a file. If the first lines do not determine the type of the file, then
 the file manager checks the <glossterm>file extension</glossterm>.</para>
     <note><para>If you open an executable text file, that is, one that Caja considers can be run as a program, then you will be asked what you want to do: run it, or display it in a text editor. You can modify this behavior in the <link linkend="caja-preferences">File Management preferences</link>.</para></note>
-    <sect2 id="goscaja-29">
-      <title>Executing the Default Action</title>
+
+    <section xml:id="goscaja-29"><info><title>Executing the Default Action</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>executing default actions
@@ -910,9 +901,9 @@ text documents is to display the file in a text viewer. In this case, you
 can double-click on the file to  display the file in a text viewer.</para>
       <para>You can set your file manager preferences so that you click once on
 a file to execute the default action. For more information, see <xref linkend="goscaja-56"/>.</para>
-    </sect2>
-    <sect2 id="goscaja-30">
-      <title>Executing Non-Default Actions</title>
+    </section>
+
+    <section xml:id="goscaja-30"><info><title>Executing Non-Default Actions</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>executing non-default
@@ -922,11 +913,12 @@ actions for files</secondary>
 the default action for a file,  select the file that you want to perform
 an action on. In the <menuchoice><guimenu>File</guimenu></menuchoice> menu you will either have "Open with" choices, or an 
 <menuchoice><guimenuitem>Open With</guimenuitem></menuchoice> submenu. Select the desired option from this list.</para>
-    </sect2>
-    <sect2 id="goscaja-add-actions">
-      <title>Adding Actions</title>
-	    <!-- preserve id for backwards compatibility: 2.12 -->
-	    <anchor id="goscaja-204"/><!-- Assigning Actions to Files -->
+    </section>
+
+    <section xml:id="goscaja-add-actions"><info><title>Adding Actions</title></info>
+      <!-- preserve id for backwards compatibility: 2.12 -->
+      <anchor xml:id="goscaja-204"/><!-- Assigning Actions to Files -->
+
       <indexterm>
         <primary>file manager</primary>
         <secondary>adding actions</secondary>
@@ -949,9 +941,9 @@ which you wish to open this type.</para>
        <para>The action you have chosen is now added to the list of actions for that particular file type. If there was 
 no prior action associated with the type, the newly added action is the default.</para>
        <para>You may also add actions in the <guilabel>Open With</guilabel> tabbed section under <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>.</para>
-   </sect2>
-    <sect2 id="goscaja-75">
-      <title>Modifying Actions</title>
+   </section>
+
+    <section xml:id="goscaja-75"><info><title>Modifying Actions</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>modifying actions</secondary>
@@ -974,19 +966,18 @@ a file of the type to which you want to modify the action.</para>
 Select the default action with the option to the left of the list.</para>
         </listitem>
       </orderedlist>
-    </sect2>    
+    </section>    
    
-	<!-- =========================================== Searching -->    
-  </sect1>
-  <sect1 id="caja-searching">
-    <title>Searching For Files</title>
+  <!-- =========================================== Searching -->    
+  </section>
+
+  <section xml:id="caja-searching"><info><title>Searching For Files</title></info>
     <indexterm>
       <primary>file manager</primary>
       <secondary>searching files</secondary>
     </indexterm>
-    <para>The <application>Caja</application> file manager includes an easy and simple to use way search for your files and folders. To begin a search press <keycombo><keycap>Ctrl</keycap><keycap>F</keycap></keycombo> or select the <guibutton>Search</guibutton> toolbar button. The search bar should appear as in <xref linkend="goscaja-FIG-925" /></para>
-                    <figure id="goscaja-FIG-925">
-                    <title>The search bar</title>
+    <para>The <application>Caja</application> file manager includes an easy and simple to use way search for your files and folders. To begin a search press <keycombo><keycap>Ctrl</keycap><keycap>F</keycap></keycombo> or select the <guibutton>Search</guibutton> toolbar button. The search bar should appear as in <xref linkend="goscaja-FIG-925"/></para>
+                    <figure xml:id="goscaja-FIG-925"><info><title>The search bar</title></info>
                       <screenshot>
                         <mediaobject>
                           <imageobject>
@@ -998,9 +989,8 @@ Select the default action with the option to the left of the list.</para>
                         </mediaobject>
                       </screenshot>
                     </figure>
-<para>Enter characters present in the name or contents of the file or folder you wish to find and press <keycap>Enter</keycap>. The results of your search should appear in the view pane as illustrated in <xref linkend="goscaja-FIG-926" /></para>
-                    <figure id="goscaja-FIG-926">
-                    <title>The result of a search</title>
+<para>Enter characters present in the name or contents of the file or folder you wish to find and press <keycap>Enter</keycap>. The results of your search should appear in the view pane as illustrated in <xref linkend="goscaja-FIG-926"/></para>
+                    <figure xml:id="goscaja-FIG-926"><info><title>The result of a search</title></info>
                       <screenshot>
                         <mediaobject>
                           <imageobject>
@@ -1012,9 +1002,8 @@ Select the default action with the option to the left of the list.</para>
                         </mediaobject>
                       </screenshot>
                     </figure>
-<para>If you are not happy with your search, you can refine it by adding addition conditions. This allows you to restrict the search to a specific file type or location. To add search conditions click the <guibutton>+</guibutton> icon. <xref linkend="goscaja-FIG-927" /> shows a search which has been restricted to the users home directory and to only search for text files.</para>
-                    <figure id="goscaja-FIG-927">
-                    <title>Restricting a search</title>
+<para>If you are not happy with your search, you can refine it by adding addition conditions. This allows you to restrict the search to a specific file type or location. To add search conditions click the <guibutton>+</guibutton> icon. <xref linkend="goscaja-FIG-927"/> shows a search which has been restricted to the users home directory and to only search for text files.</para>
+                    <figure xml:id="goscaja-FIG-927"><info><title>Restricting a search</title></info>
                       <screenshot>
                         <mediaobject>
                           <imageobject>
@@ -1026,16 +1015,15 @@ Select the default action with the option to the left of the list.</para>
                         </mediaobject>
                       </screenshot>
                     </figure>
-    <sect2 id="caja-saving-searches">
-      <title>Saving Searches</title>
+
+    <section xml:id="caja-saving-searches"><info><title>Saving Searches</title></info>
       <indexterm>
         <primary>file manager</primary>
-        <secondary>executing default actions
-for files</secondary>
+        <secondary>executing default actions for files</secondary>
       </indexterm>
-      <para>Caja searches can also be saved for future use. Once saved, searches may be reopened later. <xref linkend="goscaja-FIG-935" /> shows a user with three saved searches, browsing one of them.</para>
-                    <figure id="goscaja-FIG-935">
-                    <title>Browsing the results of a saved search</title>
+      <para>Caja searches can also be saved for future use. Once saved, searches may be reopened later. <xref linkend="goscaja-FIG-935"/> shows a user with three saved searches, browsing one of them.</para>
+                    <figure xml:id="goscaja-FIG-935"><info><title>Browsing the results of a saved search</title></info>
+                    
                       <screenshot>
                         <mediaobject>
                           <imageobject>
@@ -1048,12 +1036,11 @@ for files</secondary>
                       </screenshot>
                     </figure>
 <para>Saved searches behave exactly like regular folders, for example you can open, move or delete files from within a saved search.</para>
-    </sect2>
-  </sect1>
+    </section>
+  </section>
 
-	<!-- =========================================== Managing -->
-  <sect1 id="goscaja-8">
-    <title>Managing Your Files and Folders</title>
+  <!-- =========================================== Managing -->
+  <section xml:id="goscaja-8"><info><title>Managing Your Files and Folders</title></info>
     <indexterm>
       <primary>file manager</primary>
       <secondary>managing files and folders</secondary>
@@ -1061,8 +1048,7 @@ for files</secondary>
     <para>This section describes how to work with your
 files and folders.</para>
 
-  	<sect2 id="caja-directories-file-systems" status="complete">
-  			<title>Directories and File Systems</title>
+  	<section xml:id="caja-directories-file-systems" status="complete"><info><title>Directories and File Systems</title></info>
 				<para>In Linux and other Unix-like operating systems, the filesystem is organised in a hierarchical, tree-like structure.  The highest level of the filesystem is the <filename>/</filename> or <emphasis>root directory</emphasis>.  These operating systems create a virtual file system, in which a filesystem object, such as a file or a directory, is represented by an inode. Each inode stores information about its parent and children, as well as its own attributes, among others, the owner, the permissions, the last change, access or modification of the filesystem object.
   				</para>
   				<para>For example, <filename>/home/jebediah/cheeses.odt</filename> shows the correct full path to the <filename>cheeses.odt</filename> file that exists in the <filename>jebediah</filename> directory which is under the <filename>home</filename> directory, which in turn, is under the root (<filename>/</filename>) directory.
@@ -1115,7 +1101,7 @@ files and folders.</para>
   							</para>
   						</listitem>
   						<listitem>
-  							<para><filename>/root</filename> - <emphasis>root</emphasis> user home directory, pronounced &apos;slash-root&apos;
+  							<para><filename>/root</filename> - <emphasis>root</emphasis> user home directory, pronounced 'slash-root'
   							</para>
   						</listitem>
   						<listitem>
@@ -1142,11 +1128,10 @@ files and folders.</para>
   							</para>
   						</listitem> 
   					</itemizedlist>
-				<note><para>More detailed information on the UNIX-like filesystem hierarchy is available at Filesystem Hierarchy Standard 3.0 <ulink url="http://refspecs.linuxfoundation.org/fhs.shtml">http://refspecs.linuxfoundation.org/fhs.shtml</ulink>.</para></note>
-  	</sect2>
+				<note><para>More detailed information on the UNIX-like filesystem hierarchy is available at Filesystem Hierarchy Standard 3.0 <link xlink:href="http://refspecs.linuxfoundation.org/fhs.shtml">http://refspecs.linuxfoundation.org/fhs.shtml</link>.</para></note>
+  	</section>
 
-    <sect2 id="goscaja-7">
-      <title>Using Views to Display Your Files and Folders</title>
+    <section xml:id="goscaja-7"><info><title>Using Views to Display Your Files and Folders</title></info>
       <indexterm>
         <primary>viewer components</primary>
       </indexterm>
@@ -1161,9 +1146,8 @@ of your folders in different ways, icon view, and list view.</para>
         <listitem>
           <para>Icon view</para>
           <para><xref linkend="goscaja-FIG-naut-icon-view"/> Shows the items in the folder as icons.
-<figure id="goscaja-FIG-naut-icon-view">
-                    <title>The Home Folder displayed in an icon view</title>
-<screenshot>
+          <figure xml:id="goscaja-FIG-naut-icon-view"><info><title>The Home Folder displayed in an icon view</title></info>
+                <screenshot>
                   <mediaobject>
                     <imageobject>
                       <imagedata fileref="figures/caja_spatial_icon_view.png" format="PNG"/>
@@ -1173,14 +1157,13 @@ of your folders in different ways, icon view, and list view.</para>
                     </textobject>
                   </mediaobject>
                 </screenshot>
-</figure></para>
+          </figure></para>
         </listitem>
         <listitem>
           <para>List view</para>
           <para><xref linkend="goscaja-FIG-naut-list-view"/> Shows the items in the folder as a list.
-<figure id="goscaja-FIG-naut-list-view">
-                    <title>The Home Folder displayed in a list view</title>
-<screenshot>
+          <figure xml:id="goscaja-FIG-naut-list-view"><info><title>The Home Folder displayed in a list view</title></info>
+                <screenshot>
                   <mediaobject>
                     <imageobject>
                       <imagedata fileref="figures/caja_spatial_list_view.png" format="PNG"/>
@@ -1190,13 +1173,13 @@ of your folders in different ways, icon view, and list view.</para>
                     </textobject>
                   </mediaobject>
                 </screenshot>
-</figure>
-</para>
+          </figure>
+          </para>
         </listitem>
       </itemizedlist>
       <para>You may use the <guilabel>View</guilabel> menu, or the <guilabel>View as</guilabel> drop-down list to choose between icon or list view. You can specify how you want to arrange or sort items in the folder and modify the size of the items in the view pane. The following sections describe how to work with icon view and list view.</para>
-      <sect3 id="goscaja-101">
-        <title>To Arrange Your Files in Icon View</title>
+
+      <section xml:id="goscaja-101"><info><title>To Arrange Your Files in Icon View</title></info>
         <indexterm>
           <primary>file manager</primary>
           <secondary>icon view</secondary>
@@ -1294,8 +1277,7 @@ detect that a PNG file is attached to an email.</para>
               <row>
                 <entry colname="colspec6" valign="top">
                   <para>
-                    <guilabel>By Modification
-Date</guilabel>
+                    <guilabel>By Modification Date</guilabel>
                   </para>
                 </entry>
                 <entry colname="colspec7" valign="top">
@@ -1342,9 +1324,9 @@ alphabetical order.</para>
             </tbody>
           </tgroup>
         </informaltable>
-      </sect3>
-      <sect3 id="goscaja-listview-arrange">
-        <title>To Arrange Your Files in List View</title>
+      </section>
+
+      <section xml:id="goscaja-listview-arrange"><info><title>To Arrange Your Files in List View</title></info>
         <indexterm>
           <primary>file manager</primary>
           <secondary>list view</secondary>
@@ -1360,9 +1342,9 @@ in the way that you selected.  In other words, when you specify how to arrange
 the items in a folder, you customize the folder to display the items in that
 way. To return the arrangement settings of the folder to the default arrangement
 settings specified in your preferences, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Reset View to Defaults</guimenuitem></menuchoice>.</para>
-      </sect3>
-<sect3 id="goscaja-102">
-      <title>To Change the Size of Items in a View</title>
+      </section>
+
+<section xml:id="goscaja-102"><info><title>To Change the Size of Items in a View</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>zooming in and out</secondary>
@@ -1384,8 +1366,7 @@ of items in a view in the following ways:</para>
       <para>You can also use the zoom buttons on the location bar in a browser window to change the
 size of items in a view. <xref linkend="goscaja-TBL-42"/> describes how
 to use the zoom buttons.</para>
-      <table frame="topbot" id="goscaja-TBL-42">
-        <title>Zoom Buttons</title>
+      <table frame="topbot" xml:id="goscaja-TBL-42"><info><title>Zoom Buttons</title></info>
         <tgroup cols="3" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="21.98*"/>
           <colspec colname="colspec1" colwidth="32.86*"/>
@@ -1476,21 +1457,20 @@ in a folder, you customize the folder to display the items at that size. To
 return the size of the items to the default size specified in your preferences,
 choose <menuchoice><guimenu>View</guimenu><guimenuitem>Reset View
 to Defaults</guimenuitem></menuchoice>.</para>
-    </sect3>
-    </sect2>
+    </section>
+    </section>
 
-    <sect2 id="caja-select">
-      <title>Selecting Files and Folders</title>
+    <section xml:id="caja-select"><info><title>Selecting Files and Folders</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-202"/>         
+      <anchor xml:id="goscaja-202"/>
+
       <indexterm>
         <primary>file manager</primary>
         <secondary>selecting files and folders</secondary>
       </indexterm>
       <para>You can select files and folders in several
 ways in the file manager. Typically, this is achieved by clicking on the files using the mouse, as explained in <xref linkend="goscaja-TBL-10"/>. In addition, <xref linkend="caja-select-pattern"/> describes how to select a group of files matching a specific pattern.</para>
-      <table frame="topbot" id="goscaja-TBL-10">
-        <title>Selecting Items in the File Manager</title>
+      <table frame="topbot" xml:id="goscaja-TBL-10"><info><title>Selecting Items in the File Manager</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="36.36*"/>
           <colspec colname="colspec2" colwidth="63.64*"/>
@@ -1515,12 +1495,10 @@ ways in the file manager. Typically, this is achieved by clicking on the files u
             </row>
             <row>
               <entry colname="colspec0" valign="top">
-                <para>Select a group of contiguous
-items</para>
+                <para>Select a group of contiguous items</para>
               </entry>
               <entry colname="colspec2" valign="top">
-                <para>In icon view,
-drag around the files that you want to select.</para>
+                <para>In icon view, drag around the files that you want to select.</para>
                 <para>In list view, click
 on the first item in the group. Press-and-hold <keycap>Shift</keycap>, then
 click on the last item in the group.</para>
@@ -1550,11 +1528,10 @@ Click on the items that you want to select.</para>
       <para>To perform the default action on an item, double-click on the item.
 You can set your file manager preferences so that you click once on a file
 to execute the default action. For more information, see <xref linkend="goscaja-56"/>.</para>
-<sect3 id="caja-select-pattern">
-<title>Selecting Files Matching a Specific Pattern</title>
+
+<section xml:id="caja-select-pattern"><info><title>Selecting Files Matching a Specific Pattern</title></info>
 <para><application>Caja</application> allows you to select all files matching a pattern based upon their filename and an optional number of wildcards. This can be useful if, for example, you wish to select all files which contain the phrase "memo" in their filename. <xref linkend="goscaja-TBL-select-pattern"/> gives some examples of possible patterns and the resulting files they would match.</para>
-<table frame="topbot" id="goscaja-TBL-select-pattern">
-        <title>Selecting Items in the File Manager</title>
+<table frame="topbot" xml:id="goscaja-TBL-select-pattern"><info><title>Selecting Items in the File Manager</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="36.36*"/>
           <colspec colname="colspec2" colwidth="63.64*"/>
@@ -1597,13 +1574,13 @@ to execute the default action. For more information, see <xref linkend="goscaja-
         </tgroup>
       </table>
       <para>To perform the Select Pattern command Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Select Patterns</guimenuitem></menuchoice> from the menu. After entering the desired pattern you are left with those files or folders which matched the pattern selected. You may then do with the selected files or folders what you choose.</para>
-      </sect3>
-    </sect2>
+      </section>
+    </section>
 
-    <sect2 id="caja-dragndrop">
-      <title>Drag-and-Drop in the File Manager</title>
+    <section xml:id="caja-dragndrop"><info><title>Drag-and-Drop in the File Manager</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-201"/>       
+      <anchor xml:id="goscaja-201"/>
+
       <indexterm>
         <primary>file manager</primary>
         <secondary>drag-and-drop</secondary>
@@ -1613,8 +1590,7 @@ file manager. When you drag-and-drop, the mouse pointer provides feedback
 about the task that you perform. <xref linkend="goscaja-TBL-11"/> describes
 the tasks that you can perform with drag-and-drop. The table also shows the
 mouse pointers that appear when you drag-and-drop.</para>
-      <table frame="topbot" id="goscaja-TBL-11">
-        <title>Drag-and-Drop in the File Manager</title>
+      <table frame="topbot" xml:id="goscaja-TBL-11"><info><title>Drag-and-Drop in the File Manager</title></info>
         <tgroup cols="3" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="36.36*"/>
           <colspec colname="colspec2" colwidth="98.56*"/>
@@ -1675,8 +1651,7 @@ mouse pointers that appear when you drag-and-drop.</para>
             </row>
             <row>
               <entry colname="colspec0" valign="top">
-                <para>Create a symbolic link to
-an item</para>
+                <para>Create a symbolic link to an item</para>
               </entry>
               <entry colname="colspec2" valign="top">
                 <para>Grab the
@@ -1698,8 +1673,7 @@ Drag the item to the location where you want the symbolic link to reside.</para>
             </row>
             <row>
               <entry colname="colspec0" valign="top">
-                <para>Ask what to do with the
-item you drag</para>
+                <para>Ask what to do with the item you drag</para>
               </entry>
               <entry colname="colspec2" valign="top">
                 <para>Grab the item, then press-and-hold <keycap>Alt</keycap>. You may also use the middle mouse button to perform the same operation.
@@ -1716,7 +1690,7 @@ A popup menu appears. Choose one of the following items from the popup menu:</pa
                     <para>
                       <guimenuitem>Copy here</guimenuitem>
                     </para>
-                    <para>Copies the item to the  location. </para>
+                    <para>Copies the item to the  location.</para>
                   </listitem>
                   <listitem>
                     <para>
@@ -1755,17 +1729,16 @@ A popup menu appears. Choose one of the following items from the popup menu:</pa
           </tbody>
         </tgroup>
       </table>
-    </sect2>
+    </section>
 
-    <sect2 id="goscaja-9">
-      <title>Moving a File or Folder</title>
+    <section xml:id="goscaja-9"><info><title>Moving a File or Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>moving files and folders</secondary>
       </indexterm>
       <para>You can move a file or folder by dragging it with the mouse, or with the cut and paste commands. The following sections describe these two methods.</para>
-      <sect3 id="goscaja-537">
-        <title>Drag to the New Location</title>
+
+      <section xml:id="goscaja-537"><info><title>Drag to the New Location</title></info>
         <para>To drag a file or folder to a new location, perform the following steps:</para>
         <orderedlist>
           <listitem>
@@ -1783,9 +1756,9 @@ A popup menu appears. Choose one of the following items from the popup menu:</pa
 location, do not open a new window. Instead, drag the file or folder to the
 new location in the same window.</para>
         <tip><para>For more on dragging items, see <xref linkend="caja-dragndrop"/>.</para></tip>
-      </sect3>
-      <sect3 id="goscaja-538">
-        <title>Cut and Paste to the New Location</title>
+      </section>
+
+      <section xml:id="goscaja-538"><info><title>Cut and Paste to the New Location</title></info>
         <para>You can cut a file or folder and paste the file or folder into another
 folder, as follows:</para>
         <orderedlist>
@@ -1798,17 +1771,17 @@ then choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste
 </guimenuitem></menuchoice>.</para>
           </listitem>
         </orderedlist>
-      </sect3>
-    </sect2>
-    <sect2 id="goscaja-10">
-      <title>Copying a File or Folder</title>
+      </section>
+    </section>
+
+    <section xml:id="goscaja-10"><info><title>Copying a File or Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>copying files and folders</secondary>
       </indexterm>
       <para>You can copy a file or folder by dragging it with the mouse, or with the copy and paste commands. The following sections describe these two methods.</para>
-      <sect3 id="goscaja-640">
-        <title>Drag to the New Location</title>
+
+      <section xml:id="goscaja-640"><info><title>Drag to the New Location</title></info>
         <para>To copy a file or folder, perform the following steps:</para>
         <orderedlist>
           <listitem>
@@ -1827,9 +1800,10 @@ location, do not open a new window. Instead, grab the file or folder, then
 press-and-hold <keycap>Ctrl</keycap>. Drag the file or folder to the new location
 in the same window.</para>
         <tip><para>For more on dragging items, see <xref linkend="caja-dragndrop"/>.</para></tip>
-      </sect3>
-      <sect3 id="goscaja-441">
-        <title>Copy and Paste to the New Location</title>
+      </section>
+
+      <section xml:id="goscaja-441"><info><title>Copy and Paste to the New Location</title></info>
+        
         <para>You can copy a file or folder and paste the file or folder into another
 folder, as follows:</para>
         <orderedlist>
@@ -1842,10 +1816,10 @@ then choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste
 </guimenuitem></menuchoice>.</para>
           </listitem>
         </orderedlist>
-      </sect3>
-    </sect2>
-    <sect2 id="goscaja-82">
-      <title>Duplicating a File or Folder</title>
+      </section>
+    </section>
+
+    <section xml:id="goscaja-82"><info><title>Duplicating a File or Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>duplicating files and
@@ -1862,9 +1836,9 @@ in the current folder, perform the following steps:</para>
           <para>A copy of the file or folder appears in the current folder.</para>
         </listitem>
       </orderedlist>
-    </sect2>
-    <sect2 id="goscaja-11">
-      <title>Creating a Folder</title>
+    </section>
+
+    <section xml:id="goscaja-11"><info><title>Creating a Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>creating folders</secondary>
@@ -1884,9 +1858,9 @@ name of the folder is selected.</para>
           <para>Type a name for the folder, then press <keycap>Return</keycap>. </para>
         </listitem>
       </orderedlist>
-    </sect2>
-    <sect2 id="goscaja-templates-docs">
-      <title>Templates and Documents</title>
+    </section>
+
+    <section xml:id="goscaja-templates-docs"><info><title>Templates and Documents</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>creating documents</secondary>
@@ -1903,8 +1877,8 @@ Document</guilabel> menu.</para>
 as submenus in the menu. </para>
       <para>You can also share templates. Create a symbolic link from the template
 folder to the folder containing the shared templates. </para>
-      <sect3 id="goscaja-514">
-        <title>To Create a Document</title>
+
+      <section xml:id="goscaja-514"><info><title>To Create a Document</title></info>
         <para>If you have document templates, you can choose to create a document
 from one of the installed templates. </para>
         <para>To create a document perform the following steps:</para>
@@ -1926,10 +1900,10 @@ want to create. </para>
             <para>Rename the document before saving to the appropriate folder.</para>
           </listitem>
         </orderedlist>
-      </sect3>
-    </sect2>
-    <sect2 id="goscaja-12">
-      <title>Renaming a File or Folder</title>
+      </section>
+    </section>
+
+    <section xml:id="goscaja-12"><info><title>Renaming a File or Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>renaming folders</secondary>
@@ -1948,9 +1922,9 @@ or folder, then choose <guimenuitem>Rename</guimenuitem>.</para>
           <para>Type a new name for the file or folder, then press <keycap>Return</keycap>.</para>
         </listitem>
       </orderedlist>
-    </sect2>
-    <sect2 id="goscaja-13">
-      <title>Moving a File or Folder to Trash</title>
+    </section>
+
+    <section xml:id="goscaja-13"><info><title>Moving a File or Folder to Trash</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>Trash</secondary>
@@ -1958,8 +1932,7 @@ or folder, then choose <guimenuitem>Rename</guimenuitem>.</para>
       </indexterm>
       <indexterm>
         <primary>Trash</primary>
-        <secondary>moving
-files or folders to</secondary>
+        <secondary>moving files or folders to</secondary>
       </indexterm>
       <para>To move a file or folder
 to <guilabel>Trash</guilabel> perform the following steps:</para>
@@ -1978,9 +1951,9 @@ file or folder, then choose <guimenuitem>Move to Trash</guimenuitem>.</para>
 location on the removable media. To remove the file or folder permanently
 from the removable media, you must empty <guilabel>Trash</guilabel>.</para>
       </note>
-    </sect2>
-    <sect2 id="goscaja-443">
-      <title>Deleting a File or Folder</title>
+    </section>
+
+    <section xml:id="goscaja-443"><info><title>Deleting a File or Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>deleting files or folders</secondary>
@@ -2009,11 +1982,11 @@ or folder, then choose <guimenuitem>Delete</guimenuitem>.</para>
 	  </para>
 	</note>
       </para>
-    </sect2>
-    <sect2 id="caja-symlink">
-      <title>Creating a Symbolic Link to a File or Folder</title>
+    </section>
+    <section xml:id="caja-symlink"><info><title>Creating a Symbolic Link to a File or Folder</title></info>
+      
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-14"/>        
+      <anchor xml:id="goscaja-14"/>        
       <indexterm>
         <primary>file manager</primary>
         <secondary>creating symbolic link</secondary>
@@ -2039,29 +2012,26 @@ to the location where you want to place the link.</para>
 or folder to which a symbolic link points.</para>
       </note>
       <tip><para>For more on dragging items, see <xref linkend="caja-dragndrop"/>.</para></tip>      
-    </sect2>
-    <sect2 id="goscaja-476">
-      <title>Viewing the Properties of a File or Folder</title>
+    </section>
+
+    <section xml:id="goscaja-476"><info><title>Viewing the Properties of a File or Folder</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>viewing properties</secondary>
       </indexterm>
-      <para>To view the properties of a file or folder, perform the
-following steps:</para>
+      <para>To view the properties of a file or folder, perform the following steps:</para>
       <orderedlist>
         <listitem>
-          <para>Select the file or folder whose properties you want to view. </para>
+          <para>Select the file or folder whose properties you want to view.</para>
         </listitem>
         <listitem>
           <para>Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. A properties dialog is displayed.</para>
         </listitem>
         <listitem>
-          <para>Use the properties dialog to view the properties of the file
-or folder. </para>
+          <para>Use the properties dialog to view the properties of the file or folder. </para>
         </listitem>
         <listitem>
-          <para>Click <guibutton>Close</guibutton> to close the properties
-dialog.</para>
+          <para>Click <guibutton>Close</guibutton> to close the properties dialog.</para>
         </listitem>
       </orderedlist>
 
@@ -2148,10 +2118,9 @@ dialog.</para>
           </tbody>
         </tgroup>
       </informaltable>
-    </sect2>
-    
-  	<sect2 id="caja-permissions-overview" status="review">
-			<title>File Permissions</title>
+    </section>
+
+    <section xml:id="caja-permissions-overview" status="review"><info><title>File Permissions</title></info>
         <para>Permissions are settings assigned to each file and folder
   that determine what type of access users can have to the file or folder. For example, you can determine whether other users can read and edit a file that belongs to you, or only have access to read it but not make changes to it.</para>
         <para>Each file belongs to a particular user, and is associated with a group that the owner belongs to. The super user "root" has the ability to access any file on the system.</para>
@@ -2196,17 +2165,14 @@ dialog.</para>
           </varlistentry>
         </variablelist>        
 
-        <para>For more on changing the permissions for a file or folder, see <xref linkend="caja-permissions" />.</para>
-    </sect2>
+        <para>For more on changing the permissions for a file or folder, see <xref linkend="caja-permissions"/>.</para>
+    </section>
 
-    <sect2 id="caja-permissions">
-      <title>Changing Permissions</title>
+    <section xml:id="caja-permissions"><info><title>Changing Permissions</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-430"/>
+      <anchor xml:id="goscaja-430"/>
       
-      <sect3 id="caja-permissions-file">    
-        <title>Changing Permissions for a File</title>
-
+      <section xml:id="caja-permissions-file"><info><title>Changing Permissions for a File</title></info>    
         <indexterm>
           <primary>file manager</primary>
           <secondary>changing permissions</secondary>
@@ -2253,10 +2219,10 @@ dialog.</para>
             <para>To allow a file to be run as a program, select <guilabel>Execute</guilabel></para>
           </listitem>
         </orderedlist>   
-      </sect3>    
+      </section>    
 
-      <sect3 id="caja-permissions-folder">    
-        <title>Changing Permissions for a Folder</title>
+      <section xml:id="caja-permissions-folder"><info><title>Changing Permissions for a Folder</title></info>    
+        
         
         <para>To change the permissions of a folder, perform the following steps:</para>
         <orderedlist>
@@ -2300,12 +2266,11 @@ dialog.</para>
         </orderedlist>  
        
         <para>To set permissions for all the items contained in a folder, set the <guilabel>File Access</guilabel> and <guilabel>Execute</guilabel> properties and click on <guibutton>Apply permissions to enclosed files</guibutton>.</para>
-      </sect3>           
+      </section>           
 
-    </sect2>
+    </section>
     
-    <sect2 id="goscaja-200">
-      <title>Adding Notes to Files and Folders</title>
+    <section xml:id="goscaja-200"><info><title>Adding Notes to Files and Folders</title></info>
       <para>You can add notes to files or folders. You can add notes to files or
 folders in the following ways:</para>
       <itemizedlist>
@@ -2316,10 +2281,10 @@ folders in the following ways:</para>
           <para>From <guilabel>Notes</guilabel> in the side pane</para>
         </listitem>
       </itemizedlist>
-      <sect3 id="caja-notes">
-        <title>To Add a Note Using the Properties Dialog</title>
+
+      <section xml:id="caja-notes"><info><title>To Add a Note Using the Properties Dialog</title></info>
         <!-- preserve id for backwards compatibility: 2.12 -->
-        <anchor id="goscaja-472"/>           
+        <anchor xml:id="goscaja-472"/>           
         <indexterm>
           <primary>notes</primary>
           <secondary>adding to files and folders</secondary>
@@ -2347,9 +2312,9 @@ dialog. A note emblem is added to the file or folder.</para>
           </listitem>
         </orderedlist>
         <para><indexterm><primary>notes</primary><secondary>deleting</secondary></indexterm><indexterm><primary>file manager</primary><secondary>notes</secondary><tertiary>deleting</tertiary></indexterm>To delete a note, delete the note text from the <guilabel>Notes</guilabel> tabbed section.</para>
-      </sect3>
-      <sect3 id="goscaja-473">
-        <title>To Add a Note Using Notes in the Side Pane</title>
+      </section>
+      <section xml:id="goscaja-473"><info><title>To Add a Note Using Notes in the Side Pane</title></info>
+        
         <para>To add a note to a file or folder, perform the following steps:</para>
         <orderedlist>
           <listitem>
@@ -2368,12 +2333,13 @@ pane. You can click on this icon to display the note.</para>
         </orderedlist>
         <para>To delete a note, delete the note text from <guilabel>Notes</guilabel>
 in the side pane.</para>
-      </sect3>
-    </sect2>
-    <sect2 id="caja-bookmarks">
-      <title>Using Bookmarks For Your Favorite Locations</title>
+      </section>
+    </section>
+
+    <section xml:id="caja-bookmarks"><info><title>Using Bookmarks For Your Favorite Locations</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-36"/>         
+      <anchor xml:id="goscaja-36"/>
+
       <indexterm>
         <primary>file manager</primary>
         <secondary>bookmarks</secondary>
@@ -2390,13 +2356,12 @@ in the side pane.</para>
       
       <para>To open an item that is in your bookmarks, choose the item from a menu.</para>
 
-      <sect3 id="goscaja-40">
-        <title>Adding a Bookmark</title>
+      <section xml:id="goscaja-40"><info><title>Adding a Bookmark</title></info>
         <para>To add a bookmark, open the folder or location that you want to bookmark, then choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Add Bookmark</guimenuitem></menuchoice>.</para>
         <para>If you are using a <application>Caja</application> browser window, choose <menuchoice><guimenu>Bookmarks</guimenu><guimenuitem>Add Bookmark</guimenuitem></menuchoice>.</para>
-      </sect3>
-      <sect3 id="goscaja-41">
-        <title>To Edit a Bookmark</title>
+      </section>
+
+      <section xml:id="goscaja-41"><info><title>To Edit a Bookmark</title></info>
         <para>To edit your bookmarks perform the following steps:</para>
         <orderedlist>
           <listitem>
@@ -2453,12 +2418,12 @@ bookmark in the menus.</para>
 of the dialog. Click <guilabel>Delete</guilabel>. </para>
           </listitem>
         </orderedlist>
-      </sect3>
-    </sect2>
-    <sect2 id="caja-trash">
-      <title>Using Trash</title>
+      </section>
+    </section>
+
+    <section xml:id="caja-trash"><info><title>Using Trash</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-44"/>         
+      <anchor xml:id="goscaja-44"/>         
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -2491,8 +2456,8 @@ case you change your mind, or accidentally remove the wrong file.</para>
       <para>If you need to retrieve a file from <guilabel>Trash</guilabel>, you
 can display <guilabel>Trash</guilabel> and move the file out of <guilabel>Trash</guilabel>. When you empty <guilabel>Trash</guilabel>, you delete the
 contents of <guilabel>Trash</guilabel> permanently. </para>
-      <sect3 id="goscaja-107">
-        <title>To Display Trash</title>
+
+      <section xml:id="goscaja-107"><info><title>To Display Trash</title></info>
         <indexterm>
           <primary>Trash</primary>
           <secondary>displaying</secondary>
@@ -2515,9 +2480,9 @@ displayed in the window.</para>
             <para>Double-click on the <guilabel>Trash</guilabel> object on the desktop.</para>
           </listitem>
         </itemizedlist>
-      </sect3>
-      <sect3 id="goscaja-108">
-        <title>To Empty Trash</title>
+      </section>
+      <section xml:id="goscaja-108"><info><title>To Empty Trash</title></info>
+        
         <indexterm>
           <primary>Trash</primary>
           <secondary>emptying</secondary>
@@ -2540,10 +2505,10 @@ Trash</guimenuitem></menuchoice>.</para>
 you no longer need.
     </para>
    </caution>
-      </sect3>
-    </sect2>
-    <sect2 id="caja-hidden-files">
-      <title>Hidden Files</title>
+      </section>
+    </section>
+
+    <section xml:id="caja-hidden-files"><info><title>Hidden Files</title></info>
       <indexterm>
         <primary>hidden</primary>
         <secondary>files</secondary>
@@ -2559,8 +2524,7 @@ you no longer need.
       
       <para>To set <application>Caja</application> to always show hidden files, see  <xref linkend="caja-preferences"/>.</para>
 
-      <sect3 id="caja-managing-hidden-files">
-        <title>Hiding a File or Folder</title>
+      <section xml:id="caja-managing-hidden-files"><info><title>Hiding a File or Folder</title></info>
         <indexterm>
           <primary>create</primary>
           <secondary>hidden</secondary>
@@ -2569,15 +2533,15 @@ you no longer need.
         <programlisting>filename
 foldername</programlisting>
         <para>You may need to refresh the relevant <application>Caja</application> window to see the change: press <keycombo><keycap>Ctrl</keycap><keycap>R</keycap></keycombo>.</para>
-      </sect3>
-  </sect2>
-  </sect1>
+      </section>
+  </section>
+  </section>
   <!-- ====================================================== File properties -->    
 
-  <sect1 id="caja-properties">
-    <title>Item Properties</title>
+  <section xml:id="caja-properties"><info><title>Item Properties</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscaja-51"/><!-- was: changing icon, but linked to from the GUI -->
+    <anchor xml:id="goscaja-51"/><!-- was: changing icon, but linked to from the GUI -->
+
     <indexterm>
       <primary>file manager</primary>
       <secondary>properties</secondary>
@@ -2608,24 +2572,17 @@ foldername</programlisting>
           </itemizedlist>
 	    </listitem>
     </orderedlist>
-      
- 
-
-  </sect1>  
-
-  
+  </section>  
   
   <!-- ====================================================== Appearance -->  
-  <sect1 id="goscaja-203">
-    <title>Modifying the Appearance of Files and Folders</title>
+  <section xml:id="goscaja-203"><info><title>Modifying the Appearance of Files and Folders</title></info>
     <indexterm>
       <primary>file manager</primary>
-      <secondary>modifying appearance
-of files and folders</secondary>
+      <secondary>modifying appearance of files and folders</secondary>
     </indexterm>
     <para>The <application>Caja</application> file manager enables you to modify the appearance of your files and folders in several ways. You may customize the way files or folders look by attaching emblems or backgrounds to them. You can also change format in which <application>Caja</application> displays these items to you. The following sections describe how to do so.</para>
-    <sect2 id="goscaja-550">
-      <title>Icons and Emblems</title>
+
+    <section xml:id="goscaja-550"><info><title>Icons and Emblems</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>icons</secondary>
@@ -2641,7 +2598,7 @@ of files and folders</secondary>
         <secondary>introduction</secondary>
       </indexterm>
       <para>The file manager displays your files and folders as icons. Depending on the type of the file the icon may be a image representative of the file type, a small thumbnail or preview showing the files contents. You can also add emblems to your file and folder icons. Such emblems appear in addition to the file icon and provide another means to manage your files. For example you can mark a file as important by adding an <guilabel>Important</guilabel> emblem to it, creating the following visual effect: </para>
-<screenshot>
+      <screenshot>
         <mediaobject>
           <imageobject>
             <imagedata fileref="figures/caja_emblem.png" format="PNG"/>
@@ -2700,8 +2657,7 @@ of files and folders</secondary>
                 </screenshot>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para><indexterm><primary>symbolic links</primary><secondary>and emblems</secondary></indexterm>Symbolic
-link</para>
+                <para><indexterm><primary>symbolic links</primary><secondary>and emblems</secondary></indexterm>Symbolic link</para>
               </entry>
             </row>
             <row>
@@ -2741,9 +2697,9 @@ link</para>
           </tbody>
         </tgroup>
       </informaltable>
-    </sect2>
-    <sect2 id="caja-icon">
-      <title>Changing the Icon for a File or Folder</title> 
+    </section>
+    <section xml:id="caja-icon"><info><title>Changing the Icon for a File or Folder</title></info>
+       
       <indexterm>
         <primary>file manager</primary>
         <secondary>icons</secondary>
@@ -2768,19 +2724,18 @@ icon</guilabel> dialog is displayed. </para>
 the icon to represent the file or folder. </para>
         </listitem>
         <listitem>
-          <para>Click <guibutton>Close</guibutton> to close the properties
-dialog.</para>
+          <para>Click <guibutton>Close</guibutton> to close the properties dialog.</para>
         </listitem>
       </orderedlist>
       <para>To restore an icon from a custom icon to the default icon,
 Select the file or folder that you want to change, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>.
 click on the <guibutton>Icon</guibutton> button, in the <guilabel>Select custom 
 icon</guilabel> dialog click <guibutton>Revert</guibutton>.</para>
-    </sect2>
-    <sect2 id="caja-emblems">
-      <title>Adding an Emblem to a File or Folder</title>
+    </section>
+
+    <section xml:id="caja-emblems"><info><title>Adding an Emblem to a File or Folder</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-112"/>       
+      <anchor xml:id="goscaja-112"/>       
       <indexterm>
         <primary>emblems</primary>
         <secondary>adding to file</secondary>
@@ -2789,8 +2744,7 @@ icon</guilabel> dialog click <guibutton>Revert</guibutton>.</para>
         <primary>emblems</primary>
         <secondary>adding to folder</secondary>
       </indexterm>
-      <para>To add an emblem to an item perform the following
-steps: </para>
+      <para>To add an emblem to an item perform the following steps: </para>
       <orderedlist>
         <listitem>
           <para>Select the item to which you want to add an emblem.</para>
@@ -2805,14 +2759,14 @@ steps: </para>
           <para>Select the emblem to add to the item.</para>
         </listitem>
         <listitem>
-          <para>Click <guibutton>Close</guibutton> to close the properties
-dialog.</para>
+          <para>Click <guibutton>Close</guibutton> to close the properties dialog.</para>
         </listitem>
       </orderedlist>
       <para>In browser windows you may also add emblems to items by dragging them from the emblem side pane.</para>
-    </sect2>
-    <sect2 id="goscaja-471">
-      <title>Creating a New Emblem</title>
+    </section>
+
+    <section xml:id="goscaja-471"><info><title>Creating a New Emblem</title></info>
+      
       <indexterm>
         <primary>emblems</primary>
         <secondary>adding new</secondary>
@@ -2828,8 +2782,7 @@ on the <guibutton>Add a New Emblem</guibutton> button. A <guilabel>Create
 a New Emblem</guilabel> dialog is displayed.</para>
         </listitem>
         <listitem>
-          <para>Type a name for the emblem in the <guilabel>Keyword</guilabel>
-text box.</para>
+          <para>Type a name for the emblem in the <guilabel>Keyword</guilabel> text box.</para>
         </listitem>
         <listitem>
           <para>Click on the <guilabel>Image</guilabel> button. A dialog is
@@ -2841,13 +2794,13 @@ click <guibutton>OK</guibutton>. </para>
 New Emblem</guilabel> dialog.</para>
         </listitem>
       </orderedlist>
-    </sect2>
-    <sect2 id="caja-backgrounds-and-emblems">
-      <title>Changing Backgrounds</title>
+    </section>
+
+    <section xml:id="caja-backgrounds-and-emblems"><info><title>Changing Backgrounds</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-50"/>         
-      <anchor id="goscaja-63"/>
-      <anchor id="goscaja-64"/>
+      <anchor xml:id="goscaja-50"/>         
+      <anchor xml:id="goscaja-63"/>
+      <anchor xml:id="goscaja-64"/>
       <indexterm>
         <primary>file manager</primary>
         <secondary>changing backgrounds</secondary>
@@ -2889,14 +2842,14 @@ New Emblem</guilabel> dialog.</para>
       <para>You can add a new color to the list by clicking the <guibutton>Add a New Color</guibutton>
       button when the colors are selected.  Select a color in the color chooser dialog and click
       <guibutton>OK</guibutton>.  The color will appear in the list of colors you can use.</para>
-    </sect2>    
-  </sect1>  
+    </section>    
+  </section>  
   
   <!-- ====================================================== Removable media -->    
-  <sect1 id="goscaja-460">
-    <title>Using Removable Media</title>
+  <section xml:id="goscaja-460"><info><title>Using Removable Media</title></info>
     <!-- compatibility -->
-    <anchor id="goscaja-469"/>
+    <anchor xml:id="goscaja-469"/>
+
     <indexterm>
       <primary>removable media</primary>
       <secondary>introduction</secondary>
@@ -2908,8 +2861,8 @@ New Emblem</guilabel> dialog.</para>
       player for an audio CD). See <xref linkend="goscaja-61"/> for how to
       configure these actions for different media formats.
     </para>
-    <sect2 id="goscaja-462">
-      <title>To Mount Media</title>
+
+    <section xml:id="goscaja-462"><info><title>To Mount Media</title></info>
       <indexterm>
         <primary>removable media</primary>
         <secondary>mounting</secondary>
@@ -2929,19 +2882,17 @@ icon. An icon that represents the media is added to the desktop. </para>
       <note>
         <para>You cannot change the name of a removable media icon.</para>
       </note>
-    </sect2>
-    <sect2 id="goscaja-461">
-      <title>To Display Media Contents</title>
+    </section>
+
+    <section xml:id="goscaja-461"><info><title>To Display Media Contents</title></info>
       <indexterm>
         <primary>removable media</primary>
         <secondary>displaying media contents</secondary>
       </indexterm>
-      <para>You can display media contents in any of the
-following ways: </para>
+      <para>You can display media contents in any of the following ways: </para>
       <itemizedlist>
         <listitem>
-          <para>Double-click on the icon that represents the media on the
-desktop. </para>
+          <para>Double-click on the icon that represents the media on the desktop.</para>
         </listitem>
         <listitem>
           <para>Right-click on the icon that represents the media on the
@@ -2950,9 +2901,9 @@ desktop, then choose <guimenuitem>Open</guimenuitem>. </para>
       </itemizedlist>
       <para>A file manager window displays the contents of the media. To reload
 the display, click on the <guibutton>Reload</guibutton> button.</para>
-    </sect2>
-    <sect2 id="goscaja-463">
-      <title>To Display Media Properties</title>
+    </section>
+
+    <section xml:id="goscaja-463"><info><title>To Display Media Properties</title></info>
       <indexterm>
         <primary>removable media</primary>
         <secondary>displaying media properties</secondary>
@@ -2960,9 +2911,9 @@ the display, click on the <guibutton>Reload</guibutton> button.</para>
       <para>To display the properties of removable media,
 right-click on the icon that represents the media on the desktop, then choose <guimenuitem>Properties</guimenuitem>. A dialog displays the properties of the media.</para>
       <para>To close the properties dialog, click <guibutton>Close</guibutton>.</para>
-    </sect2>
-    <sect2 id="goscaja-464">
-      <title>To Eject Media</title>
+    </section>
+
+    <section xml:id="goscaja-464"><info><title>To Eject Media</title></info>
       <indexterm>
         <primary>removable media</primary>
         <secondary>ejecting</secondary>
@@ -2991,12 +2942,13 @@ for the drive disappears.</para>
           <caution>
             <para>You must unmount removable media before ejecting. Do not remove a USB flash drive before you unmount the flash drive. If you do not unmount the media first you might lose data.</para>
           </caution>
-    </sect2>
-  </sect1>
-  <sect1 id="caja-cdwriter">
-    <title>Writing CDs or DVDs</title>
+    </section>
+  </section>
+
+  <section xml:id="caja-cdwriter"><info><title>Writing CDs or DVDs</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscaja-475"/>
+    <anchor xml:id="goscaja-475"/>
+
     <indexterm>
       <primary>file manager</primary>
       <secondary>writing CDs</secondary>
@@ -3018,8 +2970,8 @@ for the drive disappears.</para>
     <para>You can start choosing files to burn to a disc at any time. The file manager provides
 a special folder for files and folders that you wish to write to a CD or DVD. From there you can easily write all the content (which you place in this special folder) to a CD or DVD.</para>
 
-    <sect2 id="caja-cdwriter-data">
-      <title>Creating Data Discs</title>
+    <section xml:id="caja-cdwriter-data"><info><title>Creating Data Discs</title></info>
+      
     <para>To write a CD or DVD, perform the following steps:</para>
     <orderedlist>
       <listitem>
@@ -3114,9 +3066,9 @@ process is complete is displayed in the dialog.</para>
     </orderedlist>
     <tip><para>You can set the CD/DVD Creator folder to open automatically when you insert a blank disc. See <xref linkend="goscaja-61"/>.</para></tip>
     <note><para>The filesystem written to the CD will be readable with long filenames on all recent operating systems. Both the Joliet and the Rock Ridge CD-ROM filesystem extensions are used.</para></note>
-    </sect2>
-    <sect2 id="caja-cdwriter-copy">
-      <title>Copying CDs or DVDs</title>
+    </section>
+
+    <section xml:id="caja-cdwriter-copy"><info><title>Copying CDs or DVDs</title></info>
         <para>You can create a copy of a CD or DVD, either to another disc or to an image file stored on your computer. To create a copy, perform the following steps:</para>
         <orderedlist>
           <listitem><para>Insert the disc you want to copy.</para></listitem>               
@@ -3126,26 +3078,25 @@ process is complete is displayed in the dialog.</para>
         </orderedlist>
         <para>If you have only one drive with write capabilities, the process will first create a disc image file on your computer. It will then eject the original disk, and ask you to change it for a blank disk on which to write the copy.</para>
         <tip><para>If you want to create more than one copy, choose the Image File option on the <guilabel>Write to Disc</guilabel> and then write the disc image: see <xref linkend="caja-cdwriter-writeimage"/>.</para></tip>
+    </section>
 
-    </sect2>    
-    <sect2 id="caja-cdwriter-writeimage">
-      <title>Creating a Disc from an Image File</title>
+    <section xml:id="caja-cdwriter-writeimage"><info><title>Creating a Disc from an Image File</title></info>
       <para>You can write a disc image to a CD or DVD. For example, you may have downloaded a disc image from the internet, or previously created one yourself. Disc images usually have a <filename>.iso</filename> file extension and are sometimes called iso files.</para>
         <para>To write a disc image, right-click on the disc image file, then choose <guimenuitem>Write to Disc</guimenuitem> from the popup menu.</para>      
-    </sect2>
-  </sect1>
+    </section>
+  </section>
 
-  <sect1 id="goscaja-515">
-    <title>Navigating Remote Servers</title>
+  <section xml:id="goscaja-515"><info><title>Navigating Remote Servers</title></info>
     <para>The <application>Caja</application> file manager provides an integrated
-access point to your files, applications, FTP sites, Windows shares, WebDav servers and SSH servers.</para>  
-    <sect2 id="caja-server-connect">
-      <title>To Access a remote server</title>
+access point to your files, applications, FTP sites, Windows shares, WebDav servers and SSH servers.</para>
+
+    <section xml:id="caja-server-connect"><info><title>To Access a remote server</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscaja-37"/>      
+      <anchor xml:id="goscaja-37"/>      
       <!-- MOVE THIS ANCHOR -->
       <!-- To Add a Network Server -->
-      <anchor id="goscaja-466"/>
+      <anchor xml:id="goscaja-466"/>
+
       <indexterm>
         <primary>FTP sites</primary>
         <secondary>accessing</secondary>
@@ -3245,14 +3196,15 @@ The user name information is not appropriate for a public FTP connection.</para>
 <para>If the server information is provided in the form of a URI, or you require a specialized connection, choose <menuchoice><guimenuitem>Custom Location</guimenuitem></menuchoice> as the service type.</para>
 <para>Once you have filled in the information, click on
 the <guibutton>Connect</guibutton> button. When the connection succeeds, the contents of the site are displayed and you may drag and drop files to and from the remote server.</para>
-    </sect2>
-    <sect2 id="caja-accessnetwork">
-      <title>To Access Network Places</title>
+    </section>
+
+    <section xml:id="caja-accessnetwork"><info><title>To Access Network Places</title></info>
       <!-- MOVE THIS ANCHOR -->
       <!-- To Add a Network Server -->
-      <anchor id="goscaja-508"/>
-      <anchor id="goscaja-509"/>
-      <anchor id="goscaja-465"/>      
+      <anchor xml:id="goscaja-508"/>
+      <anchor xml:id="goscaja-509"/>
+      <anchor xml:id="goscaja-465"/>
+
       <indexterm>
         <primary>network places</primary>
         <secondary>accessing</secondary>
@@ -3274,18 +3226,17 @@ manager window.</para>
       <para><indexterm><primary>Samba servers</primary><see>Windows network</see></indexterm>To access Windows shares, double-click on the <guilabel>Windows
 Network (SMB) </guilabel> object. A list of the Windows shares available to
 you is displayed in the file manager window.</para>
-    </sect2>
+    </section>
+
     <!-- special URIs by and large obsolete or at least arcane -->
-    <sect2 id="goscaja-467">
-      <title>Accessing Special URI Locations</title>
+    <section xml:id="goscaja-467"><info><title>Accessing Special URI Locations</title></info>
       <indexterm>
         <primary>special URI locations</primary>
         <secondary>accessing</secondary>
       </indexterm>
       <indexterm>
         <primary>file manager</primary>
-        <secondary>special URI
-locations</secondary>
+        <secondary>special URI locations</secondary>
       </indexterm>
       <indexterm>
         <primary>URI, special</primary>
@@ -3295,8 +3246,7 @@ locations</secondary>
       <para>These are intended for advanced users: in most cases, an easier method of accessing the function or location exists.</para>
       <para><xref linkend="goscaja-TBL-479"/> lists the special URI locations that you can
 use with the file manager.</para>
-      <table frame="topbot" id="goscaja-TBL-479">
-        <title>Special URI Locations</title>
+      <table frame="topbot" xml:id="goscaja-TBL-479"><info><title>Special URI Locations</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="33.94*"/>
           <colspec colname="colspec1" colwidth="66.06*"/>
@@ -3338,20 +3288,18 @@ You can also use this URI to add network locations to your system. See also <xre
           </tbody>
         </tgroup>
       </table>
-    </sect2>
-  </sect1>
+    </section>
+  </section>
 
-
-	<!-- ============================================== prefs -->
-  <sect1 id="caja-preferences">
-
-    <title>Caja Preferences</title>
+  <!-- ============================================== prefs -->
+  <section xml:id="caja-preferences"><info><title>Caja Preferences</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscaja-15"/>
-    <anchor id="goscaja-17"/>
+    <anchor xml:id="goscaja-15"/>
+    <anchor xml:id="goscaja-17"/>
     <!-- preserve id for backwards compatibility: 2.16 -->    
-    <anchor id="prefs-filemanager"/>
-    <anchor id="goscustdesk-84"/>        
+    <anchor xml:id="prefs-filemanager"/>
+    <anchor xml:id="goscustdesk-84"/>
+
     <indexterm>
       <primary>file manager</primary>
       <secondary>customizing</secondary>
@@ -3362,13 +3310,12 @@ You can also use this URI to add network locations to your system. See also <xre
       <tertiary>introduction</tertiary>
     </indexterm>
     <indexterm>
-      <primary>preferences,
-file manager</primary>
+      <primary>preferences, file manager</primary>
       <see>file manager preferences</see>
     </indexterm>
     <para>Use the <guilabel>File Management Preferences</guilabel> dialog to customize the file manager to suit your requirements
 and preferences.</para>
-		<para>To display the <guilabel>File Management Preferences</guilabel> dialog, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. You can also access this dialog directly from the top panel Menubar
+    <para>To display the <guilabel>File Management Preferences</guilabel> dialog, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. You can also access this dialog directly from the top panel Menubar
 by choosing <menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisubmenu><guimenuitem>File Management</guimenuitem></menuchoice>.</para>
     <para>You can set preferences in the following categories: </para>
     <itemizedlist>
@@ -3376,8 +3323,7 @@ by choosing <menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisub
         <para>The default settings for views.</para>
       </listitem>
       <listitem>
-        <para>The behavior of files and folders, executable text files,
-and Trash.</para>
+        <para>The behavior of files and folders, executable text files, and Trash.</para>
       </listitem>
       <listitem>
         <para>The information that is displayed in icon captions and the date format.</para>
@@ -3392,8 +3338,8 @@ and Trash.</para>
         <para>How removable media and connected devices are handled.</para>
       </listitem>
     </itemizedlist>
-    <sect2 id="goscaja-438">
-      <title>Views Preferences</title>
+
+    <section xml:id="goscaja-438"><info><title>Views Preferences</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>preferences</secondary>
@@ -3407,8 +3353,7 @@ choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem>
 display the <guilabel>Views</guilabel> tabbed section.</para>
       <para><xref linkend="goscaja-TBL-30"/> lists the views preferences that
 you can modify. </para>
-      <table frame="topbot" id="goscaja-TBL-30">
-        <title>Views Preferences</title>
+      <table frame="topbot" xml:id="goscaja-TBL-30"><info><title>Views Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="35.09*"/>
           <colspec colname="colspec1" colwidth="64.91*"/>
@@ -3459,8 +3404,7 @@ files when you sort a folder.</para>
             <row>
               <entry colname="colspec0" valign="top">
                 <para>
-                  <guilabel>Show hidden and
-backup files</guilabel>
+                  <guilabel>Show hidden and backup files</guilabel>
                 </para>
               </entry>
               <entry colname="colspec1">
@@ -3524,9 +3468,9 @@ for items beside the icon rather than under the icon.</para>
           </tbody>
         </tgroup>
       </table>
-    </sect2>
-    <sect2 id="goscaja-56">
-      <title>Behavior Preferences</title>
+    </section>
+
+    <section xml:id="goscaja-56"><info><title>Behavior Preferences</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>preferences</secondary>
@@ -3607,9 +3551,9 @@ tab to display the <guilabel>Behavior</guilabel> tabbed section. You can set the
       	  </listitem>
       	</varlistentry>
       </variablelist>
-    </sect2>
-    <sect2 id="goscaja-439">
-      <title>Display Preferences</title>
+    </section>
+
+    <section xml:id="goscaja-439"><info><title>Display Preferences</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>icons</secondary>
@@ -3655,8 +3599,7 @@ select:</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-the size of the item.</para>
+                <para>Choose this option to display the size of the item.</para>
               </entry>
             </row>
             <row>
@@ -3666,8 +3609,7 @@ the size of the item.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-the description of the MIME type of the item.</para>
+                <para>Choose this option to display the description of the MIME type of the item.</para>
               </entry>
             </row>
             <row>
@@ -3677,8 +3619,7 @@ the description of the MIME type of the item.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose
-this option to display the last modification date of  the item.</para>
+                <para>Choose this option to display the last modification date of the item.</para>
               </entry>
             </row>
             <row>
@@ -3688,8 +3629,7 @@ this option to display the last modification date of  the item.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose
-this option to display the date that the item was last accessed.</para>
+                <para>Choose this option to display the date that the item was last accessed.</para>
               </entry>
             </row>
             <row>
@@ -3699,8 +3639,7 @@ this option to display the date that the item was last accessed.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-the owner of the item.</para>
+                <para>Choose this option to display the owner of the item.</para>
               </entry>
             </row>
             <row>
@@ -3710,8 +3649,7 @@ the owner of the item.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-the group to which the item belongs.</para>
+                <para>Choose this option to display the group to which the item belongs.</para>
               </entry>
             </row>
             <row>
@@ -3744,8 +3682,7 @@ notation, for example <computeroutput>764</computeroutput>. </para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-the MIME type of the item.</para>
+                <para>Choose this option to display the MIME type of the item.</para>
               </entry>
             </row>
             <row>
@@ -3755,8 +3692,7 @@ the MIME type of the item.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-no information for the item.</para>
+                <para>Choose this option to display no information for the item.</para>
               </entry>
             </row>
           </tbody>
@@ -3765,9 +3701,9 @@ no information for the item.</para>
       <para>
       The date <guilabel>Format</guilabel> option lets you choose how the date is displayed throughout Caja.
       </para>
-    </sect2>
-    <sect2 id="goscaja-490">
-      <title>List Columns Preferences</title>
+    </section>
+
+    <section xml:id="goscaja-490"><info><title>List Columns Preferences</title></info>
       <para>You can specify what information is displayed in list view in file manager
 windows. You can specify which columns are displayed in list view, and the
 order in which the columns are displayed.</para>
@@ -3791,7 +3727,7 @@ buttons to specify the position of columns in list view.</para>
                 <para>Information</para>
               </entry>
               <entry>
-                <para>Description </para>
+                <para>Description</para>
               </entry>
             </row>
           </thead>
@@ -3803,8 +3739,7 @@ buttons to specify the position of columns in list view.</para>
                 </para>
               </entry>
               <entry colname="colspec1">
-                <para>Choose this option to display the name of
-the item.</para>
+                <para>Choose this option to display the name of the item.</para>
               </entry>
             </row>
             <row>
@@ -3814,8 +3749,7 @@ the item.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-the size of the item.</para>
+                <para>Choose this option to display the size of the item.</para>
               </entry>
             </row>
             <row>
@@ -3837,8 +3771,7 @@ and Programs</application> preference tool.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose
-this option to display the last modification date of the item.</para>
+                <para>Choose this option to display the last modification date of the item.</para>
               </entry>
             </row>
             <row>
@@ -3848,8 +3781,7 @@ this option to display the last modification date of the item.</para>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose
-this option to display the date that the item was last accessed.</para>
+                <para>Choose this option to display the date that the item was last accessed.</para>
               </entry>
             </row>
             <row>
@@ -3859,8 +3791,7 @@ this option to display the date that the item was last accessed.</para>
                 </para>
               </entry>
               <entry colname="colspec1">
-                <para>Choose this option to display the group to
-which the item belongs.</para>
+                <para>Choose this option to display the group to which the item belongs.</para>
               </entry>
             </row>
             <row>
@@ -3870,8 +3801,7 @@ which the item belongs.</para>
                 </para>
               </entry>
               <entry colname="colspec1">
-                <para>Choose this option to display the MIME type
-of the item.</para>
+                <para>Choose this option to display the MIME type of the item.</para>
               </entry>
             </row>
             <row>
@@ -3892,8 +3822,7 @@ option to display the permissions of the item in octal notation, for example <co
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
-                <para>Choose this option to display
-the owner of the item.</para>
+                <para>Choose this option to display the owner of the item.</para>
               </entry>
             </row>
             <row>
@@ -3911,9 +3840,9 @@ characters, for example <computeroutput>-rwxrw-r--</computeroutput>.</para>
           </tbody>
         </tgroup>
       </informaltable>
-    </sect2>
-    <sect2 id="goscaja-60">
-      <title>Preview Preferences</title>
+    </section>
+
+    <section xml:id="goscaja-60"><info><title>Preview Preferences</title></info>
       <indexterm>
         <primary>file manager</primary>
         <secondary>preferences</secondary>
@@ -3978,8 +3907,7 @@ on other file systems.</para>
 tabbed section. </para>
       <para><xref linkend="goscaja-TBL-41"/> lists the preview preferences that
 you can modify.</para>
-      <table frame="topbot" id="goscaja-TBL-41">
-        <title>Preview Preferences</title>
+      <table frame="topbot" xml:id="goscaja-TBL-41"><info><title>Preview Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="35.09*"/>
           <colspec colname="colspec1" colwidth="64.91*"/>
@@ -4032,8 +3960,7 @@ file size for files for which the file manager creates a thumbnail.</para>
             <row>
               <entry colname="colspec0" valign="top">
                 <para>
-                  <guilabel>Preview sound
-files</guilabel>
+                  <guilabel>Preview sound files</guilabel>
                 </para>
               </entry>
               <entry colname="colspec1" valign="top">
@@ -4055,9 +3982,9 @@ need to increase your zoom level to see the number of items in each folder.</par
           </tbody>
         </tgroup>
       </table>
-    </sect2>
-    <sect2 id="goscaja-61">
-      <title>Media Preferences</title>
+    </section>
+
+    <section xml:id="goscaja-61"><info><title>Media Preferences</title></info>
       <para>
         You can configure how <application>Caja</application> handles
         removable media and devices that are connected to the computer, such
@@ -4131,10 +4058,8 @@ need to increase your zoom level to see the number of items in each folder.</par
       </informaltable>
       <para>The most common media formats can be configured in the <guilabel>Media Handling</guilabel> section: audio CDs, video DVDs, music players, cameras, and software cds.</para>
       <para>To configure the handling for other media formats, first select the format in the <guilabel>Type</guilabel> drop-down list, then select the desired handling for this format in the <guilabel>Action</guilabel> drop-down list.</para>
-      <para><xref linkend="goscaja-TBL-43"/> lists other media handling preferences that
-you can modify.</para>
-      <table frame="topbot" id="goscaja-TBL-43">
-        <title>Preview Preferences</title>
+      <para><xref linkend="goscaja-TBL-43"/> lists other media handling preferences that you can modify.</para>
+      <table frame="topbot" xml:id="goscaja-TBL-43"><info><title>Preview Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="35.09*"/>
           <colspec colname="colspec1" colwidth="64.91*"/>
@@ -4178,12 +4103,11 @@ you can modify.</para>
          </tbody>
        </tgroup>
       </table>
-    </sect2>
+    </section>
 
-  </sect1>
+  </section>
   
-  <sect1 id="goscaja-440">
-    <title>Extending Caja</title>
+  <section xml:id="goscaja-440"><info><title>Extending Caja</title></info>
     <indexterm>
       <primary>file manager</primary>
       <secondary>running scripts</secondary>
@@ -4191,9 +4115,9 @@ you can modify.</para>
     <indexterm>
       <primary>scripts, running from file manager</primary>
     </indexterm>
-<para>Caja can be extended in two main ways. Through <application>Caja</application> extensions, and through scripts. This section explains the difference between the two and how to install.</para>
-    <sect2 id="goscaja-444">
-      <title>Caja Scripts</title>
+    <para>Caja can be extended in two main ways. Through <application>Caja</application> extensions, and through scripts. This section explains the difference between the two and how to install.</para>
+
+    <section xml:id="goscaja-444"><info><title>Caja Scripts</title></info>
       <para>Caja can run scripts. Scripts are typically simpler in operation than full <application>Caja</application> extensions and can be written in any scripted language capable of being executed on your computer. To run a script choose <menuchoice><guimenu>File</guimenu><guimenuitem>Scripts</guimenuitem></menuchoice>, then choose the script that you want to run from the submenu.</para>
       <para>To run a script on a particular file, select the file in the view pane.
 Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Scripts</guimenuitem></menuchoice>, then choose the script that you want to run on the file from
@@ -4202,18 +4126,18 @@ the submenu. You can also select multiple files to run your scripts on.</para>
       <note>
         <para>If you do not have any scripts installed, the script menu will not appear.</para>
       </note>
-      <sect3 id="goscaja-install-scripts">
-      <title>Installing File Manager Scripts</title>
+
+      <section xml:id="goscaja-install-scripts"><info><title>Installing File Manager Scripts</title></info>
         <para>The file manager includes a special folder where you can
 store your scripts. All executable files in this folder will appear in the Scripts menu. The script folder 
 is located at $HOME/.config/caja/scripts.</para>
         <para>To install a script, simply copy the script to the script folder and give it the user executable permission.</para>
       <para>To view the contents of your scripts folder, if you already have scripts installed, choose <menuchoice><guimenu>File</guimenu><guisubmenu>Scripts</guisubmenu><guimenuitem>Open Scripts Folder</guimenuitem></menuchoice>.
 You will have to navigate to the scripts folder with the file manager if you do not yet have any scripts. You may need to show hidden files for this, use <menuchoice><guimenu>View</guimenu><guimenuitem>Show Hidden Files</guimenuitem></menuchoice></para>
-<para>A good source to download <application>Caja</application> scripts is from the <ulink url="http://g-scripts.sourceforge.net"><citetitle>G-Scripts website</citetitle></ulink>.</para>
-    </sect3>
-    <sect3 id="goscaja-write-scripts">
-      <title>Writing File Manager Scripts</title>
+<para>A good source to download <application>Caja</application> scripts is from the <link xlink:href="http://g-scripts.sourceforge.net"><citetitle>G-Scripts website</citetitle></link>.</para>
+    </section>
+
+    <section xml:id="goscaja-write-scripts"><info><title>Writing File Manager Scripts</title></info>
        <para>When executed from a local folder, scripts will be passed the selected file names. When 
 executed from a remote folder (e.g. a folder showing web or ftp content), scripts will be passed no parameters.</para>
        <para>The following table shows variables passed to the script :</para>
@@ -4275,13 +4199,13 @@ executed from a remote folder (e.g. a folder showing web or ftp content), script
             </tbody>
           </tgroup>
         </informaltable>
-    </sect3>
-  </sect2>
-  <sect2 id="caja-extensions">
-    <title>Caja Extensions</title>
+    </section>
+  </section>
+
+  <section xml:id="caja-extensions"><info><title>Caja Extensions</title></info>
     <para><application>Caja</application> extensions are far more powerful than <application>Caja</application> scripts, allowing more freedom where and how they extend <application>Caja</application>. <application>Caja</application> extensions are typically installed by your system administrator.</para>
-<para>Some popular <application>Caja</application> extensions include:
-<orderedlist>
+    <para>Some popular <application>Caja</application> extensions include:
+      <orderedlist>
         <listitem>
           <para>caja-actions</para>
           <para>This extension allows you to easily assign actions based on file type</para>
@@ -4295,10 +4219,10 @@ executed from a remote folder (e.g. a folder showing web or ftp content), script
           <para>This extension provides an easy way to open a terminal at the selected starting location.</para>
         </listitem>
       </orderedlist>
-</para>
-<note>
+    </para>
+    <note>
         <para>If you are looking for the <guilabel>Open Terminal</guilabel> command which used to exist in the <application>Caja</application> right click menu by default then you should install the <application>caja-open-terminal</application> extension.</para>
-      </note>
-  </sect2>
-  </sect1>
+    </note>
+  </section>
+  </section>
 </chapter>

--- a/mate-user-guide/C/goscustdesk.xml
+++ b/mate-user-guide/C/goscustdesk.xml
@@ -1,18 +1,22 @@
-<chapter id="prefs">
-  <title>Configuring Your Desktop</title>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         version="5.0" xml:id="prefs" xml:lang="en">
+    <info><title>Configuring Your Desktop</title></info>
   
   <!-- ids in this section are gradually being converted 
   to something like 'prefs-mouse'.
   remember to add an anchor for the old id in the right place -->
 
   <!-- Maintained for 2.8 compatibility -->
-  <anchor id="goscustdesk-6"/>
+  <anchor xml:id="goscustdesk-6"/>
 
   <!-- Desktop Overview / Desktop Preferences -->
-  <anchor id="gosoverview-55"/>
+  <anchor xml:id="gosoverview-55"/>
   
   <!-- ids of sections removed from this document for 2.14 -->
-  <anchor id="goscustdesk-10"/><!-- Customizing Your Panels -->
+  <anchor xml:id="goscustdesk-10"/><!-- Customizing Your Panels -->
 
   <highlights>
     <para>This chapter describes how to use the preference tools to
@@ -25,14 +29,12 @@ customize the MATE Desktop.</para>
   <para>Some applications or system components may add their own preference tools to the menu.</para>
   <note><para>Some preference tools let you modify essential parts of your system, and therefore require administrative access. When you open the preference tool, a dialog box will prompt you for your password. These are in the <menuchoice><guimenu>System</guimenu><guisubmenu>Administration</guisubmenu></menuchoice> submenu. This menu also contains more complex utility applications for managing and updating your system.</para></note>
 
-
-<sect1 id="prefs-personal">
-  <title>Personal</title>
+<section xml:id="prefs-personal"><info><title>Personal</title></info>
+  
   <!-- Was Login Photo prefs, could go to About Me if that was enabled by default -->
-  <anchor id="goscustdesk-95"/>
+  <anchor xml:id="goscustdesk-95"/>
 
-  <sect2 id="goscustaccess-11">
-    <title>Assistive Technologies Preferences</title>
+  <section xml:id="goscustaccess-11"><info><title>Assistive Technologies Preferences</title></info>
     <indexterm>
       <primary>accessibility</primary>
       <secondary>setting assistive technology
@@ -58,8 +60,7 @@ in the MATE Desktop. You can also use the <application>Assistive Technology</app
     </itemizedlist>
     <para><xref linkend="goscustaccess-TBL-14"/> lists the assistive technology
 preferences that you can modify.</para>
-    <table frame="topbot" id="goscustaccess-TBL-14">
-      <title>Assistive Technology Preferences</title>
+    <table frame="topbot" xml:id="goscustaccess-TBL-14"><info><title>Assistive Technology Preferences</title></info>
       <tgroup cols="2" colsep="0" rowsep="0">
         <colspec colwidth="50*"/>
         <colspec colwidth="50*"/>
@@ -90,20 +91,17 @@ again after enabling this option for it to be fully effective.</para>
         </tbody>
       </tgroup>
     </table>
-  </sect2>
+  </section>
 
-  <sect2 id="prefs-keyboard-shortcuts">
-    <title>Keyboard Shortcuts Preferences</title>
-
+  <section xml:id="prefs-keyboard-shortcuts"><info><title>Keyboard Shortcuts Preferences</title></info>
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="goscustdesk-39"/>
+    <anchor xml:id="goscustdesk-39"/>
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Keyboard Shortcuts</secondary>
     </indexterm>
     <indexterm>
-      <primary>shortcut
-keys</primary>
+      <primary>shortcut keys</primary>
       <secondary>configuring</secondary>
     </indexterm>
     <indexterm>
@@ -153,12 +151,11 @@ keys that provides an alternative to standard ways of performing an action. For 
     <para>
       To remove a custom shortcut, use the <guilabel>Remove</guilabel> button.
     </para>
-  </sect2>  
+  </section>  
 
-  <sect2 id="prefs-preferredapps">
-    <title>Preferred Applications</title>
+  <section xml:id="prefs-preferredapps"><info><title>Preferred Applications</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscustdoc-2"/>       
+    <anchor xml:id="goscustdoc-2"/>       
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Preferred Applications</secondary>
@@ -204,16 +201,14 @@ email clients or document viewers.</para>
     <para>For each preferred application category, a drop-down menu contains a list of possible applications you can choose from. The list depends on the applications installed on your computer.</para>
     <para>In each category, the last item in the menu (<guimenuitem>Custom</guimenuitem>) permits you to customize the command used by the system when the specific launch action occurs.</para>
     
-    <sect3 id="goscustlookandfeel-32">
-      <title>Custom Command Options</title>
+    <section xml:id="goscustlookandfeel-32"><info><title>Custom Command Options</title></info>
       <indexterm>
         <primary>preferred applications</primary>
         <secondary>custom command</secondary>
       </indexterm>
       <para>The following table summarizes the various options you can choose from when you select
 <guimenuitem>Custom</guimenuitem> in the drop-down application menu.</para>
-      <table frame="topbot" id="goscustlookandfeel-TBL-37">
-        <title>Custom command options</title>
+      <table frame="topbot" xml:id="goscustlookandfeel-TBL-37"><info><title>Custom command options</title></info>
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="colspec0" colwidth="18.86*"/>
           <colspec colname="colspec1" colwidth="47.14*"/>
@@ -277,16 +272,13 @@ commands to run (<option>-x</option> for <application>mate-terminal</application
           </tbody>
         </tgroup>
       </table>
-    </sect3>
-  </sect2>
+    </section>
+  </section>
+</section>
 
-</sect1>
+<section xml:id="prefs-look-and-feel"><info><title>Look and Feel</title></info>
 
-<sect1 id="prefs-look-and-feel">
-	<title>Look and Feel</title>
-
-  <sect2 id="prefs-appearance">
-    <title>Appearance Preferences</title>
+  <section xml:id="prefs-appearance"><info><title>Appearance Preferences</title></info>
     <para>The <application>Appearance</application> preference tool lets
     you configure various aspects of how your desktop looks:</para>
     <itemizedlist>
@@ -302,12 +294,12 @@ commands to run (<option>-x</option> for <application>mate-terminal</application
       <listitem>
         <para>User Interface.</para>
       </listitem>
-     </itemizedlist> 
-  <sect3 id="prefs-theme">
-    <title>Theme Preferences</title>
-    <anchor id="goscustdesk-12"/>
-    <anchor id="goscustdesk-54"/>
-    <anchor id="goscustdesk-82"/>
+     </itemizedlist>
+
+  <section xml:id="prefs-theme"><info><title>Theme Preferences</title></info>
+    <anchor xml:id="goscustdesk-12"/>
+    <anchor xml:id="goscustdesk-54"/>
+    <anchor xml:id="goscustdesk-82"/>
   
     <indexterm>
       <primary>themes</primary>
@@ -315,8 +307,7 @@ commands to run (<option>-x</option> for <application>mate-terminal</application
     </indexterm>
     <indexterm>
       <primary>themes</primary>
-      <secondary>setting window
-frame options</secondary>
+      <secondary>setting window frame options</secondary>
     </indexterm>
     <indexterm>
       <primary>themes</primary>
@@ -336,8 +327,7 @@ the visual appearance of a part of the MATE Desktop. You can choose themes
 to change the appearance of the MATE Desktop. Use the <application>Theme</application> tabbed section to select a theme. You can choose from a list
 of available themes. The list of available themes includes several themes
 for users with accessibility requirements. </para>
-    <para>A theme contains settings that affect different parts of the MATE Desktop,
-as follows:</para>
+    <para>A theme contains settings that affect different parts of the MATE Desktop, as follows:</para>
     <variablelist>
       <varlistentry>
         <term>Controls</term>
@@ -385,8 +375,8 @@ and size of the mouse pointer. You can choose the options for setting the pointe
         </listitem>
       </varlistentry>
     </variablelist>
-    <sect4 id="goscustdesk-61">
-      <title>To Create a Custom Theme</title>
+    <section xml:id="goscustdesk-61"><info><title>To Create a Custom Theme</title></info>
+      
       <para>The themes that are listed in the <guilabel>Theme</guilabel>
 tabbed section are different combinations of controls options, window frame options,
 and icon options. You can create a custom theme that uses different combinations
@@ -435,9 +425,9 @@ the dialog, then click <guibutton>Save</guibutton>. The custom theme now appears
 in your list of available themes.</para>
         </listitem>
       </orderedlist>
-    </sect4>
-    <sect4 id="goscustdesk-62">
-      <title>To Install a New Theme</title>
+    </section>
+
+    <section xml:id="goscustdesk-62"><info><title>To Install a New Theme</title></info>
       <para>You can add a theme to the list of available themes. The new theme must
 be an archive file that is tarred and zipped. That is, the new theme must
 be a <filename>.tar.gz</filename> file.</para>
@@ -460,7 +450,7 @@ entry. Alternatively, select the theme archive file in the file list. When you h
 the new theme. </para>
         </listitem>
       </orderedlist>
-    </sect4>
+    </section>
 
 <!--How does this work nowadays ?
     <sect4 id="goscustdesk-80">
@@ -498,8 +488,8 @@ the new option. </para>
       </orderedlist>
     </sect4>
 -->
-    <sect4 id="goscustdesk-81">
-      <title>To Delete a Theme Option</title>
+
+    <section xml:id="goscustdesk-81"><info><title>To Delete a Theme Option</title></info>
       <para>You can delete controls options, window frame options, or icons options.</para>
       <para>To delete a controls option, window frame option, or icons option, perform
 the following steps:</para>
@@ -524,13 +514,12 @@ A <guilabel>Customize Theme</guilabel> dialog is displayed.</para>
           options.</para>
         </listitem>
       </orderedlist>
-    </sect4>
-  </sect3>
+    </section>
+  </section>
 
-  <sect3 id="prefs-desktopbackground">
-    <title>Desktop Background Preferences</title>
+  <section xml:id="prefs-desktopbackground"><info><title>Desktop Background Preferences</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscustdesk-7"/>       
+    <anchor xml:id="goscustdesk-7"/>       
     <indexterm>
       <primary>desktop</primary>
       <secondary>customizing background</secondary>
@@ -567,8 +556,7 @@ is a visual effect where one color blends gradually into another color. </para>
 and Emblems</guilabel> dialog</link> in the <application>Caja</application> file manager.</para></tip>
     <para><xref linkend="goscustdesk-TBL-14"/> lists the background preferences
 that you can modify.</para>
-    <table frame="topbot" id="goscustdesk-TBL-14">
-      <title>Desktop Background Preferences</title>
+    <table frame="topbot" xml:id="goscustdesk-TBL-14"><info><title>Desktop Background Preferences</title></info>
       <tgroup cols="2" colsep="1" rowsep="1">
         <colspec colname="colspec0" colwidth="18.86*"/>
         <colspec colname="colspec1" colwidth="47.14*"/>
@@ -648,8 +636,7 @@ the image you want and click <guibutton>Open</guibutton>.</para>
             </entry>
             <entry colname="colspec1" colsep="0" rowsep="0">
               <para>Choose the image that you want to remove,
-then click <guilabel>Remove</guilabel>.  This removes the image from the list of available wallpapers; however, it does not delete the image from your computer.
-</para>
+then click <guilabel>Remove</guilabel>.  This removes the image from the list of available wallpapers; however, it does not delete the image from your computer.</para>
             </entry>
           </row>
           <row>
@@ -693,14 +680,13 @@ color that you want to appear at the bottom edge.</para>
         </tbody>
       </tgroup>
     </table>
-  </sect3>
+  </section>
 
-  <sect3 id="prefs-font">
-    <title>Font Preferences</title>
+  <section xml:id="prefs-font"><info><title>Font Preferences</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscustdesk-38"/>
-    <anchor id="goscustdesk-83"/>
-    <anchor id="goscustdesk-94"/>
+    <anchor xml:id="goscustdesk-38"/>
+    <anchor xml:id="goscustdesk-83"/>
+    <anchor xml:id="goscustdesk-94"/>
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Font</secondary>
@@ -728,8 +714,7 @@ color that you want to appear at the bottom edge.</para>
     <para>Use the <guilabel>Fonts</guilabel> tabbed section in the <application>Appearance</application> preference tool
 to choose which fonts are used in different parts of the desktop, and the way in which fonts are displayed on the screen.</para>
 
-    <sect4 id="prefs-font-choose">
-      <title>Choosing Fonts</title>
+    <section xml:id="prefs-font-choose"><info><title>Choosing Fonts</title></info>
       <para>The font selector button shows the name of the font and its point size. The name is also shown in bold, italic, or regular type.</para>
       <para>To change the font, click the font selector button. The font picker dialog opens. Select the font family, style, and point size from the lists. The preview area shows your current choice. Click <guibutton>OK</guibutton> to accept the change and update the desktop.</para>
       <para>You can choose fonts for the following parts of the desktop:</para>
@@ -767,10 +752,9 @@ to choose which fonts are used in different parts of the desktop, and the way in
       	  </listitem>
       	</varlistentry>
       	</variablelist>
-  	</sect4>
+  	</section>
 	
-  	<sect4 id="prefs-font-rendering">
-      <title>Font Rendering</title>
+  	<section xml:id="prefs-font-rendering"><info><title>Font Rendering</title></info>
       <para>You can set the following options relating to how fonts are displayed on the screen:</para>
 	
     	<variablelist>
@@ -835,7 +819,8 @@ to choose which fonts are used in different parts of the desktop, and the way in
     	</varlistentry>
     </variablelist>
    
-    </sect4>
+    </section>
+
 <!-- go to fonts folder no longer exists
     <sect4 id="goscustdesk-83">
       <title>Previewing a Font</title>
@@ -880,12 +865,11 @@ you want to add.</para>
       <tip><para>You can also open the <guilabel>Fonts</guilabel> folder by typing the following URI into <application>Caja</application> file manager's <link linkend="caja-open-location">Open Location dialog</link>: <command>fonts:///</command>.</para></tip>
     </sect4>
 -->
-  </sect3>
+  </section>
 
-  <sect3 id="prefs-menustoolbars">
-    <title>Interface Preferences</title>
+  <section xml:id="prefs-menustoolbars"><info><title>Interface Preferences</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscustuserinter-2"/>    
+    <anchor xml:id="goscustuserinter-2"/>    
     <indexterm>
       <primary>toolbars, customizing appearance</primary>
     </indexterm>
@@ -895,8 +879,7 @@ you want to add.</para>
     </indexterm>
     <indexterm>
       <primary>menus</primary>
-      <secondary>in applications,
-customizing appearance</secondary>
+      <secondary>in applications, customizing appearance</secondary>
     </indexterm>
     <para>You can use the <guilabel>Interface</guilabel> tabbed section in the <application>Appearance</application> preference tool to customize the appearance
 of menus, menubars, and toolbars for applications that are part of MATE.</para>
@@ -947,14 +930,12 @@ of menus, menubars, and toolbars for applications that are part of MATE.</para>
     	  </listitem>
     	</varlistentry>
     </variablelist>
-  </sect3>
-  </sect2>
+  </section>
+  </section>
 
-  <sect2 id="prefs-windows">
-    <title>Windows Preferences</title>
-
+  <section xml:id="prefs-windows"><info><title>Windows Preferences</title></info>
     <!-- preserve for backwards compatibility: 2.12 -->
-    <anchor id="goscustdesk-58"/>    
+    <anchor xml:id="goscustdesk-58"/>    
 
     <indexterm>
       <primary>window manager</primary>
@@ -968,8 +949,7 @@ of menus, menubars, and toolbars for applications that are part of MATE.</para>
 preference tool to customize window behavior for the MATE Desktop.</para>
     <para><xref linkend="goscustwindows-TBL-14"/> lists the windows preferences
 that you can modify.</para>
-    <table frame="topbot" id="goscustwindows-TBL-14">
-      <title>Windows Preferences</title>
+    <table frame="topbot" xml:id="goscustwindows-TBL-14"><info><title>Windows Preferences</title></info>
       <tgroup cols="2" colsep="1" rowsep="1">
         <colspec colname="colspec0" colwidth="18.86*"/>
         <colspec colname="colspec1" colwidth="47.14*"/>
@@ -1071,10 +1051,9 @@ the key to press-and-hold when you drag a window to move the window.</para>
       Keyboard Layout Options dialog, see <xref linkend="prefs-keyboard-layoutoptions"/>. 
       </para>
     </note>
-  </sect2>
+  </section>
 
-  <sect2 id="prefs-screensaver">
-    <title>Screensaver Preferences</title>
+  <section xml:id="prefs-screensaver"><info><title>Screensaver Preferences</title></info>
     <indexterm>
       <primary>preference tools</primary>
       <secondary>screensaver</secondary>
@@ -1105,26 +1084,17 @@ the key to press-and-hold when you drag a window to move the window.</para>
     	  <listitem><para>When this option is selected, the screensaver will prompt you for your password when you try to return to the desktop. For more on locking your screen, see <xref linkend="lock-screen"/>.</para></listitem>  	
     	</varlistentry>
   </variablelist>
-  </sect2>
+  </section>
+</section>
 
-</sect1>
+<section xml:id="prefs-internet-and-network"><info><title>Internet and Network</title></info>
 
-<sect1 id="prefs-internet-and-network">
-	<title>Internet and Network</title>
-
-  <sect2 id="prefs-network-admin">
- 	<title>Network Settings</title>
-
+  <section xml:id="prefs-network-admin"><info><title>Network Settings</title></info>
     <para>The <application>Network Settings</application> allows you to specify the way your system connects to other computers and to internet.</para>
     <para>You will be prompted for the administrator password when you start <application>Network Settings</application>. This is because the changes done with this tool will affect the whole system.</para>
 
-  <sect3 id="prefs-network-admin-getting-started">
-    <title>Getting started</title>
-
-
-
+  <section xml:id="prefs-network-admin-getting-started"><info><title>Getting started</title></info>
     <para>The <application>Network Settings</application> main window contains four tabbed sections:</para>
-
     <variablelist>
 	 <varlistentry>
 	   <term><guilabel>Connections</guilabel></term>
@@ -1147,20 +1117,18 @@ the key to press-and-hold when you drag a window to move the window.</para>
 	   </listitem>
 	 </varlistentry>
 
-      <varlistentry>
+	 <varlistentry>
 	   <term><guilabel>Hosts</guilabel></term>
 	   <listitem>
 		<para>Shows the list of aliases for accessing other computers.</para>
 	   </listitem>
 	 </varlistentry>
     </variablelist>
-  </sect3>
+  </section>
 
-  <sect3 id="prefs-network-admin-usage">
-    <title>Usage</title>
+  <section xml:id="prefs-network-admin-usage"><info><title>Usage</title></info>
 
-    <sect4 id="tool-modify-connection">
-	 <title>To modify a connection settings</title>
+    <section xml:id="tool-modify-connection"><info><title>To modify a connection settings</title></info>
 	 <para>In the <guilabel>Connections</guilabel> section, select the interface you want to modify and press the <guilabel>Properties</guilabel> button, depending on the interface type you will be able to modify different data.</para>
 
 	 <variablelist>
@@ -1192,78 +1160,64 @@ the key to press-and-hold when you drag a window to move the window.</para>
 		</listitem>
 	   </varlistentry>
 	 </variablelist>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To activate or deactivate an interface</title>
+    <section><info><title>To activate or deactivate an interface</title></info>
 	 <para>In the <guilabel>Connections</guilabel> section, enable or disable the checkbox beside the interface.</para>
-    </sect4>
+    </section>
     
-    <sect4>
-	 <title>To change your host name and domain name</title>
+    <section><info><title>To change your host name and domain name</title></info>
 	 <para>In the <guilabel>General</guilabel> section, change the hostname or domain name text boxes.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To add a new domain name server</title>
+    <section><info><title>To add a new domain name server</title></info>
 	 <para>In the <guilabel>DNS Servers</guilabel> section, press the <guilabel>Add</guilabel> button and fill in the new list row with the new domain name server.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To delete a domain name server</title>
+    <section><info><title>To delete a domain name server</title></info>
 	 <para>In the <guilabel>DNS Servers</guilabel> section, select a DNS IP address from the list and press the <guilabel>Delete</guilabel> button.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To add a new search domain</title>
+    <section><info><title>To add a new search domain</title></info>
 	 <para>In the <guilabel>Search Domains</guilabel> section, press the <guilabel>Add</guilabel> button and fill in the new list row with the new search domain.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To delete a search domain</title>
+    <section><info><title>To delete a search domain</title></info>
 	 <para>In the <guilabel>Search Domains</guilabel> section, select a search domain from the list and press the <guilabel>Delete</guilabel> button.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To add a new host alias</title>
+    <section><info><title>To add a new host alias</title></info>
 	 <para>In the <guilabel>Hosts</guilabel> section, press the <guilabel>Add</guilabel> button and type an IP address and the aliases that will point to in the window that pops up.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To modify a host alias</title>
+    <section><info><title>To modify a host alias</title></info>
 	 <para>In the <guilabel>Hosts</guilabel> section, select an alias, press the <guilabel>Properties</guilabel> button from the list and modify the alias settings in the window that pops up.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To delete a host alias</title>
+    <section><info><title>To delete a host alias</title></info>
 	 <para>In the <guilabel>Hosts</guilabel> section, select an alias from the list and press the <guilabel>Delete</guilabel> button.</para>
-    </sect4>
+    </section>
 
-    <sect4 id="prefs-network-admin-add-new-profile">
-	 <title>To save your current network configuration as a "Location"</title>
+    <section xml:id="prefs-network-admin-add-new-profile"><info><title>To save your current network configuration as a "Location"</title></info>
 	 <para>Press the <guilabel>Add</guilabel> button besides the <guilabel>Locations</guilabel> menu, specify the location name in the window that pops up.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To delete a location</title>
+    <section><info><title>To delete a location</title></info>
 	 <para>Press the <guilabel>Remove</guilabel> button besides the <guilabel>Locations</guilabel> menu, the selected profile will be deleted.</para>
-    </sect4>
+    </section>
 
-    <sect4>
-	 <title>To switch to a location</title>
+    <section><info><title>To switch to a location</title></info>
 	 <para>Select one location from the <guilabel>Locations</guilabel> menu, all the configuration will be switched automatically to the chosen location.</para>
-    </sect4>
+    </section>
 
-	</sect3>
-  </sect2>
+  </section>
+  </section>
 
-  <sect2 id="prefs-networkproxy">
-    <title>Network Proxy Preferences</title>
+  <section xml:id="prefs-networkproxy"><info><title>Network Proxy Preferences</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscustdesk-50"/>       
+    <anchor xml:id="goscustdesk-50"/>       
     <indexterm>
-      <primary>preference
-tools</primary>
+      <primary>preference tools</primary>
       <secondary>Network Proxy</secondary>
     </indexterm>
     <indexterm>
@@ -1349,13 +1303,11 @@ tools</primary>
     </variablelist>
     
     <para>Set which hosts should not use the proxy in the <guilabel>Ignore Host List</guilabel> in the <guilabel>Ignored Hosts</guilabel> tabbed section. When you access these hosts, you will connect to the Internet directly without a proxy.</para>
-    
-  </sect2>
+  </section>
 
-  <sect2 id="prefs-remotedesktop">
-    <title>Remote Desktop Preferences</title>
+  <section xml:id="prefs-remotedesktop"><info><title>Remote Desktop Preferences</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscustdesk-90"/>
+    <anchor xml:id="goscustdesk-90"/>
     <indexterm>
       <primary>setting session sharing preferences</primary>
     </indexterm>           
@@ -1364,8 +1316,7 @@ between multiple users, and to set session-sharing preferences.</para>
     <para><xref linkend="goscustdesk-TBL-91"/> lists the session-sharing preferences
 that you can set. These preferences have a direct impact on the security of
 your system.</para>
-    <table frame="topbot" id="goscustdesk-TBL-91">
-      <title>Session Sharing Preferences</title>
+    <table frame="topbot" xml:id="goscustdesk-TBL-91"><info><title>Session Sharing Preferences</title></info>
       <tgroup cols="2" colsep="1" rowsep="1">
         <colspec colname="colspec18" colwidth="19.21*"/>
         <colspec colname="colspec19" colwidth="46.79*"/>
@@ -1383,8 +1334,7 @@ your system.</para>
           <row>
             <entry colsep="0" rowsep="0" valign="top">
               <para>
-                <guilabel>Allow other
-users to view your desktop</guilabel>
+                <guilabel>Allow other users to view your desktop</guilabel>
               </para>
             </entry>
             <entry colsep="0" rowsep="0" valign="top">
@@ -1396,8 +1346,7 @@ are ignored.</para>
           <row>
             <entry colsep="0" rowsep="0" valign="top">
               <para>
-                <guilabel>Allow other
-users to control your desktop</guilabel>
+                <guilabel>Allow other users to control your desktop</guilabel>
               </para>
             </entry>
             <entry colsep="0" rowsep="0" valign="top">
@@ -1452,26 +1401,21 @@ must enter.</para>
         </tbody>
       </tgroup>
     </table>
-  </sect2>  
+  </section>  
+</section>
 
-</sect1>
-
-
-<sect1 id="prefs-hardware">
-	<title>Hardware</title>
-
-  <sect2 id="prefs-keyboard">
-    <title>Keyboard Preferences</title>
+<section xml:id="prefs-hardware"><info><title>Hardware</title></info>
+	
+  <section xml:id="prefs-keyboard"><info><title>Keyboard Preferences</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goscustperiph-2"/>       
+    <anchor xml:id="goscustperiph-2"/>       
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Keyboard</secondary>
     </indexterm>
     <indexterm>
       <primary>keyboard</primary>
-      <secondary>configuring
-general preferences</secondary>
+      <secondary>configuring general preferences</secondary>
     </indexterm>
     <para>Use the <application>Keyboard</application> preference tool to modify the autorepeat preferences for
 your keyboard, and to configure typing break settings. </para>
@@ -1504,14 +1448,14 @@ preference tool in the following functional areas:</para>
     </itemizedlist>
     -->
     <para>To open the <link linkend="prefs-keyboard-a11y"><application>Keyboard <emphasis>Accessibility</emphasis></application> preference tool</link>, click the <guibutton>Accessibility</guibutton> button.</para>    
-    <sect3 id="goscustdesk-40">
-      <title>Keyboard Preferences</title>
+    <section xml:id="goscustdesk-40"><info><title>Keyboard Preferences</title></info>
+      
       <para>Use the <guilabel>General</guilabel> tabbed section to set general
 keyboard preferences.</para>
       <para><xref linkend="goscustperiph-TBL-3"/> lists the keyboard preferences
 that you can modify.</para>
-      <table frame="topbot" id="goscustperiph-TBL-3">
-        <title>Keyboard Preferences</title>
+      <table frame="topbot" xml:id="goscustperiph-TBL-3"><info><title>Keyboard Preferences</title></info>
+        
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="colspec18" colwidth="19.21*"/>
           <colspec colname="colspec19" colwidth="46.79*"/>
@@ -1529,8 +1473,7 @@ that you can modify.</para>
             <row>
               <entry colsep="0" rowsep="0" valign="top">
                 <para>
-                  <guilabel>Key presses
-repeat when key is held down</guilabel>
+                  <guilabel>Key presses repeat when key is held down</guilabel>
                 </para>
               </entry>
               <entry colsep="0" rowsep="0" valign="top">
@@ -1586,8 +1529,7 @@ blinks in fields and text boxes.</para>
             <row>
               <entry colname="colspec18" colsep="0" rowsep="0">
                 <para>
-                  <guilabel>Type
-to test settings</guilabel>
+                  <guilabel>Type to test settings</guilabel>
                 </para>
               </entry>
               <entry colname="colspec19" colsep="0" rowsep="0">
@@ -1599,11 +1541,11 @@ test area to test the effect of your settings.</para>
           </tbody>
         </tgroup>
       </table>
-    </sect3>
-    <sect3 id="prefs-keyboard-layouts">
-      <title>Keyboard Layouts Preferences</title>
+    </section>
+
+    <section xml:id="prefs-keyboard-layouts"><info><title>Keyboard Layouts Preferences</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscustdesk-100"/>         
+      <anchor xml:id="goscustdesk-100"/>         
       <para>Use the <guilabel>Layouts</guilabel> tabbed section to set your keyboard's language, and also the make and model of keyboard you are using.</para>
       <para>This will allow MATE to make use of special media keys on your keyboard, and to show the correct characters for your keyboard's language.</para>
       
@@ -1630,12 +1572,11 @@ test area to test the effect of your settings.</para>
       <para>Click <guibutton>Reset to Defaults</guibutton> to restore all keyboard layout settings to their initial state for your system and locale.</para>
 
       <para>Click the <guibutton>Layout Options</guibutton> button to open the <guilabel>Keyboard Layout Options</guilabel> dialog.</para>
-   </sect3>
+   </section>
     
-    <sect3 id="prefs-keyboard-layoutoptions"> 
-      <title>Keyboard Layout Options</title>
+    <section xml:id="prefs-keyboard-layoutoptions"><info><title>Keyboard Layout Options</title></info> 
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="goscustdesk-101"/>
+      <anchor xml:id="goscustdesk-101"/>
       <para>The <guilabel>Keyboard Layout Options</guilabel> dialog has options for the behavior of keyboard modifier keys and certain shortcut options.</para>
       <para>Expand each group label to show the available options. A label in boldface indicates that the options in the group have been changed from the default setting.</para>
       <note><para>The options shown in this dialog depend on the X windowing system you are using. Not all the following options might be listed on your system, and not all the options shown might work on your system.</para></note>
@@ -1679,7 +1620,6 @@ test area to test the effect of your settings.</para>
                 <term><guilabel>Group Shift/Lock behavior</guilabel></term>
                 <listitem><para>
                   Select keys or key combinations to switch your keyboard layout when pressed.
- 
                 </para></listitem>
         </varlistentry>
         <varlistentry>
@@ -1716,20 +1656,16 @@ test area to test the effect of your settings.</para>
                 </listitem>
         </varlistentry>
       </variablelist>
-    </sect3>
+    </section>
 
-    <sect3 id="prefs-keyboard-a11y">
-
-      <title>Keyboard Accessibility Preferences</title>
-
+    <section xml:id="prefs-keyboard-a11y"><info><title>Keyboard Accessibility Preferences</title></info>
     <indexterm>
       <primary>AccessX</primary>
       <see>preference tools, Keyboard Accessibility</see>
     </indexterm>
     <indexterm>
       <primary>keyboard</primary>
-      <secondary>configuring
-accessibility options</secondary>
+      <secondary>configuring accessibility options</secondary>
     </indexterm>
     <indexterm>
       <primary>accessibility</primary>
@@ -1740,19 +1676,17 @@ accessibility options</secondary>
       <secondary>Keyboard Accessibility</secondary>
     </indexterm>
 
-
     <!-- Maintained for 2.8 compatibility -->
-      <anchor id="goscustaccess-6"/>
-      <anchor id="goscustaccess-8"/>
-      <anchor id="goscustaccess-9"/>
+      <anchor xml:id="goscustaccess-6"/>
+      <anchor xml:id="goscustaccess-8"/>
+      <anchor xml:id="goscustaccess-9"/>
       <para>The <guilabel>Accessibility</guilabel> tabbed section allows you to set  options such as filtering out accidental keypresses and using shortcut keys without having to hold down several keys at once. These features are also known as AccessX.</para>
 
        <para>This section describes each of the preferences you can set. For a more task-oriented description of keyboard accessibility, see the <citetitle>MATE Desktop Accessibility Guide</citetitle>.</para>
 
       <para><xref linkend="goscustdesk-TBL-85"/> lists the accessibility preferences
  that you can modify.</para>
-     <table frame="topbot" id="goscustdesk-TBL-85">
-        <title>Accessibility Preferences</title>
+     <table frame="topbot" xml:id="goscustdesk-TBL-85"><info><title>Accessibility Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colwidth="50*"/>
           <colspec colwidth="50*"/>
@@ -1862,7 +1796,7 @@ keypress before the automatic repeat of a pressed key.</para>
                 </entry>
              </row>
             <row>
-              <entry  valign="top">
+              <entry valign="top">
                 <para>
                   <guilabel>Type to test settings</guilabel>
                 </para>
@@ -1880,15 +1814,13 @@ of your settings.</para>
       <para>To configure audio feedback for keyboard accessibility features,
       click the <guibutton>Audio Feedback</guibutton> button. It opens the
       <guilabel>Keyboard Accessibility Audio Feedback</guilabel> window.</para>
-    </sect3>
+    </section>
 
-   <sect3>
-      <title>Keyboard Accessibility Audio Feedback</title>
+   <section><info><title>Keyboard Accessibility Audio Feedback</title></info>
       <para>Configure audio feedback for keyboard accessibility features.</para>
       <para><xref linkend="goscustdesk-TBL-86"/> lists the audio feedback preferences
       that you can modify.</para>
-      <table frame="topbot" id="goscustdesk-TBL-86">
-        <title>Audio Feedback Preferences</title>
+      <table frame="topbot" xml:id="goscustdesk-TBL-86"><info><title>Audio Feedback Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colwidth="50*"/>
           <colspec colwidth="50*"/>
@@ -1977,17 +1909,15 @@ of your settings.</para>
           </tbody>
         </tgroup>
       </table>
-   </sect3>
+   </section>
  
-   <sect3>
-     <title>Mouse Keys Preferences</title>
-     <anchor id="goscustaccess-10"/>
+   <section><info><title>Mouse Keys Preferences</title></info>
+     <anchor xml:id="goscustaccess-10"/>
      <para>The options in the <guilabel>Mouse Keys</guilabel> tabbed section
      let you configure the keyboard as a substitute for the mouse.</para>
       <para><xref linkend="goscustdesk-TBL-88"/> lists the mouse keys preferences
  that you can modify.</para>
-      <table frame="topbot" id="goscustdesk-TBL-88">
-        <title>Typing Break Preferences</title>
+      <table frame="topbot" xml:id="goscustdesk-TBL-88"><info><title>Typing Break Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colwidth="50*"/>
           <colspec colwidth="50*"/>
@@ -2052,15 +1982,13 @@ after a keypress before the pointer moves.</para>
           </tbody>
         </tgroup>
       </table>
-  </sect3>
+  </section>
 
-    <sect3 id="goscustdesk-86">
-      <title>Typing Break Preferences</title>
+    <section xml:id="goscustdesk-86"><info><title>Typing Break Preferences</title></info>
+      
       <para>Configure the Typing Break Preferences to make MATE remind you to rest after you have been using the keyboard and mouse for a long time. During a Typing Break, the screen will be locked.</para>
-      <para><xref linkend="goscustdesk-TBL-87"/> lists the typing break preferences
- that you can modify.</para>
-      <table frame="topbot" id="goscustdesk-TBL-87">
-        <title>Typing Break Preferences</title>
+      <para><xref linkend="goscustdesk-TBL-87"/> lists the typing break preferences that you can modify.</para>
+      <table frame="topbot" xml:id="goscustdesk-TBL-87"><info><title>Typing Break Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colwidth="50*"/>
           <colspec colwidth="50*"/>
@@ -2082,8 +2010,7 @@ after a keypress before the pointer moves.</para>
                 </para>
               </entry>
               <entry valign="top">
-                <para>Select this option to
-lock the screen when you are due a typing break.</para>
+                <para>Select this option to lock the screen when you are due a typing break.</para>
               </entry>
             </row>
             <row>
@@ -2125,15 +2052,12 @@ typing breaks.</para>
       <note><para>
         If you stop using the keyboard and mouse for a length of time equal to the <guilabel>Break interval</guilabel> setting, the current work interval will be reset.
       </para></note>
-    </sect3>    
-    
-    
-  </sect2>
+    </section>    
+  </section>
 
-  <sect2 id="prefs-mouse">
-    <title>Mouse Preferences</title>
+  <section xml:id="prefs-mouse"><info><title>Mouse Preferences</title></info>
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="goscustperiph-5"/>
+    <anchor xml:id="goscustperiph-5"/>
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Mouse</secondary>
@@ -2157,9 +2081,7 @@ typing breaks.</para>
       </listitem>
     </itemizedlist>
     
-    
-    <sect3 id="goscustdesk-55">
-      <title>General Mouse Preferences</title>
+    <section xml:id="goscustdesk-55"><info><title>General Mouse Preferences</title></info>
       <para>Use the <guilabel>General</guilabel> tabbed section to specify whether
       the mouse buttons are configured for left-hand or right-hand use and configure
       the speed and sensitivity of your mouse.</para>
@@ -2167,8 +2089,7 @@ typing breaks.</para>
 that you can modify.</para>
 
     <!-- convert to variablelist -->
-    <table frame="topbot" id="goscustperiph-TBL-6">
-        <title>Mouse Button Preferences</title>
+    <table frame="topbot" xml:id="goscustperiph-TBL-6"><info><title>Mouse Button Preferences</title></info>
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="colspec18" colwidth="19.21*"/>
           <colspec colname="colspec19" colwidth="46.79*"/>
@@ -2228,18 +2149,18 @@ you to locate the mouse pointer.</para>
                   <guilabel>Acceleration</guilabel>
                 </para>
               </entry>
-              <entry colsep="0" rowsep="0"  valign="top">
+              <entry colsep="0" rowsep="0" valign="top">
                 <para>Use the slider to specify the speed at which your
 mouse pointer moves on your screen when you move your mouse.</para>
               </entry>
             </row>
             <row>
-              <entry colsep="0" rowsep="0"  valign="top">
+              <entry colsep="0" rowsep="0" valign="top">
                 <para>
                   <guilabel>Sensitivity</guilabel>
                 </para>
               </entry>
-              <entry  colsep="0" rowsep="0" valign="top">
+              <entry colsep="0" rowsep="0" valign="top">
                 <para>Use the slider to specify how sensitive your mouse
 pointer is to movements of your mouse.</para>
               </entry>
@@ -2267,17 +2188,15 @@ action.</para>
 the amount of time that can pass between clicks when you double-click. If
 the interval between the first and second clicks exceeds the time that is
 specified here, the action is not interpreted as a double-click. </para>
-
                 <para>Use the light bulb icon to check double-click sensitivity: the light will light up briefly for a click, but stay lit for a double-click.</para>
               </entry>
             </row>
           </tbody>
         </tgroup>
       </table>
-    </sect3>
+    </section>
 
-    <sect3 id="goscustdesk-53">
-      <title>Mouse Accessibility Preferences</title>
+    <section xml:id="goscustdesk-53"><info><title>Mouse Accessibility Preferences</title></info>
       <para>Use the <guilabel>Accessibility</guilabel> tabbed section to configure
       accessibility features that can help people who have difficulty with exact positioning of the pointer or with pressing the mouse buttons:</para>
       <itemizedlist>
@@ -2328,8 +2247,7 @@ specified here, the action is not interpreted as a double-click. </para>
       </itemizedlist>
       <para><xref linkend="goscustdesk-TBL-47"/> lists the mouse accessibility preferences
 that you can modify:</para>
-      <table frame="topbot" id="goscustdesk-TBL-47">
-        <title>Mouse Motion Preferences</title>
+      <table frame="topbot" xml:id="goscustdesk-TBL-47"><info><title>Mouse Motion Preferences</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colwidth="30.10*"/>
           <colspec colwidth="69.90*"/>
@@ -2426,7 +2344,6 @@ that you can modify:</para>
               </entry>
               <entry rowsep="0" colsep="0" valign="top">
                 <para>Select this option to pick the type of click by moving the mouse in a certain direction. The four combo boxes below this option allow to assign directions to the different types of click. Note that each direction can be used only for one type of click.</para> 
-              
               </entry>
             </row>
             <row>
@@ -2480,11 +2397,10 @@ that you can modify:</para>
           </tbody>
         </tgroup>
       </table>
-    </sect3>
-  </sect2>
+    </section>
+  </section>
 
-  <sect2 id="goscustdesk-70">
-    <title>Monitors</title>
+  <section xml:id="goscustdesk-70"><info><title>Monitors</title></info>
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Display</secondary>
@@ -2562,10 +2478,10 @@ section label.</para>
     This option may not be supported on all graphics cards.</para></listitem>
   </varlistentry>
 </variablelist>
-</sect2>
+</section>
 
-  <sect2 id="goscustmulti-2">
-    <title>Sound Preferences</title>
+  <section xml:id="goscustmulti-2"><info><title>Sound Preferences</title></info>
+    
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Sound</secondary>
@@ -2576,12 +2492,10 @@ section label.</para>
     </indexterm>
     <indexterm>
       <primary>sound</primary>
-      <secondary>associating
-events with sounds</secondary>
+      <secondary>associating events with sounds</secondary>
     </indexterm>
     <indexterm>
-      <primary>events, associating
-sounds with</primary>
+      <primary>events, associating sounds with</primary>
     </indexterm>
     <indexterm>
       <primary>volume</primary>
@@ -2609,13 +2523,11 @@ preference tool in the following functional areas:</para>
       </listitem>
     </itemizedlist>
     <para>You can change the overall output volume using the <guilabel>Output volume</guilabel> slider at the top of the window. The <guilabel>Mute</guilabel> checkbox allows to temporarily suppress all output without disturbing the current volume.</para>
-    <sect3 id="goscustdesk-48">
-      <title>Sound Effects Preferences</title>
+
+    <section xml:id="goscustdesk-48"><info><title>Sound Effects Preferences</title></info>
       <para>A sound theme is collection of sound effects that are associated to various events, such as opening a dialog, clicking a button or selecting an item in a menu. One of the most prominent event sounds is the <emphasis>System Bell</emphasis> sound that often played to indicate a keyboard input error. Use the <guilabel>Sound Effects</guilabel> tabbed section of the <application>Sound</application> preference tool to choose a sound theme and modify the bell sound.</para>
-      <para><xref linkend="goscustmulti-TBL-6"/> lists the sound effects preferences
-that you can modify.</para>
-      <table frame="topbot" id="goscustmulti-TBL-6">
-        <title>Sound Effects Preferences</title>
+      <para><xref linkend="goscustmulti-TBL-6"/> lists the sound effects preferences that you can modify.</para>
+      <table frame="topbot" xml:id="goscustmulti-TBL-6"><info><title>Sound Effects Preferences</title></info>
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="colspec18" colwidth="19.21*"/>
           <colspec colname="colspec19" colwidth="46.79*"/>
@@ -2658,8 +2570,7 @@ control the volume for event sounds.</para>
                 <para><guilabel>Choose an alert sound </guilabel> list</para>
               </entry>
               <entry colname="colspec19" colsep="0" rowsep="0" valign="top">
-                <para>Choose an alternative sound for the System Bell from 
-                this list.</para>
+                <para>Choose an alternative sound for the System Bell from this list.</para>
                 <para>Selecting a list element plays the sound.</para>
               </entry>
             </row>
@@ -2677,15 +2588,13 @@ control the volume for event sounds.</para>
           </tbody>
         </tgroup>
       </table>
-    </sect3>
-    <sect3>
-      <title>Sound Input Preferences</title>
+    </section>
+
+    <section><info><title>Sound Input Preferences</title></info>
       <para>Use the <guilabel>Input</guilabel> tabbed section to set your 
       preferences for sound input.</para>
-      <para><xref linkend="goscustdesk-TBL-1"/> lists the
-sound input preferences that you can modify.</para>
-      <table frame="topbot" id="goscustdesk-TBL-1">
-        <title>Sound Input Preferences</title>
+      <para><xref linkend="goscustdesk-TBL-1"/> lists the sound input preferences that you can modify.</para>
+      <table frame="topbot" xml:id="goscustdesk-TBL-1"><info><title>Sound Input Preferences</title></info>
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="colspec18" colwidth="19.21*"/>
           <colspec colname="colspec19" colwidth="46.79*"/>
@@ -2739,15 +2648,14 @@ sound input preferences that you can modify.</para>
       <note><para>Note that the input volume can also be controlled with
       the microphone icon that is shown in the notification area of the panel
       when an application is listening for sound input.</para></note>
-    </sect3>
-    <sect3>
-      <title>Sound Output Preferences</title>
+    </section>
+
+    <section><info><title>Sound Output Preferences</title></info>
       <para>Use the <guilabel>Output</guilabel> tabbed section to set your 
       preferences for sound output.</para>
       <para><xref linkend="goscustdesk-TBL-2"/> lists the
 sound output preferences that you can modify.</para>
-      <table frame="topbot" id="goscustdesk-TBL-2">
-        <title>Sound Output Preferences</title>
+      <table frame="topbot" xml:id="goscustdesk-TBL-2"><info><title>Sound Output Preferences</title></info>
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="colspec18" colwidth="19.21*"/>
           <colspec colname="colspec19" colwidth="46.79*"/>
@@ -2803,15 +2711,15 @@ sound output preferences that you can modify.</para>
       </table>
       <note><para>Note that the output volume can also be controlled with
       the speaker icon that is shown in the notification area of the panel.</para></note>
-    </sect3>
-    <sect3 id="goscustdesk-41">
-      <title>Application Sound Preferences</title>
+    </section>
+
+    <section xml:id="goscustdesk-41"><info><title>Application Sound Preferences</title></info>
       <para>Use the <guilabel>Applications</guilabel> tabbed section to 
       control the volume of sound played by individual applications.</para>
       <para>Each application that is currently playing sound is identified
       by its name and icon.</para>
-    </sect3>
-  </sect2>
+    </section>
+  </section>
 
 <!--
 <sect2 id="goscustdesk-79">
@@ -2820,20 +2728,13 @@ sound output preferences that you can modify.</para>
 </indexterm><para>Information to be supplied in a future release.</para>
 </sect2>
 -->
+</section>
 
+<section xml:id="prefs-system"><info><title>System</title></info>
 
-</sect1>
-
-
-<sect1 id="prefs-system">
-	<title>System</title>
-
-  <sect2 id="prefs-sessions">
-    <title>Sessions Preferences</title>
-    
+  <section xml:id="prefs-sessions"><info><title>Sessions Preferences</title></info>
     <!-- preserve for backwards compatibility: 2.12 -->
-    <anchor id="goscustsession-5"/>   
-        
+    <anchor xml:id="goscustsession-5"/>   
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Sessions</secondary>
@@ -2866,8 +2767,8 @@ in the following functional areas:</para>
         </para>
       </listitem>
     </itemizedlist>
-    <sect3 id="goscustsession-16">
-      <title>Setting Session Preferences</title>
+
+    <section xml:id="goscustsession-16"><info><title>Setting Session Preferences</title></info>
       <indexterm>
         <primary>sessions</primary>
         <secondary>setting options</secondary>
@@ -2876,8 +2777,7 @@ in the following functional areas:</para>
 to manage multiple sessions, and to set preferences for the current session.</para>
       <para><xref linkend="goscustsession-TBL-11"/> lists the session options that
 you can modify.</para>
-      <table frame="topbot" id="goscustsession-TBL-11">
-        <title>Session Options</title>
+      <table frame="topbot" xml:id="goscustsession-TBL-11"><info><title>Session Options</title></info>
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="colspec0" colwidth="18.86*"/>
           <colspec colname="colspec1" colwidth="47.14*"/>
@@ -2933,9 +2833,9 @@ the saved settings.</para>
           </tbody>
         </tgroup>
       </table>
-    </sect3>
-    <sect3 id="goscustsession-12">
-      <title>Configuring Startup Applications</title>
+    </section>
+
+    <section xml:id="goscustsession-12"><info><title>Configuring Startup Applications</title></info>
       <indexterm>
         <primary>startup applications</primary>
         <secondary>non-session-managed</secondary>
@@ -2951,8 +2851,7 @@ execute automatically when you log in.</para>
 information, see <xref linkend="goscustsession-16"/>.</para>
       <para><xref linkend="goscustsession-TBL-19"/> lists the startup applications
 preferences that you can modify.</para>
-      <table frame="topbot" id="goscustsession-TBL-19">
-        <title>Startup Programs Preferences</title>
+      <table frame="topbot" xml:id="goscustsession-TBL-19"><info><title>Startup Programs Preferences</title></info>
         <tgroup cols="2">
           <colspec colname="col1" colwidth="18.86*"/>
           <colspec colname="col2" colwidth="47.14*"/>
@@ -2996,10 +2895,7 @@ then click on the <guilabel>Remove</guilabel> button.</para>
           </tbody>
         </tgroup>
       </table>
-    </sect3>
-  </sect2>
-
-</sect1>
-
-
+    </section>
+  </section>
+</section>
 </chapter>

--- a/mate-user-guide/C/gosdconf.xml
+++ b/mate-user-guide/C/gosdconf.xml
@@ -1,6 +1,11 @@
-<chapter id="mate-dconf">
-
-  <title>Desktop Settings Storage</title>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0" xml:id="mate-dconf" xml:lang="en">
+    <info><title>Desktop Settings Storage</title></info>
 
   <highlights>
     <para>
@@ -11,9 +16,7 @@
     </para>
   </highlights>
 
-  <sect1 id="mate-dconf-intro">
-    <title>Introduction</title>
-
+  <section xml:id="mate-dconf-intro"><info><title>Introduction</title></info>
     <para>
       The settings of your MATE desktop are managed and stored by
       <application>dconf</application>, which is a key-based configuration system
@@ -23,7 +26,7 @@
     <para>
       <application>dconf</application> uses several database files in GVDB binary format, one database per file.
       A dconf profile consists of a single file, in plain text format, which contains a list of database files in GVDB format.
-      All dconf profiles are stored in the <filename class='directory'>/etc/dconf/profile</filename> folder.
+      All dconf profiles are stored in the <filename class="directory">/etc/dconf/profile</filename> folder.
     </para>
     <para>
       In most systems, there is no dconf profile file since they only use the default database, user.db which is stored in ~/.config/dconf/user. In such case, there is no system-wide setting, i.e. users just have their own settings.
@@ -43,10 +46,10 @@ system-db: distro</literallayout>
 
     <itemizedlist>
       <listitem>
-        <para><database class='name'>user</database> is the name of the user's databases. They are usually located in the <filename class='directory'>~/.config/dconf</filename> folder</para>
+        <para><database class="name">user</database> is the name of the user's databases. They are usually located in the <filename class="directory">~/.config/dconf</filename> folder</para>
       </listitem>
       <listitem>
-        <para><database class='name'>local</database>, <database class='name'>site</database> and <database class='name'>distro</database> are system databases. They are usually located in the <filename class='directory'>/etc/dconf/db</filename> folder</para>
+        <para><database class="name">local</database>, <database class="name">site</database> and <database class="name">distro</database> are system databases. They are usually located in the <filename class="directory">/etc/dconf/db</filename> folder</para>
       </listitem>
     </itemizedlist>
 
@@ -57,11 +60,11 @@ system-db: distro</literallayout>
     </para>
 
     <note>
-      <para>Refer to the <ulink url="man:dconf(7)" type="man"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>7</manvolnum></citerefentry></ulink> for more information about the dconf configuration system.</para>
+      <para>Refer to the <link xlink:href="man:dconf(7)"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>7</manvolnum></citerefentry></link> for more information about the dconf configuration system.</para>
     </note>
 
-  <sect2 id="mate-dconf-one-read">
-    <title>To read the value of a dconf key</title>
+  <section xml:id="mate-dconf-one-read"><info><title>To read the value of a dconf key</title></info>
+    
 
     <para>
       The value of a dconf key can be read using the <command>dconf</command> or <command>gsettings</command> command line tools, or the <application>Dconf Editor</application> GUI application.
@@ -86,8 +89,8 @@ system-db: distro</literallayout>
       </listitem>
     </itemizedlist>
 
-    <figure id="dconf-logical-full-bakgroud-keys-fig">
-      <title>/org/mate/desktop/background/ dconf directory</title> 
+    <figure xml:id="dconf-logical-full-bakgroud-keys-fig"><info><title>/org/mate/desktop/background/ dconf directory</title></info>
+       
       <mediaobject>
         <imageobject>
           <imagedata fileref="figures/org_mate_desktop_background_logical_view.png" format="PNG"/>
@@ -102,8 +105,8 @@ system-db: distro</literallayout>
       You can read the value of a dconf key:
     </para>
 
-    <sect3 id="read-key-dconf-using-dconf-editor">
-      <title>Using the dconf-editor GUI application</title>
+    <section xml:id="read-key-dconf-using-dconf-editor"><info><title>Using the dconf-editor GUI application</title></info>
+      
       <para>
         To show the value of a dconf key using the <application>Dconf Editor</application> application, perform the following steps:
       </para>
@@ -116,8 +119,8 @@ system-db: distro</literallayout>
         </listitem>
       </orderedlist>
 
-      <figure>
-        <title>Dconf-Editor showing the value of /org/mate/desktop/background/picture-filename key</title>
+      <figure><info><title>Dconf-Editor showing the value of /org/mate/desktop/background/picture-filename key</title></info>
+        
         <screenshot>
           <mediaobject>
             <imageobject>
@@ -129,10 +132,10 @@ system-db: distro</literallayout>
           </mediaobject>
         </screenshot>
       </figure>
-    </sect3>
+    </section>
 
-    <sect3 id="read-key-dconf-using-dconf">
-      <title>Using the dconf command line tool</title>
+    <section xml:id="read-key-dconf-using-dconf"><info><title>Using the dconf command line tool</title></info>
+      
       <para>
         To read the value of a dconf key using the <command>dconf</command> command line tool, run the following command:
       </para>
@@ -143,13 +146,13 @@ system-db: distro</literallayout>
       </para>
       <synopsis>dconf read [-d] KEY</synopsis>
       <para>
-        Refer to the <ulink url="man:dconf" type="man"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>dconf</command> command line tool.
+        Refer to the <link xlink:href="man:dconf"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>dconf</command> command line tool.
       </para>
       <tip><para>You can use the <keycap>Tab</keycap> key to auto complete the path to the dconf key. </para></tip>
-    </sect3>
+    </section>
 
-    <sect3 id="read-key-dconf-using-gsettings">
-      <title>Using the gsettings command line tool</title>
+    <section xml:id="read-key-dconf-using-gsettings"><info><title>Using the gsettings command line tool</title></info>
+      
       <para>
         To read the value of a dconf key using the <command>gsettings</command> command line tool, run the following command:
       </para>
@@ -160,13 +163,13 @@ system-db: distro</literallayout>
       </para>
       <synopsis>gsettings [--schemadir SCHEMADIR] get SCHEMA[:PATH] KEY</synopsis>
       <para>
-        Refer to the <ulink url="man:gsettings" type="man"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>gsettings</command> command line tool.
+        Refer to the <link xlink:href="man:gsettings"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>gsettings</command> command line tool.
       </para>
-    </sect3>
-  </sect2>
+    </section>
+  </section>
 
-  <sect2 id="mate-dconf-one-change">
-    <title>To change the value of a dconf key</title>
+  <section xml:id="mate-dconf-one-change"><info><title>To change the value of a dconf key</title></info>
+    
 
     <para>
       The value of a dconf key can be modified using the <command>dconf</command> command or the <application>Dconf Editor</application> application.
@@ -189,8 +192,8 @@ system-db: distro</literallayout>
       </listitem>
     </itemizedlist>
 
-    <figure id="dconf-logical-short-bakgroud-keys-fig">
-      <title>/org/mate/desktop/background/ dconf directory</title>
+    <figure xml:id="dconf-logical-short-bakgroud-keys-fig"><info><title>/org/mate/desktop/background/ dconf directory</title></info>
+      
       <mediaobject>
         <imageobject>
           <imagedata fileref="figures/org_mate_desktop_background_only_logical_view.png" format="PNG"/>
@@ -205,8 +208,8 @@ system-db: distro</literallayout>
       You can mofify the value of a dconf key:
     </para>
 
-    <sect3 id="modify-key-dconf-using-dconf-editor">
-      <title>Using the dconf-editor GUI application</title>
+    <section xml:id="modify-key-dconf-using-dconf-editor"><info><title>Using the dconf-editor GUI application</title></info>
+      
       <para>
         To edit the background picture of your MATE desktop in <application>Dconf Editor</application>, perform the following steps:
       </para>
@@ -226,8 +229,8 @@ system-db: distro</literallayout>
         </listitem>
       </orderedlist>
 
-      <figure>
-        <title>Editing the value of /org/mate/desktop/background/picture-filename key in Dconf-Editor dialog</title>
+      <figure><info><title>Editing the value of /org/mate/desktop/background/picture-filename key in Dconf-Editor dialog</title></info>
+        
         <screenshot>
           <mediaobject>
             <imageobject>
@@ -239,10 +242,10 @@ system-db: distro</literallayout>
           </mediaobject>
         </screenshot>
       </figure>
-    </sect3>
+    </section>
 
-    <sect3 id="modify-key-dconf-using-dconf">
-      <title>Using the dconf command line tool</title>
+    <section xml:id="modify-key-dconf-using-dconf"><info><title>Using the dconf command line tool</title></info>
+      
       <para>
         To change the background picture of your MATE desktop, run the following command:
       </para>
@@ -253,12 +256,12 @@ system-db: distro</literallayout>
       </para>
       <synopsis>dconf write KEY VALUE</synopsis>
       <para>
-        Refer to the <ulink url="man:dconf" type="man"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>dconf</command>.
+        Refer to the <link xlink:href="man:dconf"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>dconf</command>.
       </para>
-    </sect3>
+    </section>
 
-    <sect3 id="modify-key-dconf-using-gsettings">
-      <title>Using the gsettings command line tool</title>
+    <section xml:id="modify-key-dconf-using-gsettings"><info><title>Using the gsettings command line tool</title></info>
+      
       <para>
         To change the background picture of your MATE desktop, run the following command:
       </para>
@@ -269,13 +272,13 @@ system-db: distro</literallayout>
       </para>
       <synopsis>gsettings [--schemadir SCHEMADIR] set SCHEMA[:PATH] KEY VALUE</synopsis>
       <para>
-        Refer to the <ulink url="man:gsettings" type="man"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>dconf</command>.
+        Refer to the <link xlink:href="man:gsettings"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>dconf</command>.
       </para>
-    </sect3>
-  </sect2>
+    </section>
+  </section>
 
-  <sect2 id="mate-dconf-some-changes">
-    <title>To change the value of several dconf keys</title>
+  <section xml:id="mate-dconf-some-changes"><info><title>To change the value of several dconf keys</title></info>
+    
 
     <para>
       To change the value of several dconf keys at the same time, perform the following steps:
@@ -306,13 +309,13 @@ $ dconf load /org/mate/ &lt; backup.dconf</screen>
     </tip>
 
     <para>
-      Refer to the <ulink url="man:dconf" type="man"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>dconf</command> command line tool.
+      Refer to the <link xlink:href="man:dconf"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>dconf</command> command line tool.
     </para>
 
-  </sect2>
+  </section>
 
-  </sect1>
+  </section>
 
-  <include href="gosdconfkeys.xml" xmlns="http://www.w3.org/2001/XInclude" />   <!-- List of dconf keys -->
+  <xi:include href="gosdconfkeys.xml"/>   <!-- List of dconf keys -->
 
 </chapter>

--- a/mate-user-guide/C/gosdconfkeys.sh
+++ b/mate-user-guide/C/gosdconfkeys.sh
@@ -18,14 +18,20 @@ if [ ! -d "mate-desktop" ]; then
   git clone https://github.com/mate-desktop/mate-desktop.git
 fi
 cat << EOF > $OUTPUT
-  <sect1 id="mate-dconf-list">
-    <title>List of Dconf Keys of MATE Desktop</title>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:its="http://www.w3.org/2005/11/its"
+         version="5.0" its:version="2.0" xml:id="mate-dconf-list" xml:lang="en">
+    <info><title>List of Dconf Keys of MATE Desktop</title></info>
 EOF
 for file in mate-desktop/schemas/*.gschema.xml.in; do
   xsltproc gosdconfkeys.xsl $file >> $OUTPUT
 done
 cat << EOF >> $OUTPUT
-  </sect1>
+  </section>
 EOF
 xmllint -format $OUTPUT > $OUTPUT.aux
 mv $OUTPUT.aux $OUTPUT

--- a/mate-user-guide/C/gosdconfkeys.xml
+++ b/mate-user-guide/C/gosdconfkeys.xml
@@ -1,22 +1,27 @@
-<?xml version="1.0"?>
-<sect1 id="mate-dconf-list">
-  <title>List of Dconf Keys of MATE Desktop</title>
-  <sect2 id="org.mate.accessibility-keyboard">
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:db="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:its="http://www.w3.org/2005/11/its" version="5.0" its:version="2.0" xml:id="mate-dconf-list" xml:lang="en">
+  <info>
+    <title>List of Dconf Keys of MATE Desktop</title>
+  </info>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.accessibility-keyboard">
     <title>Dconf Directory: /org/mate/desktop/accessibility/keyboard/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/accessibility/keyboard/
 $ gsettings list-keys org.mate.accessibility-keyboard</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>enable</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/enable
 $ gsettings get org.mate.accessibility-keyboard enable</screen>
           </para>
@@ -26,7 +31,7 @@ $ gsettings get org.mate.accessibility-keyboard enable</screen>
         <term>feature-state-change-beep</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/feature-state-change-beep
 $ gsettings get org.mate.accessibility-keyboard feature-state-change-beep</screen>
           </para>
@@ -36,7 +41,7 @@ $ gsettings get org.mate.accessibility-keyboard feature-state-change-beep</scree
         <term>timeout-enable</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/timeout-enable
 $ gsettings get org.mate.accessibility-keyboard timeout-enable</screen>
           </para>
@@ -46,7 +51,7 @@ $ gsettings get org.mate.accessibility-keyboard timeout-enable</screen>
         <term>timeout</term>
         <listitem>
           <para>(i) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/timeout
 $ gsettings get org.mate.accessibility-keyboard timeout</screen>
           </para>
@@ -56,7 +61,7 @@ $ gsettings get org.mate.accessibility-keyboard timeout</screen>
         <term>bouncekeys-enable</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/bouncekeys-enable
 $ gsettings get org.mate.accessibility-keyboard bouncekeys-enable</screen>
           </para>
@@ -66,7 +71,7 @@ $ gsettings get org.mate.accessibility-keyboard bouncekeys-enable</screen>
         <term>bouncekeys-delay</term>
         <listitem>
           <para>(i) Ignore multiple presses of the _same_ key within @delay milliseconds.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/bouncekeys-delay
 $ gsettings get org.mate.accessibility-keyboard bouncekeys-delay</screen>
           </para>
@@ -76,7 +81,7 @@ $ gsettings get org.mate.accessibility-keyboard bouncekeys-delay</screen>
         <term>bouncekeys-beep-reject</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/bouncekeys-beep-reject
 $ gsettings get org.mate.accessibility-keyboard bouncekeys-beep-reject</screen>
           </para>
@@ -86,7 +91,7 @@ $ gsettings get org.mate.accessibility-keyboard bouncekeys-beep-reject</screen>
         <term>mousekeys-enable</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-enable
 $ gsettings get org.mate.accessibility-keyboard mousekeys-enable</screen>
           </para>
@@ -96,7 +101,7 @@ $ gsettings get org.mate.accessibility-keyboard mousekeys-enable</screen>
         <term>mousekeys-max-speed</term>
         <listitem>
           <para>(i) How many pixels per second to move at the maximum speed.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-max-speed
 $ gsettings get org.mate.accessibility-keyboard mousekeys-max-speed</screen>
           </para>
@@ -106,7 +111,7 @@ $ gsettings get org.mate.accessibility-keyboard mousekeys-max-speed</screen>
         <term>mousekeys-accel-time</term>
         <listitem>
           <para>(i) How many milliseconds it takes to go from 0 to maximum speed.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-accel-time
 $ gsettings get org.mate.accessibility-keyboard mousekeys-accel-time</screen>
           </para>
@@ -116,7 +121,7 @@ $ gsettings get org.mate.accessibility-keyboard mousekeys-accel-time</screen>
         <term>mousekeys-init-delay</term>
         <listitem>
           <para>(i) How many milliseconds to wait before mouse movement keys start to operate.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-init-delay
 $ gsettings get org.mate.accessibility-keyboard mousekeys-init-delay</screen>
           </para>
@@ -126,7 +131,7 @@ $ gsettings get org.mate.accessibility-keyboard mousekeys-init-delay</screen>
         <term>slowkeys-enable</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-enable
 $ gsettings get org.mate.accessibility-keyboard slowkeys-enable</screen>
           </para>
@@ -136,7 +141,7 @@ $ gsettings get org.mate.accessibility-keyboard slowkeys-enable</screen>
         <term>slowkeys-delay</term>
         <listitem>
           <para>(i) Do not accept a key as being pressed unless held for @delay milliseconds.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-delay
 $ gsettings get org.mate.accessibility-keyboard slowkeys-delay</screen>
           </para>
@@ -146,7 +151,7 @@ $ gsettings get org.mate.accessibility-keyboard slowkeys-delay</screen>
         <term>slowkeys-beep-press</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-beep-press
 $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-press</screen>
           </para>
@@ -156,7 +161,7 @@ $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-press</screen>
         <term>slowkeys-beep-accept</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-beep-accept
 $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-accept</screen>
           </para>
@@ -166,7 +171,7 @@ $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-accept</screen>
         <term>slowkeys-beep-reject</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-beep-reject
 $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-reject</screen>
           </para>
@@ -176,7 +181,7 @@ $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-reject</screen>
         <term>stickykeys-enable</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-enable
 $ gsettings get org.mate.accessibility-keyboard stickykeys-enable</screen>
           </para>
@@ -186,7 +191,7 @@ $ gsettings get org.mate.accessibility-keyboard stickykeys-enable</screen>
         <term>stickykeys-latch-to-lock</term>
         <listitem>
           <para>(b) Latch modifiers when pressed twice in a row until the same modifier is pressed again.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-latch-to-lock
 $ gsettings get org.mate.accessibility-keyboard stickykeys-latch-to-lock</screen>
           </para>
@@ -196,7 +201,7 @@ $ gsettings get org.mate.accessibility-keyboard stickykeys-latch-to-lock</screen
         <term>stickykeys-two-key-off</term>
         <listitem>
           <para>(b) Disable if two keys are pressed at the same time.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-two-key-off
 $ gsettings get org.mate.accessibility-keyboard stickykeys-two-key-off</screen>
           </para>
@@ -206,7 +211,7 @@ $ gsettings get org.mate.accessibility-keyboard stickykeys-two-key-off</screen>
         <term>stickykeys-modifier-beep</term>
         <listitem>
           <para>(b) Beep when a modifier is pressed.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-modifier-beep
 $ gsettings get org.mate.accessibility-keyboard stickykeys-modifier-beep</screen>
           </para>
@@ -216,53 +221,57 @@ $ gsettings get org.mate.accessibility-keyboard stickykeys-modifier-beep</screen
         <term>togglekeys-enable</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/keyboard/togglekeys-enable
 $ gsettings get org.mate.accessibility-keyboard togglekeys-enable</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.accessibility-startup">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.accessibility-startup">
     <title>Dconf Directory: /org/mate/desktop/accessibility/startup/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/accessibility/startup/
 $ gsettings list-keys org.mate.accessibility-startup</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>exec-ats</term>
         <listitem>
           <para>(as) List of assistive technology applications to start when logging into the MATE desktop.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/accessibility/startup/exec-ats
 $ gsettings get org.mate.accessibility-startup exec-ats</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.applications-at-mobility">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.applications-at-mobility">
     <title>Dconf Directory: /org/mate/desktop/applications/at/mobility/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/applications/at/mobility/
 $ gsettings list-keys org.mate.applications-at-mobility</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>exec</term>
         <listitem>
           <para>(s) Preferred Mobility assistive technology application to be used for login, menu, or command line.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/at/mobility/exec
 $ gsettings get org.mate.applications-at-mobility exec</screen>
           </para>
@@ -272,30 +281,32 @@ $ gsettings get org.mate.applications-at-mobility exec</screen>
         <term>startup</term>
         <listitem>
           <para>(b) MATE to start preferred Mobility assistive technology application during login.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/at/mobility/startup
 $ gsettings get org.mate.applications-at-mobility startup</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.applications-at-visual">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.applications-at-visual">
     <title>Dconf Directory: /org/mate/desktop/applications/at/visual/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/applications/at/visual/
 $ gsettings list-keys org.mate.applications-at-visual</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>exec</term>
         <listitem>
           <para>(s) Preferred Visual assistive technology application to be used for login, menu, or command line.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/at/visual/exec
 $ gsettings get org.mate.applications-at-visual exec</screen>
           </para>
@@ -305,30 +316,32 @@ $ gsettings get org.mate.applications-at-visual exec</screen>
         <term>startup</term>
         <listitem>
           <para>(b) MATE to start preferred Visual assistive technology application during login.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/at/visual/startup
 $ gsettings get org.mate.applications-at-visual startup</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.applications-browser">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.applications-browser">
     <title>Dconf Directory: /org/mate/desktop/applications/browser/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/applications/browser/
 $ gsettings list-keys org.mate.applications-browser</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>exec</term>
         <listitem>
           <para>(s) Default browser for all URLs.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/browser/exec
 $ gsettings get org.mate.applications-browser exec</screen>
           </para>
@@ -338,7 +351,7 @@ $ gsettings get org.mate.applications-browser exec</screen>
         <term>needs-term</term>
         <listitem>
           <para>(b) Whether the default browser needs a terminal to run.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/browser/needs-term
 $ gsettings get org.mate.applications-browser needs-term</screen>
           </para>
@@ -348,30 +361,57 @@ $ gsettings get org.mate.applications-browser needs-term</screen>
         <term>nremote</term>
         <listitem>
           <para>(b) Whether the default browser understands netscape remote.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/browser/nremote
 $ gsettings get org.mate.applications-browser nremote</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.applications-office.calendar">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.applications-calculator">
+    <title>Dconf Directory: /org/mate/desktop/applications/calculator/</title>
+    <para>To obtain the list of dconf keys, run one of the following commands:</para>
+    <para its:translate="no">
+      <screen>$ dconf list /org/mate/desktop/applications/calculator/
+$ gsettings list-keys org.mate.applications-calculator</screen>
+    </para>
+    <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
+           The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
+    <variablelist>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
+      <varlistentry>
+        <term>exec</term>
+        <listitem>
+          <para>(s) Calculator program to use when starting applications that require one.</para>
+          <para its:translate="no">
+            <screen>$ dconf read /org/mate/desktop/applications/calculator/exec
+$ gsettings get org.mate.applications-calculator exec</screen>
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.applications-office.calendar">
     <title>Dconf Directory: /org/mate/desktop/applications/calendar/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/applications/calendar/
 $ gsettings list-keys org.mate.applications-office.calendar</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>exec</term>
         <listitem>
           <para>(s) Default calendar application</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/calendar/exec
 $ gsettings get org.mate.applications-office.calendar exec</screen>
           </para>
@@ -381,30 +421,32 @@ $ gsettings get org.mate.applications-office.calendar exec</screen>
         <term>needs-term</term>
         <listitem>
           <para>(b) Whether the default calendar application needs a terminal to run</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/calendar/needs-term
 $ gsettings get org.mate.applications-office.calendar needs-term</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.applications-office.tasks">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.applications-office.tasks">
     <title>Dconf Directory: /org/mate/desktop/applications/tasks/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/applications/tasks/
 $ gsettings list-keys org.mate.applications-office.tasks</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>exec</term>
         <listitem>
           <para>(s) Default tasks application</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/tasks/exec
 $ gsettings get org.mate.applications-office.tasks exec</screen>
           </para>
@@ -414,30 +456,32 @@ $ gsettings get org.mate.applications-office.tasks exec</screen>
         <term>needs-term</term>
         <listitem>
           <para>(b) Whether the default tasks application needs a terminal to run</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/tasks/needs-term
 $ gsettings get org.mate.applications-office.tasks needs-term</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.applications-terminal">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.applications-terminal">
     <title>Dconf Directory: /org/mate/desktop/applications/terminal/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/applications/terminal/
 $ gsettings list-keys org.mate.applications-terminal</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>exec</term>
         <listitem>
           <para>(s) Terminal program to use when starting applications that require one.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/terminal/exec
 $ gsettings get org.mate.applications-terminal exec</screen>
           </para>
@@ -447,30 +491,32 @@ $ gsettings get org.mate.applications-terminal exec</screen>
         <term>exec-arg</term>
         <listitem>
           <para>(s) Argument used to execute programs in the terminal defined by the 'exec' key.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/applications/terminal/exec-arg
 $ gsettings get org.mate.applications-terminal exec-arg</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.background">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.background">
     <title>Dconf Directory: /org/mate/desktop/background/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/background/
 $ gsettings list-keys org.mate.background</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>draw-background</term>
         <listitem>
           <para>(b) Have MATE draw the desktop background.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/draw-background
 $ gsettings get org.mate.background draw-background</screen>
           </para>
@@ -480,7 +526,7 @@ $ gsettings get org.mate.background draw-background</screen>
         <term>show-desktop-icons</term>
         <listitem>
           <para>(b) Have MATE file manager (Caja) draw the desktop icons.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/show-desktop-icons
 $ gsettings get org.mate.background show-desktop-icons</screen>
           </para>
@@ -490,7 +536,7 @@ $ gsettings get org.mate.background show-desktop-icons</screen>
         <term>background-fade</term>
         <listitem>
           <para>(b) If set to true, then MATE will change the desktop background with a fading effect.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/background-fade
 $ gsettings get org.mate.background background-fade</screen>
           </para>
@@ -500,7 +546,7 @@ $ gsettings get org.mate.background background-fade</screen>
         <term>picture-options</term>
         <listitem>
           <para>() Determines how the image set by wallpaper_filename is rendered.  Possible values are "wallpaper", "centered", "scaled", "stretched", "zoom", "spanned".</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/picture-options
 $ gsettings get org.mate.background picture-options</screen>
           </para>
@@ -510,7 +556,7 @@ $ gsettings get org.mate.background picture-options</screen>
         <term>picture-filename</term>
         <listitem>
           <para>(s) File to use for the background image.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/picture-filename
 $ gsettings get org.mate.background picture-filename</screen>
           </para>
@@ -520,7 +566,7 @@ $ gsettings get org.mate.background picture-filename</screen>
         <term>picture-opacity</term>
         <listitem>
           <para>(i) Opacity with which to draw the background picture.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/picture-opacity
 $ gsettings get org.mate.background picture-opacity</screen>
           </para>
@@ -530,7 +576,7 @@ $ gsettings get org.mate.background picture-opacity</screen>
         <term>primary-color</term>
         <listitem>
           <para>(s) Left or Top color when drawing gradients, or the solid color.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/primary-color
 $ gsettings get org.mate.background primary-color</screen>
           </para>
@@ -540,7 +586,7 @@ $ gsettings get org.mate.background primary-color</screen>
         <term>secondary-color</term>
         <listitem>
           <para>(s) Right or Bottom color when drawing gradients, not used for solid color.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/secondary-color
 $ gsettings get org.mate.background secondary-color</screen>
           </para>
@@ -550,30 +596,32 @@ $ gsettings get org.mate.background secondary-color</screen>
         <term>color-shading-type</term>
         <listitem>
           <para>() How to shade the background color. Possible values are "horizontal-gradient", "vertical-gradient", and "solid".</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/background/color-shading-type
 $ gsettings get org.mate.background color-shading-type</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.debug">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.debug">
     <title>Dconf Directory: /org/mate/debug/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/debug/
 $ gsettings list-keys org.mate.debug</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>caja</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/debug/caja
 $ gsettings get org.mate.debug caja</screen>
           </para>
@@ -583,7 +631,7 @@ $ gsettings get org.mate.debug caja</screen>
         <term>marco</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/debug/marco
 $ gsettings get org.mate.debug marco</screen>
           </para>
@@ -593,7 +641,7 @@ $ gsettings get org.mate.debug marco</screen>
         <term>mate-session</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/debug/mate-session
 $ gsettings get org.mate.debug mate-session</screen>
           </para>
@@ -603,7 +651,7 @@ $ gsettings get org.mate.debug mate-session</screen>
         <term>mate-settings-daemon</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/debug/mate-settings-daemon
 $ gsettings get org.mate.debug mate-settings-daemon</screen>
           </para>
@@ -613,53 +661,57 @@ $ gsettings get org.mate.debug mate-settings-daemon</screen>
         <term>mate-panel</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/debug/mate-panel
 $ gsettings get org.mate.debug mate-panel</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.file-views">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.file-views">
     <title>Dconf Directory: /org/mate/desktop/file-views/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/file-views/
 $ gsettings list-keys org.mate.file-views</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>icon-theme</term>
         <listitem>
           <para>(s) Theme used for displaying file icons.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/file-views/icon-theme
 $ gsettings get org.mate.file-views icon-theme</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.interface">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.interface">
     <title>Dconf Directory: /org/mate/desktop/interface/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/interface/
 $ gsettings list-keys org.mate.interface</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>accessibility</term>
         <listitem>
           <para>(b) Whether Applications should have accessibility support.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/accessibility
 $ gsettings get org.mate.interface accessibility</screen>
           </para>
@@ -669,7 +721,7 @@ $ gsettings get org.mate.interface accessibility</screen>
         <term>enable-animations</term>
         <listitem>
           <para>(b) Whether animations should be displayed. Note: This is a global key, it changes the behaviour of the window manager, the panel etc.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/enable-animations
 $ gsettings get org.mate.interface enable-animations</screen>
           </para>
@@ -679,7 +731,7 @@ $ gsettings get org.mate.interface enable-animations</screen>
         <term>menus-have-tearoff</term>
         <listitem>
           <para>(b) Whether menus should have a tearoff.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/menus-have-tearoff
 $ gsettings get org.mate.interface menus-have-tearoff</screen>
           </para>
@@ -689,7 +741,7 @@ $ gsettings get org.mate.interface menus-have-tearoff</screen>
         <term>toolbar-style</term>
         <listitem>
           <para>(s) Toolbar Style. Valid values are "both", "both-horiz", "icons", and "text".</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/toolbar-style
 $ gsettings get org.mate.interface toolbar-style</screen>
           </para>
@@ -699,7 +751,7 @@ $ gsettings get org.mate.interface toolbar-style</screen>
         <term>menus-have-icons</term>
         <listitem>
           <para>(b) Whether menus may display an icon next to a menu entry.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/menus-have-icons
 $ gsettings get org.mate.interface menus-have-icons</screen>
           </para>
@@ -709,7 +761,7 @@ $ gsettings get org.mate.interface menus-have-icons</screen>
         <term>buttons-have-icons</term>
         <listitem>
           <para>(b) Whether buttons may display an icon in addition to the button text.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/buttons-have-icons
 $ gsettings get org.mate.interface buttons-have-icons</screen>
           </para>
@@ -719,7 +771,7 @@ $ gsettings get org.mate.interface buttons-have-icons</screen>
         <term>menubar-detachable</term>
         <listitem>
           <para>(b) Whether the user can detach menubars and move them around.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/menubar-detachable
 $ gsettings get org.mate.interface menubar-detachable</screen>
           </para>
@@ -729,7 +781,7 @@ $ gsettings get org.mate.interface menubar-detachable</screen>
         <term>toolbar-detachable</term>
         <listitem>
           <para>(b) Whether the user can detach toolbars and move them around.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/toolbar-detachable
 $ gsettings get org.mate.interface toolbar-detachable</screen>
           </para>
@@ -739,7 +791,7 @@ $ gsettings get org.mate.interface toolbar-detachable</screen>
         <term>toolbar-icons-size</term>
         <listitem>
           <para>(s) Size of icons in toolbars, either "small-toolbar" or "large-toolbar".</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/toolbar-icons-size
 $ gsettings get org.mate.interface toolbar-icons-size</screen>
           </para>
@@ -749,7 +801,7 @@ $ gsettings get org.mate.interface toolbar-icons-size</screen>
         <term>cursor-blink</term>
         <listitem>
           <para>(b) Whether the cursor should blink.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/cursor-blink
 $ gsettings get org.mate.interface cursor-blink</screen>
           </para>
@@ -759,7 +811,7 @@ $ gsettings get org.mate.interface cursor-blink</screen>
         <term>cursor-blink-time</term>
         <listitem>
           <para>(i) Length of the cursor blink cycle, in milliseconds.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/cursor-blink-time
 $ gsettings get org.mate.interface cursor-blink-time</screen>
           </para>
@@ -769,7 +821,7 @@ $ gsettings get org.mate.interface cursor-blink-time</screen>
         <term>icon-theme</term>
         <listitem>
           <para>(s) Icon theme to use for the panel, Caja etc.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/icon-theme
 $ gsettings get org.mate.interface icon-theme</screen>
           </para>
@@ -779,7 +831,7 @@ $ gsettings get org.mate.interface icon-theme</screen>
         <term>gtk-theme</term>
         <listitem>
           <para>(s) Basename of the default theme used by gtk+.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-theme
 $ gsettings get org.mate.interface gtk-theme</screen>
           </para>
@@ -789,7 +841,7 @@ $ gsettings get org.mate.interface gtk-theme</screen>
         <term>gtk-key-theme</term>
         <listitem>
           <para>(s) Basename of the default theme used by gtk+.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-key-theme
 $ gsettings get org.mate.interface gtk-key-theme</screen>
           </para>
@@ -799,7 +851,7 @@ $ gsettings get org.mate.interface gtk-key-theme</screen>
         <term>gtk-color-scheme</term>
         <listitem>
           <para>(s) A '\n' separated list of "name:color" as defined by the 'gtk-color-scheme' setting</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-color-scheme
 $ gsettings get org.mate.interface gtk-color-scheme</screen>
           </para>
@@ -809,7 +861,7 @@ $ gsettings get org.mate.interface gtk-color-scheme</screen>
         <term>font-name</term>
         <listitem>
           <para>(s) Name of the default font used by gtk+.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/font-name
 $ gsettings get org.mate.interface font-name</screen>
           </para>
@@ -819,7 +871,7 @@ $ gsettings get org.mate.interface font-name</screen>
         <term>gtk-im-preedit-style</term>
         <listitem>
           <para>(s) Name of the GTK+ input method Preedit Style used by gtk+.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-im-preedit-style
 $ gsettings get org.mate.interface gtk-im-preedit-style</screen>
           </para>
@@ -829,7 +881,7 @@ $ gsettings get org.mate.interface gtk-im-preedit-style</screen>
         <term>gtk-im-status-style</term>
         <listitem>
           <para>(s) Name of the GTK+ input method Status Style used by gtk+.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-im-status-style
 $ gsettings get org.mate.interface gtk-im-status-style</screen>
           </para>
@@ -839,7 +891,7 @@ $ gsettings get org.mate.interface gtk-im-status-style</screen>
         <term>gtk-im-module</term>
         <listitem>
           <para>(s) Name of the input method module used by GTK+.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-im-module
 $ gsettings get org.mate.interface gtk-im-module</screen>
           </para>
@@ -849,7 +901,7 @@ $ gsettings get org.mate.interface gtk-im-module</screen>
         <term>gtk-dialogs-use-header</term>
         <listitem>
           <para>(b) Whether builtin GTK+ dialogs such as the file chooser, the color chooser or the font chooser will use a header bar at the top to show action widgets, or an action area at the bottom. This setting does not affect custom dialogs using GtkDialog directly, or message dialogs.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-dialogs-use-header
 $ gsettings get org.mate.interface gtk-dialogs-use-header</screen>
           </para>
@@ -859,7 +911,7 @@ $ gsettings get org.mate.interface gtk-dialogs-use-header</screen>
         <term>gtk-overlay-scrolling</term>
         <listitem>
           <para>(b) Whether built-in GTK+ scrolled windows will use overlay scrolling. Overlay scrolling hides and reduces the size of the scrollbar until it gets focus.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-overlay-scrolling
 $ gsettings get org.mate.interface gtk-overlay-scrolling</screen>
           </para>
@@ -869,7 +921,7 @@ $ gsettings get org.mate.interface gtk-overlay-scrolling</screen>
         <term>gtk-enable-animations</term>
         <listitem>
           <para>(b) Whether to enable toolkit-wide animations.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-enable-animations
 $ gsettings get org.mate.interface gtk-enable-animations</screen>
           </para>
@@ -879,7 +931,7 @@ $ gsettings get org.mate.interface gtk-enable-animations</screen>
         <term>document-font-name</term>
         <listitem>
           <para>(s) Name of the default font used for reading documents.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/document-font-name
 $ gsettings get org.mate.interface document-font-name</screen>
           </para>
@@ -889,7 +941,7 @@ $ gsettings get org.mate.interface document-font-name</screen>
         <term>monospace-font-name</term>
         <listitem>
           <para>(s) Name of a monospaced (fixed-width) font for use in locations like terminals.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/monospace-font-name
 $ gsettings get org.mate.interface monospace-font-name</screen>
           </para>
@@ -899,7 +951,7 @@ $ gsettings get org.mate.interface monospace-font-name</screen>
         <term>use-custom-font</term>
         <listitem>
           <para>(b) Whether to use a custom font in gtk+ applications.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/use-custom-font
 $ gsettings get org.mate.interface use-custom-font</screen>
           </para>
@@ -909,7 +961,7 @@ $ gsettings get org.mate.interface use-custom-font</screen>
         <term>status-bar-meter-on-right</term>
         <listitem>
           <para>(b) Whether to display a status bar meter on the right.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/status-bar-meter-on-right
 $ gsettings get org.mate.interface status-bar-meter-on-right</screen>
           </para>
@@ -919,7 +971,7 @@ $ gsettings get org.mate.interface status-bar-meter-on-right</screen>
         <term>file-chooser-backend</term>
         <listitem>
           <para>(s) Module to use as the filesystem model for the GtkFileChooser widget.  Possible values are "gio" and "gtk+".</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/file-chooser-backend
 $ gsettings get org.mate.interface file-chooser-backend</screen>
           </para>
@@ -929,7 +981,7 @@ $ gsettings get org.mate.interface file-chooser-backend</screen>
         <term>menubar-accel</term>
         <listitem>
           <para>(s) Keyboard shortcut to open the menu bars.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/menubar-accel
 $ gsettings get org.mate.interface menubar-accel</screen>
           </para>
@@ -939,7 +991,7 @@ $ gsettings get org.mate.interface menubar-accel</screen>
         <term>show-input-method-menu</term>
         <listitem>
           <para>(b) Whether the context menus of entries and text views  should offer to change the input method.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/show-input-method-menu
 $ gsettings get org.mate.interface show-input-method-menu</screen>
           </para>
@@ -949,7 +1001,7 @@ $ gsettings get org.mate.interface show-input-method-menu</screen>
         <term>show-unicode-menu</term>
         <listitem>
           <para>(b) Whether the context menus of entries and text views  should offer to insert control characters.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/show-unicode-menu
 $ gsettings get org.mate.interface show-unicode-menu</screen>
           </para>
@@ -959,7 +1011,7 @@ $ gsettings get org.mate.interface show-unicode-menu</screen>
         <term>gtk-decoration-layout</term>
         <listitem>
           <para>(s) This setting determines which buttons should be put in the titlebar of client-side decorated windows, and whether they should be placed at the left of right. See https://developer.gnome.org/gtk3/stable/GtkSettings.html#GtkSettings--gtk-decoration-layout.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-decoration-layout
 $ gsettings get org.mate.interface gtk-decoration-layout</screen>
           </para>
@@ -969,7 +1021,7 @@ $ gsettings get org.mate.interface gtk-decoration-layout</screen>
         <term>gtk-shell-shows-app-menu</term>
         <listitem>
           <para>(b)  This setting determines where application menu will be displayed - in a window or on a panel with MenuModel protocol. See https://developer.gnome.org/gtk3/stable/GtkSettings.html#GtkSettings--gtk-shell-shows-app-menu.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-shell-shows-app-menu
 $ gsettings get org.mate.interface gtk-shell-shows-app-menu</screen>
           </para>
@@ -979,7 +1031,7 @@ $ gsettings get org.mate.interface gtk-shell-shows-app-menu</screen>
         <term>gtk-shell-shows-menubar</term>
         <listitem>
           <para>(b)  This setting determines where window menubars will be displayed - in a window or on a panel with MenuModel protocol. See https://developer.gnome.org/gtk3/stable/GtkSettings.html#GtkSettings--gtk-shell-shows-menubar.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-shell-shows-menubar
 $ gsettings get org.mate.interface gtk-shell-shows-menubar</screen>
           </para>
@@ -989,7 +1041,7 @@ $ gsettings get org.mate.interface gtk-shell-shows-menubar</screen>
         <term>automatic-mnemonics</term>
         <listitem>
           <para>(b) Whether mnemonics should be automatically shown and hidden when the user presses the Alt key.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/automatic-mnemonics
 $ gsettings get org.mate.interface automatic-mnemonics</screen>
           </para>
@@ -999,7 +1051,7 @@ $ gsettings get org.mate.interface automatic-mnemonics</screen>
         <term>window-scaling-factor</term>
         <listitem>
           <para>(i) This controls the GTK scale factor that maps from window coordinates to the actual device pixels. On traditional systems this is 1, but on very high density displays (e.g. HiDPI, Retina) this can be a higher value (often 2). Set to 0 to auto-detect.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/window-scaling-factor
 $ gsettings get org.mate.interface window-scaling-factor</screen>
           </para>
@@ -1009,7 +1061,7 @@ $ gsettings get org.mate.interface window-scaling-factor</screen>
         <term>window-scaling-factor-qt-sync</term>
         <listitem>
           <para>(b) This setting determines whether MATE controls the scale factor for QT applications. Enable to synchronize with the GTK scale factor when initializing the session, disable to control this value elsewhere. Requires restarting your session.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/window-scaling-factor-qt-sync
 $ gsettings get org.mate.interface window-scaling-factor-qt-sync</screen>
           </para>
@@ -1021,30 +1073,32 @@ $ gsettings get org.mate.interface window-scaling-factor-qt-sync</screen>
           <para>(b) 
         If true, gtk+ uses the primary paste selection, usually triggered by a middle mouse button click.
       </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/interface/gtk-enable-primary-paste
 $ gsettings get org.mate.interface gtk-enable-primary-paste</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.lockdown">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.lockdown">
     <title>Dconf Directory: /org/mate/desktop/lockdown/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/lockdown/
 $ gsettings list-keys org.mate.lockdown</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>disable-command-line</term>
         <listitem>
           <para>(b) Prevent the user from accessing the terminal or specifying a command line to be executed. For example, this would disable access to the panel's "Run Application" dialog.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-command-line
 $ gsettings get org.mate.lockdown disable-command-line</screen>
           </para>
@@ -1054,7 +1108,7 @@ $ gsettings get org.mate.lockdown disable-command-line</screen>
         <term>disable-save-to-disk</term>
         <listitem>
           <para>(b) Prevent the user from saving files to disk. For example, this would disable access to all applications' "Save as" dialogs.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-save-to-disk
 $ gsettings get org.mate.lockdown disable-save-to-disk</screen>
           </para>
@@ -1064,7 +1118,7 @@ $ gsettings get org.mate.lockdown disable-save-to-disk</screen>
         <term>disable-printing</term>
         <listitem>
           <para>(b) Prevent the user from printing. For example, this would disable access to all applications' "Print" dialogs.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-printing
 $ gsettings get org.mate.lockdown disable-printing</screen>
           </para>
@@ -1074,7 +1128,7 @@ $ gsettings get org.mate.lockdown disable-printing</screen>
         <term>disable-print-setup</term>
         <listitem>
           <para>(b) Prevent the user from modifying print settings. For example, this would disable access to all applications' "Print Setup" dialogs.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-print-setup
 $ gsettings get org.mate.lockdown disable-print-setup</screen>
           </para>
@@ -1084,7 +1138,7 @@ $ gsettings get org.mate.lockdown disable-print-setup</screen>
         <term>disable-user-switching</term>
         <listitem>
           <para>(b) Prevent the user from switching to another account while his session is active.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-user-switching
 $ gsettings get org.mate.lockdown disable-user-switching</screen>
           </para>
@@ -1094,7 +1148,7 @@ $ gsettings get org.mate.lockdown disable-user-switching</screen>
         <term>disable-lock-screen</term>
         <listitem>
           <para>(b) Prevent the user from locking the screen.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-lock-screen
 $ gsettings get org.mate.lockdown disable-lock-screen</screen>
           </para>
@@ -1104,7 +1158,7 @@ $ gsettings get org.mate.lockdown disable-lock-screen</screen>
         <term>disable-application-handlers</term>
         <listitem>
           <para>(b) Prevent running any URL or MIME type handler applications.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-application-handlers
 $ gsettings get org.mate.lockdown disable-application-handlers</screen>
           </para>
@@ -1114,7 +1168,7 @@ $ gsettings get org.mate.lockdown disable-application-handlers</screen>
         <term>disable-theme-settings</term>
         <listitem>
           <para>(b) Prevent the user from changing theme settings.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-theme-settings
 $ gsettings get org.mate.lockdown disable-theme-settings</screen>
           </para>
@@ -1124,30 +1178,32 @@ $ gsettings get org.mate.lockdown disable-theme-settings</screen>
         <term>disable-log-out</term>
         <listitem>
           <para>(b) Prevent the user from logging out.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/lockdown/disable-log-out
 $ gsettings get org.mate.lockdown disable-log-out</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.peripherals-keyboard">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.peripherals-keyboard">
     <title>Dconf Directory: /org/mate/desktop/peripherals/keyboard/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/peripherals/keyboard/
 $ gsettings list-keys org.mate.peripherals-keyboard</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>repeat</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/repeat
 $ gsettings get org.mate.peripherals-keyboard repeat</screen>
           </para>
@@ -1157,7 +1213,7 @@ $ gsettings get org.mate.peripherals-keyboard repeat</screen>
         <term>click</term>
         <listitem>
           <para>(b) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/click
 $ gsettings get org.mate.peripherals-keyboard click</screen>
           </para>
@@ -1167,7 +1223,7 @@ $ gsettings get org.mate.peripherals-keyboard click</screen>
         <term>rate</term>
         <listitem>
           <para>(i) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/rate
 $ gsettings get org.mate.peripherals-keyboard rate</screen>
           </para>
@@ -1177,7 +1233,7 @@ $ gsettings get org.mate.peripherals-keyboard rate</screen>
         <term>delay</term>
         <listitem>
           <para>(i) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/delay
 $ gsettings get org.mate.peripherals-keyboard delay</screen>
           </para>
@@ -1187,7 +1243,7 @@ $ gsettings get org.mate.peripherals-keyboard delay</screen>
         <term>click-volume</term>
         <listitem>
           <para>(i) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/click-volume
 $ gsettings get org.mate.peripherals-keyboard click-volume</screen>
           </para>
@@ -1197,7 +1253,7 @@ $ gsettings get org.mate.peripherals-keyboard click-volume</screen>
         <term>bell-mode</term>
         <listitem>
           <para>(s) possible values are "on", "off", and "custom".</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/bell-mode
 $ gsettings get org.mate.peripherals-keyboard bell-mode</screen>
           </para>
@@ -1207,7 +1263,7 @@ $ gsettings get org.mate.peripherals-keyboard bell-mode</screen>
         <term>bell-pitch</term>
         <listitem>
           <para>(i) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/bell-pitch
 $ gsettings get org.mate.peripherals-keyboard bell-pitch</screen>
           </para>
@@ -1217,7 +1273,7 @@ $ gsettings get org.mate.peripherals-keyboard bell-pitch</screen>
         <term>bell-duration</term>
         <listitem>
           <para>(i) </para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/bell-duration
 $ gsettings get org.mate.peripherals-keyboard bell-duration</screen>
           </para>
@@ -1227,7 +1283,7 @@ $ gsettings get org.mate.peripherals-keyboard bell-duration</screen>
         <term>bell-custom-file</term>
         <listitem>
           <para>(s) File name of the bell sound to be played.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/bell-custom-file
 $ gsettings get org.mate.peripherals-keyboard bell-custom-file</screen>
           </para>
@@ -1237,7 +1293,7 @@ $ gsettings get org.mate.peripherals-keyboard bell-custom-file</screen>
         <term>remember-numlock-state</term>
         <listitem>
           <para>(b) When set to true, MATE will remember the state of the NumLock LED between sessions.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/remember-numlock-state
 $ gsettings get org.mate.peripherals-keyboard remember-numlock-state</screen>
           </para>
@@ -1247,30 +1303,32 @@ $ gsettings get org.mate.peripherals-keyboard remember-numlock-state</screen>
         <term>numlock-state</term>
         <listitem>
           <para>() The remembered state of the NumLock LED.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/keyboard/numlock-state
 $ gsettings get org.mate.peripherals-keyboard numlock-state</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.peripherals-mouse">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.peripherals-mouse">
     <title>Dconf Directory: /org/mate/desktop/peripherals/mouse/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/peripherals/mouse/
 $ gsettings list-keys org.mate.peripherals-mouse</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>left-handed</term>
         <listitem>
           <para>(b) Swap left and right mouse buttons for left-handed mice.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/left-handed
 $ gsettings get org.mate.peripherals-mouse left-handed</screen>
           </para>
@@ -1280,7 +1338,7 @@ $ gsettings get org.mate.peripherals-mouse left-handed</screen>
         <term>motion-acceleration</term>
         <listitem>
           <para>(d) Acceleration multiplier for mouse motion.  A value of -1 is the system default.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/motion-acceleration
 $ gsettings get org.mate.peripherals-mouse motion-acceleration</screen>
           </para>
@@ -1290,7 +1348,7 @@ $ gsettings get org.mate.peripherals-mouse motion-acceleration</screen>
         <term>motion-threshold</term>
         <listitem>
           <para>(i) Distance in pixels the pointer must move before accelerated mouse motion is activated.  A value of -1 is the system default.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/motion-threshold
 $ gsettings get org.mate.peripherals-mouse motion-threshold</screen>
           </para>
@@ -1300,7 +1358,7 @@ $ gsettings get org.mate.peripherals-mouse motion-threshold</screen>
         <term>drag-threshold</term>
         <listitem>
           <para>(i) Distance before a drag is started.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/drag-threshold
 $ gsettings get org.mate.peripherals-mouse drag-threshold</screen>
           </para>
@@ -1310,7 +1368,7 @@ $ gsettings get org.mate.peripherals-mouse drag-threshold</screen>
         <term>double-click</term>
         <listitem>
           <para>(i) Length of a double click.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/double-click
 $ gsettings get org.mate.peripherals-mouse double-click</screen>
           </para>
@@ -1320,7 +1378,7 @@ $ gsettings get org.mate.peripherals-mouse double-click</screen>
         <term>middle-button-enabled</term>
         <listitem>
           <para>(b) Enables middle mouse button emulation through simultaneous left and right button click.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/middle-button-enabled
 $ gsettings get org.mate.peripherals-mouse middle-button-enabled</screen>
           </para>
@@ -1330,7 +1388,7 @@ $ gsettings get org.mate.peripherals-mouse middle-button-enabled</screen>
         <term>locate-pointer</term>
         <listitem>
           <para>(b) Highlights the current location of the pointer when the Control key is pressed and released.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/locate-pointer
 $ gsettings get org.mate.peripherals-mouse locate-pointer</screen>
           </para>
@@ -1340,7 +1398,7 @@ $ gsettings get org.mate.peripherals-mouse locate-pointer</screen>
         <term>cursor-theme</term>
         <listitem>
           <para>(s) Cursor theme name.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/cursor-theme
 $ gsettings get org.mate.peripherals-mouse cursor-theme</screen>
           </para>
@@ -1350,30 +1408,32 @@ $ gsettings get org.mate.peripherals-mouse cursor-theme</screen>
         <term>cursor-size</term>
         <listitem>
           <para>(i) Size of the cursor referenced by cursor_theme.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/peripherals/mouse/cursor-size
 $ gsettings get org.mate.peripherals-mouse cursor-size</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.sound">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.sound">
     <title>Dconf Directory: /org/mate/desktop/sound/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/sound/
 $ gsettings list-keys org.mate.sound</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>default-mixer-device</term>
         <listitem>
           <para>(s) The default mixer device used by the multimedia key bindings.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/sound/default-mixer-device
 $ gsettings get org.mate.sound default-mixer-device</screen>
           </para>
@@ -1383,7 +1443,7 @@ $ gsettings get org.mate.sound default-mixer-device</screen>
         <term>default-mixer-tracks</term>
         <listitem>
           <para>(as) The default mixer tracks used by the multimedia key bindings.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/sound/default-mixer-tracks
 $ gsettings get org.mate.sound default-mixer-tracks</screen>
           </para>
@@ -1393,7 +1453,7 @@ $ gsettings get org.mate.sound default-mixer-tracks</screen>
         <term>enable-esd</term>
         <listitem>
           <para>(b) Enable sound server startup.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/sound/enable-esd
 $ gsettings get org.mate.sound enable-esd</screen>
           </para>
@@ -1403,7 +1463,7 @@ $ gsettings get org.mate.sound enable-esd</screen>
         <term>event-sounds</term>
         <listitem>
           <para>(b) Whether to play sounds on user events.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/sound/event-sounds
 $ gsettings get org.mate.sound event-sounds</screen>
           </para>
@@ -1413,7 +1473,7 @@ $ gsettings get org.mate.sound event-sounds</screen>
         <term>theme-name</term>
         <listitem>
           <para>(s) The XDG sound theme to use for event sounds.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/sound/theme-name
 $ gsettings get org.mate.sound theme-name</screen>
           </para>
@@ -1423,30 +1483,32 @@ $ gsettings get org.mate.sound theme-name</screen>
         <term>input-feedback-sounds</term>
         <listitem>
           <para>(b) Whether to play sounds on input events.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/sound/input-feedback-sounds
 $ gsettings get org.mate.sound input-feedback-sounds</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.thumbnail-cache">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.thumbnail-cache">
     <title>Dconf Directory: /org/mate/desktop/thumbnail-cache/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/thumbnail-cache/
 $ gsettings list-keys org.mate.thumbnail-cache</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>maximum-age</term>
         <listitem>
           <para>(i) Maximum age for thumbnails in the cache, in days. Set to -1 to disable cleaning.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/thumbnail-cache/maximum-age
 $ gsettings get org.mate.thumbnail-cache maximum-age</screen>
           </para>
@@ -1456,30 +1518,32 @@ $ gsettings get org.mate.thumbnail-cache maximum-age</screen>
         <term>maximum-size</term>
         <listitem>
           <para>(i) Maximum size of the thumbnail cache, in megabytes. Set to -1 to disable cleaning.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/thumbnail-cache/maximum-size
 $ gsettings get org.mate.thumbnail-cache maximum-size</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.thumbnailers">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.thumbnailers">
     <title>Dconf Directory: /org/mate/desktop/thumbnailers/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/thumbnailers/
 $ gsettings list-keys org.mate.thumbnailers</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>disable-all</term>
         <listitem>
           <para>(b) Set to true to disable all external thumbnailer programs, independent on whether they are independently disabled/enabled.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/thumbnailers/disable-all
 $ gsettings get org.mate.thumbnailers disable-all</screen>
           </para>
@@ -1489,30 +1553,32 @@ $ gsettings get org.mate.thumbnailers disable-all</screen>
         <term>disable</term>
         <listitem>
           <para>(as) Thumbnails will not be created for files whose mime-type is contained in the list.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/thumbnailers/disable
 $ gsettings get org.mate.thumbnailers disable</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-  <sect2 id="org.mate.typing-break">
+  </section>
+  <section xmlns:its="http://www.w3.org/2005/11/its" xml:id="org.mate.typing-break">
     <title>Dconf Directory: /org/mate/desktop/typing-break/</title>
     <para>To obtain the list of dconf keys, run one of the following commands:</para>
-    <para>
+    <para its:translate="no">
       <screen>$ dconf list /org/mate/desktop/typing-break/
 $ gsettings list-keys org.mate.typing-break</screen>
     </para>
     <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
     <variablelist>
-      <title>List of dconf keys</title>
+      <info>
+        <title>List of dconf keys</title>
+      </info>
       <varlistentry>
         <term>type-time</term>
         <listitem>
           <para>(i) Number of minutes of typing time before break mode starts.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/typing-break/type-time
 $ gsettings get org.mate.typing-break type-time</screen>
           </para>
@@ -1522,7 +1588,7 @@ $ gsettings get org.mate.typing-break type-time</screen>
         <term>break-time</term>
         <listitem>
           <para>(i) Number of minutes that the typing break should last.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/typing-break/break-time
 $ gsettings get org.mate.typing-break break-time</screen>
           </para>
@@ -1532,7 +1598,7 @@ $ gsettings get org.mate.typing-break break-time</screen>
         <term>allow-postpone</term>
         <listitem>
           <para>(b) Whether or not the typing break screen can be postponed.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/typing-break/allow-postpone
 $ gsettings get org.mate.typing-break allow-postpone</screen>
           </para>
@@ -1542,12 +1608,12 @@ $ gsettings get org.mate.typing-break allow-postpone</screen>
         <term>enabled</term>
         <listitem>
           <para>(b) Whether or not keyboard locking is enabled.</para>
-          <para>
+          <para its:translate="no">
             <screen>$ dconf read /org/mate/desktop/typing-break/enabled
 $ gsettings get org.mate.typing-break enabled</screen>
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
-  </sect2>
-</sect1>
+  </section>
+</section>

--- a/mate-user-guide/C/gosdconfkeys.xsl
+++ b/mate-user-guide/C/gosdconfkeys.xsl
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:its="http://www.w3.org/2005/11/its">
 <xsl:output method="xml" omit-xml-declaration="yes" />
 <xsl:template match="schema[key]">
-  <sect2><xsl:attribute name="id"><xsl:value-of select="@id" /></xsl:attribute>
+  <section><xsl:attribute name="xml:id"><xsl:value-of select="@id" /></xsl:attribute>
     <title>Dconf Directory: <xsl:value-of select="@path" /></title>
      <para>To obtain the list of dconf keys, run one of the following commands:</para>
-     <para><screen><xsl:text disable-output-escaping="yes">$ dconf list </xsl:text><xsl:value-of select="@path" />
+     <para its:translate="no"><screen><xsl:text disable-output-escaping="yes">$ dconf list </xsl:text><xsl:value-of select="@path" />
 <xsl:text>&#xa;</xsl:text><xsl:text disable-output-escaping="yes">$ gsettings list-keys </xsl:text><xsl:value-of select="@id" /></screen></para>
      <para>In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available.
            The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands.</para>
-     <variablelist>
-       <title>List of dconf keys</title>
+     <variablelist><info><title>List of dconf keys</title></info>
        <xsl:for-each select="key">
          <varlistentry>
            <term><xsl:value-of select="@name"/></term>
            <listitem><para>(<xsl:value-of select="@type"/>) <xsl:value-of select="description"/></para>
-             <para><screen><xsl:text disable-output-escaping="yes">$ dconf read </xsl:text><xsl:value-of select="../@path" /><xsl:value-of select="@name"/>
+             <para its:translate="no"><screen><xsl:text disable-output-escaping="yes">$ dconf read </xsl:text><xsl:value-of select="../@path" /><xsl:value-of select="@name"/>
 <xsl:text>&#xa;</xsl:text><xsl:text disable-output-escaping="yes">$ gsettings get </xsl:text><xsl:value-of select="../@id" /><xsl:text> </xsl:text><xsl:value-of select="@name"/></screen></para>
            </listitem>
          </varlistentry>
        </xsl:for-each>
     </variablelist>
-  </sect2>
+  </section>
 </xsl:template>
 </xsl:stylesheet>

--- a/mate-user-guide/C/goseditmainmenu.xml
+++ b/mate-user-guide/C/goseditmainmenu.xml
@@ -1,13 +1,18 @@
-<chapter id="menubar">
-  <title>Using the Main Menubar</title>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         version="5.0" xml:id="menubar" xml:lang="en">
+    <info><title>Using the Main Menubar</title></info>
   
   <!-- preserve id for backwards compatibility: 2.12 -->
-  <anchor id="goseditmainmenu-1"/><!-- Working With Menus -->
-  <anchor id="goseditmainmenu-2"/><!-- Introduction to Menus -->  
-  <anchor id="goseditmainmenu-5"/><!-- Menu Features -->
-  <anchor id="goseditmainmenu-11"/><!-- Menu Item Popup Menu -->
-  <anchor id="goseditmainmenu-51"/><!-- Actions Menu -->
-  <anchor id="menus-introduction"/><!-- Introduction to Menus --> 
+  <anchor xml:id="goseditmainmenu-1"/><!-- Working With Menus -->
+  <anchor xml:id="goseditmainmenu-2"/><!-- Introduction to Menus -->  
+  <anchor xml:id="goseditmainmenu-5"/><!-- Menu Features -->
+  <anchor xml:id="goseditmainmenu-11"/><!-- Menu Item Popup Menu -->
+  <anchor xml:id="goseditmainmenu-51"/><!-- Actions Menu -->
+  <anchor xml:id="menus-introduction"/><!-- Introduction to Menus --> 
         
   <highlights>
     <para>This chapter describes how to use the MATE Panel Menubar.</para>
@@ -30,10 +35,9 @@
   <para>The following sections describe these three menus.</para>
   <tip><para>By default, the panel menubar is on the <xref linkend="top-panel"/>. But like any other panel object, you can move the menubar to another panel, or have more than one instance of the menubar in your panels. For more on this, see <xref linkend="panel-menus"/>.</para></tip>
 
-  <section id="applications-menu">
-    <title>Applications Menu</title>
+  <section xml:id="applications-menu"><info><title>Applications Menu</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goseditmainmenu-8"/>     
+    <anchor xml:id="goseditmainmenu-8"/>
     <indexterm>
       <primary>menus</primary>
       <secondary>Applications menu</secondary>
@@ -48,8 +52,8 @@
     </orderedlist>
     <para>When you install a new application, it is automatically added to the <guimenu>Applications</guimenu> menu in a suitable category. For example, if you install an instant messenger application, a VoIP application, or an FTP client, you will find it in the <guimenu>Internet</guimenu> submenu.</para>
   </section>
-  <section id="places-menu">
-    <title>Places Menu</title>
+
+  <section xml:id="places-menu"><info><title>Places Menu</title></info>
     <indexterm>
       <primary>Places menu</primary>
     </indexterm>
@@ -67,12 +71,12 @@
                    
     <itemizedlist>          
       <listitem><para><guimenuitem>Connect to Server</guimenuitem> lets you choose a server on your network. For more on this, see <xref linkend="caja-server-connect"/>.</para></listitem>
-      <listitem><para><guimenuitem>Search for Files</guimenuitem> lets you search for files on your computer. For more on this, see the <ulink type="help" url="help:mate-search-tool">Search for Files Manual</ulink>.</para></listitem>
+      <listitem><para><guimenuitem>Search for Files</guimenuitem> lets you search for files on your computer. For more on this, see the <link xlink:href="help:mate-search-tool">Search for Files Manual</link>.</para></listitem>
       <listitem><para>The <guimenuitem>Recent Documents</guimenuitem> submenu lists the documents you have recently opened. The last entry in the submenu clears the list.</para></listitem>                  
     </itemizedlist>                
   </section>
-  <section id="desktop-menu">
-    <title>System Menu</title>  
+
+  <section xml:id="desktop-menu"><info><title>System Menu</title></info>
     <indexterm>
       <primary>System Menu</primary>
     </indexterm>
@@ -88,11 +92,11 @@
      
      <para>For more on logging out and shutting down, see <xref linkend="shutdown"/>.</para> 
 
-  </section>    
-  <section id="menu-editor">
-    <title>Customizing the Panel Menubar</title>
+  </section>
+
+  <section xml:id="menu-editor"><info><title>Customizing the Panel Menubar</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="goseditmainmenu-54"/>          
+    <anchor xml:id="goseditmainmenu-54"/>
     <indexterm>
       <primary>menus</primary>
       <secondary>customizing</secondary>

--- a/mate-user-guide/C/gosfeedback.xml
+++ b/mate-user-guide/C/gosfeedback.xml
@@ -1,11 +1,15 @@
-  <appendix id="feedback">
-    <title>Feedback</title>
-    <para>This section contains information on reporting bugs in MATE, making suggestions and comments about MATE applications or documentation, and ways in which you can help MATE.</para>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<appendix xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         version="5.0" xml:id="feedback" xml:lang="en">
+    <info><title>Feedback</title></info>
     
+    <para>This section contains information on reporting bugs in MATE, making suggestions and comments about MATE applications or documentation, and ways in which you can help MATE.</para>
 
-    <section id="feedback-bugs">
-    <title>Reporting Bugs</title>
-    <!-- NOTE TO TRANSLATORS: This section is material taken from mate-desktop/desktop-docs/mate-feedback/ Look for existing translations there before translating it all over again :) -->
+    <section xml:id="feedback-bugs"><info><title>Reporting Bugs</title></info>
+      <!-- NOTE TO TRANSLATORS: This section is material taken from mate-desktop/desktop-docs/mate-feedback/ Look for existing translations there before translating it all over again :) -->
       <para>
      If you have found a bug in a MATE application, please
    report it! Developers do read all the bug reports and try to fix
@@ -19,42 +23,36 @@
       </para>
       <para>
 	You can also submit bugs and browse the list of known bugs by
-	connecting to the <ulink type="http"
-	url="https://github.com/mate-desktop/">MATE bug tracking
-	database</ulink>.  You will need to register before you can
-	submit any bugs this way. 
+	connecting to the <link xlink:href="https://github.com/mate-desktop/">MATE bug tracking
+	database</link>.  You will need to register before you can submit any bugs this way. 
       </para>
       
       <para>
 	Please note that some of MATE applications are developed outside of MATE, or by
 	commercial companies (these products are still free
 	software). For example, <application>blueman</application>, a
-	bluetooth application, is developed at <ulink type="http"
-    url="https://github.com/blueman-project/blueman/">GitHub</ulink>. Bug reports and
+	bluetooth application, is developed at <link xlink:href="https://github.com/blueman-project/blueman/">GitHub</link>. Bug reports and
 	comments about these products should be directed to the
 	respective organization or company. If you are using <application>Bug 
 	Buddy</application>, it will automatically send bug reports to
 	the correct database.
 	</para>
 
-
     </section>
-    <section id="feedback-wishlist"> 
-      <title>Suggestions and Comments</title> 
+
+    <section xml:id="feedback-wishlist"><info><title>Suggestions and Comments</title></info> 
       <!-- NOTE TO TRANSLATORS: This section is material taken from mate-desktop/desktop-docs/mate-feedback/ Look for existing translations there before translating it all over again :) -->      
       <para> 
 	If you have a suggestion or want to request a new feature for
       one of the applications, it can also be done using the bug
       tracking database. Submit your suggestion as a bug report as
-      described in <xref linkend="feedback-bugs" /> and at the appropriate
+      described in <xref linkend="feedback-bugs"/> and at the appropriate
       step select <guilabel>Severity: Enhancement</guilabel>. 
       </para>
     </section>
 
-      <section id="feedback-docs">
-      <title>Documentation Comments</title>
+    <section xml:id="feedback-docs"><info><title>Documentation Comments</title></info>
       <!-- NOTE TO TRANSLATORS: This section is material taken from mate-desktop/desktop-docs/mate-feedback/ Look for existing translations there before translating it all over again :) -->      
-
       <para> If you found an inaccuracy or misprint in one of MATE
 	documents, or have any comments or suggestions about
 	documentation, please let us know! The easiest way of doing so
@@ -68,22 +66,16 @@
       </para>
       <para>
 	Alternatively, you can just send your comments by email to the
-	<ulink type="http"
-	url="http://ml.mate-desktop.org/listinfo">MATE
-	Documentation Project</ulink> mailing list.
+	<link xlink:href="http://ml.mate-desktop.org/listinfo">MATE
+	Documentation Project</link> mailing list.
       </para>
     </section>
     <!-- NOTE TO TRANSLATORS: end of old material -->
 
-
-    <section id="joinmate">
-      <title>Joining the MATE Project</title>
+    <section xml:id="joinmate"><info><title>Joining the MATE Project</title></info>
       <para>We hope you enjoy using MATE and that you find working with MATE productive. However, there is always room for improvement.</para>
       <para>MATE invites you to join our free software community if you have some spare time. There are many different fields. MATE needs programmers, but it also needs translators, documentation writers, testers, artists, writers, and more.</para>
-      <para>For more information on joining MATE, please visit <ulink type="http" url="http://live.gnome.org/JoinMate">http://live.gnome.org/JoinMate</ulink>.</para>
-      <para>For more information on giving feedback on MATE, such as bug reports, suggestions, and corrections to documentation, see <xref linkend="feedback-bugs" />.</para>
-
+      <para>For more information on joining MATE, please visit <link xlink:href="http://live.gnome.org/JoinMate">http://live.gnome.org/JoinMate</link>.</para>
+      <para>For more information on giving feedback on MATE, such as bug reports, suggestions, and corrections to documentation, see <xref linkend="feedback-bugs"/>.</para>
     </section>
-  
-
   </appendix>

--- a/mate-user-guide/C/gosoverview.xml
+++ b/mate-user-guide/C/gosoverview.xml
@@ -1,20 +1,22 @@
-<!-- -*- indent-tabs-mode: nil -*- -->
-<chapter id="overview">
-<title>Desktop Overview</title>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         version="5.0" xml:id="overview" xml:lang="en">
+    <info><title>Desktop Overview</title></info>
 
 <!-- Maintained for 2.8 compatibility -->
-<anchor id="gosoverview-1"/>
+<anchor xml:id="gosoverview-1"/>
 
 <!-- MOVE THESE ANCHORS -->
 <!-- Desktop Overview / To Find Out More -->
-<anchor id="gosoverview-12"/>
+<anchor xml:id="gosoverview-12"/>
 <!-- Desktop Overview / To Find Out More / About MATE Desktop Topics -->
-<anchor id="gosoverview-31"/>
+<anchor xml:id="gosoverview-31"/>
 <!-- Desktop Overview / To Find Out More / About Applets -->
-<anchor id="gosgetstarted-33"/>
+<anchor xml:id="gosgetstarted-33"/>
 <!-- Desktop Overview / To Find Out More / About Applications -->
-<anchor id="gosgetstarted-35"/>
-
+<anchor xml:id="gosgetstarted-35"/>
 
 <highlights>
   <para>This chapter introduces you to some of the very basic components of the desktop. These components include <glossterm>Windows</glossterm>, <glossterm>Workspaces</glossterm>, and <glossterm>Applications</glossterm>. Almost all the work (or play) that you do in MATE will involve these very basic components.</para>
@@ -26,11 +28,10 @@
   </note>
 </highlights>
 
-<section id="overview-intro">
-  <title>Introduction</title>
-
+<section xml:id="overview-intro"><info><title>Introduction</title></info>
+  
   <!-- Maintained for 2.8 compatibility -->
-  <anchor id="gosoverview-5"/>
+  <anchor xml:id="gosoverview-5"/>
 
   <indexterm>
     <primary>MATE Desktop components, introducing</primary>
@@ -106,9 +107,8 @@
   to using the various components of your desktop.</para>
 </section>
 
-<section id="overview-desktop">
-  <title>The Desktop</title>
-  <anchor id="caja-desktop"/>
+<section xml:id="overview-desktop"><info><title>The Desktop</title></info>
+  <anchor xml:id="caja-desktop"/>
   
   <para>The desktop lies behind all other components on your screen. When no windows are visible, the desktop is that part of the screen between the top and bottom panels. You can place files and folders on the desktop that you want to have easy access to.</para>
   <para>The desktop also has several special objects on it:</para>
@@ -134,11 +134,10 @@
   
 </section>
 
-<section id="overview-windows">
-  <title>Windows</title>
-
+<section xml:id="overview-windows"><info><title>Windows</title></info>
+  
   <!-- Maintained for 2.8 compatibility -->
-  <anchor id="gosoverview-18"/>
+  <anchor xml:id="gosoverview-18"/>
 
   <indexterm>
     <primary>windows</primary>
@@ -154,11 +153,9 @@
   <para>The rest of this section describes the different types of windows and how you
   can interact with them.</para>
 
-  <section id="windows-types">
-    <title>Types of Windows</title>
-
+  <section xml:id="windows-types"><info><title>Types of Windows</title></info>
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosoverview-16"/>
+    <anchor xml:id="gosoverview-16"/>
 
     <para>There are two main types of window:</para>
     
@@ -187,22 +184,20 @@
     </variablelist>
   </section>
 
-  <section id="windows-manipulating">
-
-    <title>Manipulating Windows</title>
+  <section xml:id="windows-manipulating"><info><title>Manipulating Windows</title></info>
 
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosoverview-32"/>
+    <anchor xml:id="gosoverview-32"/>
 
     <para>You can change the size and position of windows on the screen. This allows you to see more than one application and do different tasks at the same time. For example, you might want to read text on a web page while writing with a word processor, or to change to another application to do a different task or check its progress.</para> 
     
     <para>You can <firstterm>minimize</firstterm> a window if you are not currently interested in seeing it. This hides it from view. You can <firstterm>maximize</firstterm> a window to fill the whole screen so you can give it your full attention.</para> 
     
-    <para><anchor id="gosoverview-FIG-33"/>Most of these actions are carried out by using the mouse on different parts of the window's frame (see <xref linkend="mouse-actions"/> for a recap of using the mouse). The top edge of the window frame, called the <firstterm>titlebar</firstterm> because it also displays the title of the window, contains several buttons that change the way the window is displayed.</para>
+    <para><anchor xml:id="gosoverview-FIG-33"/>Most of these actions are carried out by using the mouse on different parts of the window's frame (see <xref linkend="mouse-actions"/> for a recap of using the mouse). The top edge of the window frame, called the <firstterm>titlebar</firstterm> because it also displays the title of the window, contains several buttons that change the way the window is displayed.</para>
     <para><xref linkend="fig-titlebar-anno-window"/> shows the titlebar for a typical application window. From left to right, this contains the Window Menu button, the window title, the minimize button, the maximize button, and the close button.</para>
     
-    <figure id="fig-titlebar-anno-window">
-      <title>Titlebar for a Typical Application Window</title>
+    <figure xml:id="fig-titlebar-anno-window"><info><title>Titlebar for a Typical Application Window</title></info>
+      
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -292,10 +287,9 @@
 
   </section>
 
-    <section id="windows-focus">
-      <title>Giving Focus to a Window</title>
+    <section xml:id="windows-focus"><info><title>Giving Focus to a Window</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gosoverview-20"/>       
+      <anchor xml:id="gosoverview-20"/>       
       <para>To work with an application, you need to give the <firstterm>focus</firstterm> to its window. When a window has focus, any actions such as mouse clicks, typing text, or keyboard shortcuts, are directed to the application in that window. Only one window can have focus at a time. The window that has focus will appear on top of other windows, so nothing covers any part of it. It may also have a different appearance from other windows, depending on your choice of <xref linkend="prefs-theme"/>.</para>
       <para>You can give the focus to a window in any of the following ways:</para>
       <itemizedlist>
@@ -328,11 +322,10 @@
       </itemizedlist>
     </section>
   </section>
-  <section id="overview-workspaces">
-    <title>Workspaces</title>
 
+  <section xml:id="overview-workspaces"><info><title>Workspaces</title></info>
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gosoverview-39"/>
+    <anchor xml:id="gosoverview-39"/>
 
     <indexterm>
       <primary>workspaces</primary>
@@ -342,8 +335,7 @@
 
     <para>By default, four workspaces are available. You can switch between them with the <application>Workspace Switcher</application> applet at the right of the <link linkend="bottom-panel">bottom panel</link>. This shows a representation of your workspaces, by default a row of four rectangles. Click on one to switch to that workspace. In <xref linkend="gosoverview-FIG-42"/>, <application>Workspace Switcher</application> contains four workspaces. The first three workspaces contain open windows. The last workspace does not contain currently open windows. The currently active workspace is highlighted.</para>
     
-    <figure id="gosoverview-FIG-42">
-      <title>Workspaces Displayed in Workspace Switcher</title>
+    <figure xml:id="gosoverview-FIG-42"><info><title>Workspaces Displayed in Workspace Switcher</title></info>
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -361,8 +353,7 @@
      <tip><para>Workspaces enable you to organize the MATE Desktop when you run many
 applications at the same time. One way to use workspaces is to allocate a specific function to each workspace: one for email, one for web browsing, one for graphic design, etc. However, everyone has their own preference and you are in no way restricted to only using workspaces like this.</para></tip>
     
-    <section id="gosoverview-41">
-      <title>Switching Between Workspaces</title>
+    <section xml:id="gosoverview-41"><info><title>Switching Between Workspaces</title></info>
       <indexterm>
         <primary>workspaces</primary>
         <secondary>switching between</secondary>
@@ -386,10 +377,10 @@ workspace.</para>
       </itemizedlist>
       <note><para>The arrow shortcut keys work according to how your workspaces are set out in the <application>Workspace Switcher</application> applet. If you change your panel so workspaces are displayed vertically instead of horizontally, use <keycombo><keycap>Ctrl</keycap><keycap>Alt</keycap><keycap>up arrow</keycap></keycombo> and <keycombo><keycap>Ctrl</keycap><keycap>Alt</keycap><keycap>down arrow</keycap></keycombo> to switch workspaces.</para></note>
     </section>
-    <section id="workspace-add">
-      <title>Adding Workspaces</title>
+    <section xml:id="workspace-add"><info><title>Adding Workspaces</title></info>
+      
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gosoverview-40"/>         
+      <anchor xml:id="gosoverview-40"/>         
       <indexterm>
         <primary>workspaces</primary>
         <secondary>specifying number of</secondary>
@@ -400,10 +391,10 @@ specify the number of workspaces that you require.</para>
     </section>
   </section>
   
-  <section id="overview-applications">
-    <title>Applications</title>
+  <section xml:id="overview-applications"><info><title>Applications</title></info>
+    
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="gosoverview-54"/>       
+    <anchor xml:id="gosoverview-54"/>       
     <indexterm>
       <primary>applications</primary>
       <secondary>overview</secondary>
@@ -416,21 +407,19 @@ specify the number of workspaces that you require.</para>
     <para>The applications that are part of MATE include the following:</para>
     
     <itemizedlist>
-      <listitem><para><ulink type="help" url="help:pluma"><application>Pluma Text Editor</application></ulink> can read, create, or modify any kind of simple text without any formatting.</para></listitem>
-      <listitem><para><ulink type="help" url="help:mate-dictionary"><application>Dictionary</application></ulink> allows you to look up definitions of a word. </para></listitem>
-      <listitem><para><ulink type="help" url="help:eom"><application>Image Viewer</application></ulink> can display single image files, as well as large image collections.</para></listitem>
-      <listitem><para><ulink type="help" url="help:gucharmap"><application>Character Map</application></ulink> lets you choose letters and symbols from the <firstterm>Unicode</firstterm> character set and paste them into any application. If you are writing in several languages, not all the characters you need will be on your keyboard.</para></listitem>
+      <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:pluma" type="help"><application>Pluma Text Editor</application></link> can read, create, or modify any kind of simple text without any formatting.</para></listitem>
+      <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:mate-dictionary" type="help"><application>Dictionary</application></link> allows you to look up definitions of a word. </para></listitem>
+      <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:eom" type="help"><application>Image Viewer</application></link> can display single image files, as well as large image collections.</para></listitem>
+      <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:gucharmap" type="help"><application>Character Map</application></link> lets you choose letters and symbols from the <firstterm>Unicode</firstterm> character set and paste them into any application. If you are writing in several languages, not all the characters you need will be on your keyboard.</para></listitem>
       <listitem><para><link linkend="caja"><application>Caja File Manager</application></link> displays your folders and their contents. Use this to copy, move and classify your files, and to access CDs, USB flash drives, and any other removable media. When you choose an item from the <link linkend="places-menu"><guimenu>Places</guimenu> menu</link>, a <application>Caja File Manager</application> window opens showing that location.</para></listitem>
-      <listitem><para><ulink type="help" url="help:mate-terminal"><application>Terminal</application></ulink> gives you access to the system command line.</para></listitem>
+      <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:mate-terminal" type="help"><application>Terminal</application></link> gives you access to the system command line.</para></listitem>
     </itemizedlist>
 
     <para>Further standard MATE applications include games, music and video players, a web browser, software accessibility tools, and utilities to manage your system. Your distributor or vendor may have added other applications, such as a word processor and a graphics editor. They may also provide you with a way to install further applications.</para>
     
     <para>All MATE applications have many features in common, which makes it easier to learn how to work with a new MATE application. The rest of this section describes some of these features.</para>
 
-    <section id="overview-lookandfeel">
-      <title>Common Features</title>
-    
+    <section xml:id="overview-lookandfeel"><info><title>Common Features</title></info>
       <para>The applications that are provided with the MATE Desktop
   share many common features, such as similar open and save dialogs and similar-looking icons. This is because they have all been developed using the MATE development platform. An application developed using this platform is called a <firstterm>MATE-compliant application</firstterm>. For example, <application>Caja</application> and the <application>pluma</application> text editor are MATE-compliant applications.</para>
       <para>Some features of MATE-compliant applications are as follows:</para>
@@ -464,13 +453,13 @@ specify the number of workspaces that you require.</para>
         </listitem>
       </itemizedlist>
     </section>
-    <section id="overview-files">
-      <title>Working With Files</title>
+
+    <section xml:id="overview-files"><info><title>Working With Files</title></info>
       <para>The work you do with an application is stored in <firstterm>files</firstterm>. These may be on your computer's hard drive, or on a removable device such as a USB flash drive. You <firstterm>open</firstterm>  a file to examine it or work on it, and you <firstterm>save</firstterm> a file to store your work. When you are done working with a file, you <firstterm>close</firstterm> it.</para>
       <para>All MATE applications use the same dialogs for opening and saving files, presenting you with a consistent interface. The following sections cover the open and the save dialog in detail.</para>
     </section>
-    <section id="filechooser-open">
-      <title>Choosing a File to Open</title>
+
+    <section xml:id="filechooser-open"><info><title>Choosing a File to Open</title></info>
       <para>The <guilabel>Open File</guilabel> dialog allows you to choose a file to open in an application.</para>
       <para>The right-hand pane of the dialog lists files and folders in the current location. You can use the mouse or the arrow keys on your keyboard to select a file.</para>
       <para>Once a file is selected in the list, perform one of the following actions to open it:</para>
@@ -491,24 +480,20 @@ specify the number of workspaces that you require.</para>
       
       <para>The lower part of the <guilabel>Open File</guilabel> dialog may contain further options specific to the current application.</para>
               
-      <section id="filechooser-open-filter">
-        <title>Filtering the File List</title>
+      <section xml:id="filechooser-open-filter"><info><title>Filtering the File List</title></info>
         <para>You can restrict the file list to show only files of certain types. To do this, choose a file type from the drop-down list beneath the file list pane. The list of file types depends on the application you are currently using. For example, a graphics application will list different image file formats, and a text editor will list different types of text file.</para>
       </section>
       
-      <section id="filechooser-open-find">
-        <title>Find-as-you-type</title>
+      <section xml:id="filechooser-open-find"><info><title>Find-as-you-type</title></info>
           <para>If you know the name of the file you want to open, begin typing it: the file list will jump to show you files whose names begin with the characters you type. Arrow keys will now select from only these files. The characters you have typed appear in a pop-up window at the base of the file list.</para>
           <para>To cancel find-as-you-type, press <keycap>Esc</keycap>.</para>    
       </section>
       
-      <section id="filechooser-open-folder">
-        <title>Choosing a folder</title> 
-        <para>You might sometimes need to choose a folder to work with rather than open a file. For example, if you use <ulink type="help" url="help:engrampa"><application>Archive Manager</application></ulink> to extract files from an archive, you need to choose a folder to place the files into. In this case, the files in the current location are greyed out, and pressing <guibutton>Open</guibutton> when a folder is selected will choose that folder.</para>
+      <section xml:id="filechooser-open-folder"><info><title>Choosing a folder</title></info>
+        <para>You might sometimes need to choose a folder to work with rather than open a file. For example, if you use <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:engrampa" type="help"><application>Archive Manager</application></link> to extract files from an archive, you need to choose a folder to place the files into. In this case, the files in the current location are greyed out, and pressing <guibutton>Open</guibutton> when a folder is selected will choose that folder.</para>
       </section>      
            
-      <section id="filechooser-open-location">
-        <title>Open Location</title>
+      <section xml:id="filechooser-open-location"><info><title>Open Location</title></info>
         <para>You can type a full or relative path to the file you want to open. Press <keycombo><keycap>Ctrl</keycap><keycap>L</keycap></keycombo> or click the button at the top left of the window to show (or hide) the <guilabel>Location</guilabel> field. Alternatively, begin typing a full path starting with <filename>/</filename> to show the <guilabel>Location</guilabel> field.</para>
         <para>Type a path from the current location, or an absolute path beginning with <filename>/</filename> or <filename>~/</filename>. The <guilabel>Location</guilabel> field has the following features to simplify the typing of a full filename:</para>
         <itemizedlist>
@@ -517,46 +502,40 @@ specify the number of workspaces that you require.</para>
         </itemizedlist>
       </section>
       
-      <section id="filechooser-open-remote">
-        <title>Opening Remote Locations</title>
+      <section xml:id="filechooser-open-remote"><info><title>Opening Remote Locations</title></info>
         <para>You can open files in remote locations by choosing the location from the left panel, or by typing a path to a remote location into the <guilabel>Location</guilabel> field.</para>
         <para>If you require a password to access the remote location, you will be asked for it when you open it.</para>
       </section> 
                    
-      <section id="filechooser-open-bookmarks">
-        <title>Adding and Removing Bookmarks</title>
+      <section xml:id="filechooser-open-bookmarks"><info><title>Adding and Removing Bookmarks</title></info>
         <para>To add the current location to the bookmarks list, press <guibutton>Add</guibutton>, or right-click a folder in the file list and choose <guimenuitem>Add to Bookmarks</guimenuitem>. You can add any folder that is listed in the current location by dragging it to the bookmarks list.</para>
         <para>To remove a bookmark from the list, select it and press <guibutton>Remove</guibutton>.</para>
         <note><para>Changes you make to the bookmarks list also affect the <guimenu>Places</guimenu> menu. For more on bookmarks, see <xref linkend="caja-bookmarks"/>.</para></note>
       </section>      
-      <section id="filechooser-open-hidden">
-        <title>Showing hidden files</title>
+
+      <section xml:id="filechooser-open-hidden"><info><title>Showing hidden files</title></info>
           <para>To show hidden files in the file list, right-click in the file list and choose <guimenuitem>Show Hidden Files</guimenuitem>. For more on hidden files, see <xref linkend="caja-managing-hidden-files"/>.</para>
       </section>
     </section>
-    <section id="filechooser-save">
-      <title>Saving a File</title>
+
+    <section xml:id="filechooser-save"><info><title>Saving a File</title></info>
         <para>The first time you save your work in an application, the <guilabel>Save As</guilabel> dialog will ask you for a location and name for the new file. When you save the file on subsequent occasions it will be updated immediately and you will not be asked to re-enter a location or name for the file. To save to a new file, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Save As</guimenuitem></menuchoice>.</para>
         <para>You can enter a filename and choose a location to save in from the drop-down list of bookmarks and commonly-used locations.</para>
                           
-        <section id="filechooser-save-expanded">
-          <title>Saving in another location</title>
+        <section xml:id="filechooser-save-expanded"><info><title>Saving in another location</title></info>
           <para>To save the file in a location not listed in the drop-down list, click the <guilabel>Browse for other folders</guilabel> expansion label. This shows a file browser similar to the one in the <guilabel>Open File</guilabel> dialog.</para>
           <tip><para>The expanded <guilabel>Save File</guilabel> dialog has the same features as the <link linkend="filechooser-open"><guilabel>Open File</guilabel> dialog</link>, such as filtering, find-as-you-type, and adding and removing bookmarks.</para></tip>
         </section>   
         
-        <section id="filechooser-save-overwrite">
-          <title>Replacing an existing file</title>
+        <section xml:id="filechooser-save-overwrite"><info><title>Replacing an existing file</title></info>
           <para>If you type in the name of an existing file, you will be asked whether you wish to replace the existing file with your current work. You can also do this by choosing the file you want to overwrite in the browser.</para>
         </section>         
                
-        <section id="filechooser-save-path">
-          <title>Typing a Path</title>
+        <section xml:id="filechooser-save-path"><info><title>Typing a Path</title></info>
           <para>To specify a path to save a file, type it into the <guilabel>Name</guilabel> field. A drop-down of possible file and folder names is displayed once you begin typing. Use <keycap>down arrow</keycap> and <keycap>up arrow</keycap> and <keycap>Return</keycap> to choose from the list. If only one file or folder matches the partial name you have typed, press <keycap>Tab</keycap> to complete the name.</para>       
         </section>
         
-        <section id="filechooser-save-newfolder">
-          <title>Creating a New Folder</title>
+        <section xml:id="filechooser-save-newfolder"><info><title>Creating a New Folder</title></info>
           <para>If you would like to create a new folder to save your file in, press the <guibutton>Create Folder</guibutton> button. Type a name for the new folder and press <keycap>Return</keycap>. You can then choose to save your file in the new folder, as you would with any other folder.</para>
         </section>
     </section>

--- a/mate-user-guide/C/gospanel.xml
+++ b/mate-user-guide/C/gospanel.xml
@@ -1,21 +1,25 @@
-<chapter id="panels">
-  <title>Using the Panels</title>
-
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         version="5.0" xml:id="panels" xml:lang="en">
+    <info><title>Using the Panels</title></info>
+  
   <!-- Maintained for 2.8 compatibility -->
-  <anchor id="gospanel-1"/>
+  <anchor xml:id="gospanel-1"/>
 
   <!-- Desktop Overview / Panels -->
-  <anchor id="gosoverview-502"/>
+  <anchor xml:id="gosoverview-502"/>
 
   <highlights>
     <para>This chapter describes how to use the panels at the top and bottom of the MATE Desktop, how to customize the objects that appear on them, and how to add new panels to the desktop.</para>
   </highlights>
 
-  <section id="panels-intro">
-    <title>Introduction</title>
-
+  <section xml:id="panels-intro"><info><title>Introduction</title></info>
+    
     <!-- Maintained for 2.8 compatibility -->
-    <anchor id="gospanel-2"/>
+    <anchor xml:id="gospanel-2"/>
 
     <indexterm>
       <primary>panels</primary>
@@ -28,10 +32,9 @@
 and a panel at the bottom edge of the screen. The following sections describe
 these panels.</para>
 
-    <section id="top-panel">
-      <title>Top Edge Panel</title>
+    <section xml:id="top-panel"><info><title>Top Edge Panel</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-6"/>         
+      <anchor xml:id="gospanel-6"/>         
       <indexterm>
         <primary>panels</primary>
         <secondary>top edge panel</secondary>
@@ -64,7 +67,7 @@ these panels.</para>
         <varlistentry>
           <term><application>Clock</application> applet</term>
           <listitem><para>The <application>Clock</application> shows the current
-      time. Click on the time to open a small calendar. You can also view a world map by clicking the <guilabel>Locations</guilabel> expansion label. For more on this, see the <ulink type="help" url="help:mate-clock">Clock Applet Manual</ulink>.</para></listitem>
+      time. Click on the time to open a small calendar. You can also view a world map by clicking the <guilabel>Locations</guilabel> expansion label. For more on this, see the <link xlink:href="help:mate-clock">Clock Applet Manual</link>.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><application>Volume Control</application>
@@ -84,10 +87,10 @@ these panels.</para>
         </varlistentry>
       </variablelist>
     </section>
-    <section id="bottom-panel">
-      <title>Bottom Edge Panel</title>
+
+    <section xml:id="bottom-panel"><info><title>Bottom Edge Panel</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-3"/>        
+      <anchor xml:id="gospanel-3"/>        
       <indexterm>
         <primary>panels</primary>
         <secondary>bottom edge panel</secondary>
@@ -119,31 +122,30 @@ these panels.</para>
       </variablelist>
     </section>
   </section>
-  <section id="gospanel-5">
-    <title>Managing Panels</title>
 
+  <section xml:id="gospanel-5"><info><title>Managing Panels</title></info>
     <!-- Desktop Overview / Panels / To Create Panels -->
-    <anchor id="gosoverview-26"/>
-    <anchor id="gospanel-11"/><!-- To Interact With a Panel -->
+    <anchor xml:id="gosoverview-26"/>
+    <anchor xml:id="gospanel-11"/><!-- To Interact With a Panel -->
     <indexterm>
       <primary>panels</primary>
       <secondary>managing</secondary>
     </indexterm>
     <para>The following sections describe how to manage your panels.</para>
     <para>To interact with a panel, you must click on a vacant space on the panel rather than on any of the objects it holds. If the hide buttons are visible on the panel, you can also middle-click or right-click on one of them to select the panel.</para>
-    <section id="gospanel-12">
-      <title>Moving a Panel</title>
+
+    <section xml:id="gospanel-12"><info><title>Moving a Panel</title></info>
       <indexterm>
         <primary>panels</primary>
         <secondary>moving</secondary>
       </indexterm>	  
 	  <para>To move a panel to another side of the screen, press and hold <keycap>ALT</keycap> and drag the panel to its new location. Click on any vacant space on the panel to begin the drag.</para>
       <para>A panel that is not set to expand to the full width of the screen can be dragged away from the edge of the screen and placed anywhere. See <xref linkend="panel-properties"/> for details on how to set a panel's expand property.</para>
-    </section>  
-    <section id="panel-properties">
-      <title>Panel Properties</title>
+    </section>
+
+    <section xml:id="panel-properties"><info><title>Panel Properties</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-28"/>         
+      <anchor xml:id="gospanel-28"/>         
       <indexterm>
         <primary>panels</primary>
         <secondary>modifying properties</secondary>
@@ -153,8 +155,7 @@ the properties of each panel, such as the position of the panel, the hide behavi
 and the visual appearance. </para>
       <para>To modify the properties of a panel, right-click on a vacant space on the panel, then choose <guimenuitem>Properties</guimenuitem>. The <guilabel>Panel Properties</guilabel> dialog contains two tabbed sections, <guilabel>General</guilabel> and <guilabel>Background</guilabel>.</para>
       
-      <section id="panel-properties-general">
-        <title>General Properties Tab</title>
+      <section xml:id="panel-properties-general"><info><title>General Properties Tab</title></info>
         <para>In the <guilabel>General</guilabel> tab, you can modify panel size, position, and hiding properties. The following table describes the
 dialog elements on the <guilabel>General</guilabel> tabbed section: </para>
         <informaltable frame="topbot">
@@ -238,10 +239,9 @@ buttons, if the hide button is enabled.</para>
             </tbody>
           </tgroup>
         </informaltable>
-
       </section>
-      <section id="panel-properties-background">
-        <title>Background Properties Tab</title>
+
+      <section xml:id="panel-properties-background"><info><title>Background Properties Tab</title></info>
         <para>You can choose the type of background for the panel in the <guilabel>Background</guilabel> tab. The choices are as follows:</para>
         <informaltable frame="topbot">
           <tgroup cols="2" colsep="0" rowsep="0">
@@ -300,7 +300,7 @@ background. Click on the button to browse for an image file. When you have selec
         </informaltable>
         
         <!-- section folded in: preserve id for backwards compatibility: 2.12 -->
-        <anchor id="gospanel-61"/>
+        <anchor xml:id="gospanel-61"/>
         <indexterm>
           <primary>panels</primary>
           <secondary>changing background</secondary>
@@ -326,8 +326,8 @@ many applications. For example:</para>
         <para>Click <guibutton>Close</guibutton> to close the <guilabel>Panel Properties</guilabel> dialog.</para>
       </section>
     </section>
-    <section id="gospanel-7">
-      <title>Hiding a Panel</title>
+
+    <section xml:id="gospanel-7"><info><title>Hiding a Panel</title></info>
       <indexterm>
         <primary>panels</primary>
         <secondary>hiding</secondary>
@@ -357,9 +357,9 @@ buttons are now visible.</para>
 automatically when the mouse is not pointing to the panel. The panel reappears
 when you point to the part of the screen where the panel resides. To set your
 panel to autohide, <link linkend="panel-properties">modify the properties</link> of the panel.</para>
-    </section>    
-    <section id="gospanel-10">
-      <title>Adding a New Panel</title>
+    </section>
+
+    <section xml:id="gospanel-10"><info><title>Adding a New Panel</title></info>
       <indexterm>
         <primary>panels</primary>
         <secondary>adding new</secondary>
@@ -367,11 +367,11 @@ panel to autohide, <link linkend="panel-properties">modify the properties</link>
       <para>To add a panel, right-click on a vacant space on any panel, then choose <guimenuitem>New Panel</guimenuitem>. The new panel is added to the MATE Desktop. The
 new panel contains no objects. You can customize the new panel to suit your
 preferences.</para>
-    </section>    
-    <section id="gospanel-31">
-      <title>Deleting a Panel</title>
+    </section>
+
+    <section xml:id="gospanel-31"><info><title>Deleting a Panel</title></info>
       <!-- Desktop Overview / Panels / To Delete Panels -->
-      <anchor id="gosoverview-508"/>
+      <anchor xml:id="gosoverview-508"/>
       <indexterm>
         <primary>panels</primary>
         <secondary>deleting</secondary>
@@ -386,10 +386,9 @@ If you have only one panel in the MATE Desktop, you cannot delete that panel.</p
   </section>
   
   <!-- =============================================== managing panel objects -->
-  <section id="gospanel-8">
-    <title>Panel Objects</title>
+  <section xml:id="gospanel-8"><info><title>Panel Objects</title></info>
     <!-- Desktop Overview / Panels / To Manipulate Panel Objects -->
-    <anchor id="gosoverview-21"/>
+    <anchor xml:id="gosoverview-21"/>
     <indexterm>
       <primary>panels</primary>
       <secondary>panel objects</secondary>
@@ -397,8 +396,8 @@ If you have only one panel in the MATE Desktop, you cannot delete that panel.</p
     </indexterm>
     <para>This section describes the objects that
 you can add to and use from your panels.</para>
-    <section id="gospanel-100">
-      <title>Interacting With Panel Objects</title>
+    <section xml:id="gospanel-100"><info><title>Interacting With Panel Objects</title></info>
+      
       <indexterm>
         <primary>panel objects</primary>
         <secondary>interacting with</secondary>
@@ -428,8 +427,7 @@ popup menu.</para>
         </varlistentry>
       </variablelist>
 
-      <section id="gospanel-39">
-        <title>To Select an Applet</title>
+      <section xml:id="gospanel-39"><info><title>To Select an Applet</title></info>
         <indexterm>
           <primary>applets</primary>
           <secondary>selecting</secondary>
@@ -455,18 +453,15 @@ popup menu.</para>
           </listitem>
         </itemizedlist>
       </section>
-
-
     </section>
-    <section id="panels-addobject">
-      <title>Adding an Object to a Panel</title>
-      
+
+    <section xml:id="panels-addobject"><info><title>Adding an Object to a Panel</title></info>
       <!-- preserve for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-15"/>   
+      <anchor xml:id="gospanel-15"/>   
 
       <!-- Desktop Overview / Panels / To Add Objects to Panels -->
-      <anchor id="gosoverview-4"/>
-      <anchor id="gospanel-40"/><!-- To Add an Applet to a Panel -->
+      <anchor xml:id="gosoverview-4"/>
+      <anchor xml:id="gospanel-40"/><!-- To Add an Applet to a Panel -->
       <indexterm>
         <primary>panel objects</primary>
         <secondary>adding</secondary>
@@ -488,19 +483,17 @@ popup menu.</para>
         </para></listitem>
       </orderedlist>
       
-      
       <para>You can also add any item in the <guimenu>Applications</guimenu> menu to the panel: right-click the menu item and choose <guimenuitem>Add this launcher to panel</guimenuitem>.</para>
 
       <para>Each launcher corresponds to a <filename>.desktop</filename> file. You
 can drag a <filename>.desktop</filename> file on to your panels to add the
 launcher to the panel. </para>
 <!--Each menu corresponds to a directory. You can drag the directory on to your panels to add the directory to the panel as a menu object. Is this still true?-->
-
     </section>
-    <section id="gospanel-9">
-      <title>Modifying the Properties of an Object</title>
+
+    <section xml:id="gospanel-9"><info><title>Modifying the Properties of an Object</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-41"/><!-- To Modify Preferences for an Applet -->
+      <anchor xml:id="gospanel-41"/><!-- To Modify Preferences for an Applet -->
       <indexterm>
         <primary>panel objects</primary>
         <secondary>modifying properties</secondary>
@@ -516,8 +509,8 @@ type of object. The properties specify details such as the following: <itemizedl
           </indexterm>
           <para>Right-click on the object to open the panel object popup
 menu, as shown in <xref linkend="gospanel-FIG-54"/>.</para>
-          <figure id="gospanel-FIG-54">
-            <title>Panel Object Popup Menu</title>
+          <figure xml:id="gospanel-FIG-54"><info><title>Panel Object Popup Menu</title></info>
+            
             <screenshot>
               <mediaobject>
                 <imageobject>
@@ -540,8 +533,8 @@ in step 1. </para>
         </listitem>
       </orderedlist>
     </section>
-    <section id="gospanel-32">
-      <title>Moving a Panel Object</title>
+
+    <section xml:id="gospanel-32"><info><title>Moving a Panel Object</title></info>
       <indexterm>
         <primary>panel objects</primary>
         <secondary>moving</secondary>
@@ -626,8 +619,8 @@ further along the panel. </para>
         </tgroup>
       </informaltable>
     </section>
-    <section id="gospanel-566">
-      <title>Locking a Panel Object</title>
+
+    <section xml:id="gospanel-566"><info><title>Locking a Panel Object</title></info>
       <indexterm>
         <primary>panel objects</primary>
         <secondary>locking</secondary>
@@ -641,8 +634,8 @@ to change position when you move other panel objects.</para>
       <para>To lock an object to its current location in the panel,
 right-click on the object to open the panel object popup menu, then select  <guimenuitem>Lock To Panel</guimenuitem>. Deselect this to unlock the object.</para>
     </section>
-    <section id="gospanel-33">
-      <title>Removing a Panel Object</title>
+
+    <section xml:id="gospanel-33"><info><title>Removing a Panel Object</title></info>
       <indexterm>
         <primary>panel objects</primary>
         <secondary>removing</secondary>
@@ -658,8 +651,7 @@ Panel</guimenuitem>. </para>
     <para>This section describes the different objects you can add to your panels.</para>
     <para>For a list of the objects that are on the top and bottom panels by default, see <xref linkend="top-panel"/> and <xref linkend="bottom-panel"/>.</para>
   -->
-  <section id="gospanel-17">
-    <title>Applets</title>
+  <section xml:id="gospanel-17"><info><title>Applets</title></info>
     <indexterm>
       <primary>applets</primary>
       <secondary>introduction</secondary>
@@ -682,7 +674,7 @@ currently open on your system.</para>
 control the volume of the speaker on your system.</para>
       </listitem>
       <listitem>
-        <para><ulink type="help" url="help:mate-clock"><application>Clock</application></ulink>: Shows the current date and time.</para>
+        <para><link xlink:href="help:mate-clock"><application>Clock</application></link>: Shows the current date and time.</para>
       </listitem>
     </itemizedlist>
     <screenshot>
@@ -697,10 +689,9 @@ control the volume of the speaker on your system.</para>
     </screenshot>
   </section>  
 
-  <section id="launchers">
-    <title>Launchers</title>
+  <section xml:id="launchers"><info><title>Launchers</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="gospanel-16"/>
+    <anchor xml:id="gospanel-16"/>
     <indexterm>
       <primary>panel objects</primary>
       <secondary>launchers</secondary>
@@ -737,8 +728,7 @@ launcher, and how the launcher runs. For more on this, see <xref linkend="launch
       In certain situations, a launcher in a menu might not show an icon. For example, if it specifies no icon to display, or if the entire menu is set to show no icons.
     </para></note>
 
-    <section id="gospanel-34">
-      <title>Adding a Launcher to a Panel</title>
+    <section xml:id="gospanel-34"><info><title>Adding a Launcher to a Panel</title></info>
       <indexterm>
         <primary>launchers</primary>
         <secondary>adding to panel</secondary>
@@ -774,10 +764,9 @@ Choose <guimenuitem>Add this launcher to panel</guimenuitem>. This method will o
       </itemizedlist>
     </section>
 
-    <section id="launchers-modify">
-      <title>Modifying a Launcher</title>
+    <section xml:id="launchers-modify"><info><title>Modifying a Launcher</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-36"/>        
+      <anchor xml:id="gospanel-36"/>        
       <indexterm>
         <primary>launchers</primary>
         <secondary>modifying properties</secondary>
@@ -800,11 +789,9 @@ see <xref linkend="launchers-properties"/>. </para>
       </orderedlist>
     </section>
 
-          
-    <section id="launchers-properties"> 
-      <title>Launcher Properties</title>
+    <section xml:id="launchers-properties"><info><title>Launcher Properties</title></info> 
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-52"/><!-- To Create a Launcher With the Create Launcher Dialog -->
+      <anchor xml:id="gospanel-52"/><!-- To Create a Launcher With the Create Launcher Dialog -->
          
       <para>When you create or edit a launcher, the following properties can be set:</para>
       <variablelist>
@@ -863,10 +850,9 @@ launcher icon on the panel.</para>
       
       <para>To change the icon for the launcher, click on the button showing the current icon. An icon selector dialog is displayed. Choose an icon from the dialog. </para>
   
-      <section id="launchers-properties-commands">
-        <title>Launcher Commands and Locations</title>
+      <section xml:id="launchers-properties-commands"><info><title>Launcher Commands and Locations</title></info>
         <!-- Maintained for backwards compatibility: 2.14 -->
-        <anchor id="gospanel-556"/>        
+        <anchor xml:id="gospanel-556"/>        
         <para>Examples of commands and locations that you can use in the <guilabel>Launcher Properties</guilabel> dialog can be found below.</para>
         
         <para>If you choose <guilabel>Application</guilabel> or <guilabel>Application in Terminal</guilabel>
@@ -984,8 +970,8 @@ shows some sample locations and the actions that will happen if you click on the
       </section>
     </section>    
   </section>
-  <section id="gospanel-557">
-    <title>Buttons</title>
+
+  <section xml:id="gospanel-557"><info><title>Buttons</title></info>
     <indexterm>
       <primary>buttons</primary>
       <secondary>adding to panel</secondary>
@@ -996,8 +982,8 @@ shows some sample locations and the actions that will happen if you click on the
     </indexterm>
     <para>You can add buttons to your panels to provide quick access
 to common actions and functions. </para>
-    <section id="gospanel-563">
-      <title>Force Quit Button</title>
+
+    <section xml:id="gospanel-563"><info><title>Force Quit Button</title></info>
       <indexterm>
         <primary>buttons</primary>
         <secondary>Force Quit</secondary>
@@ -1039,10 +1025,11 @@ button, then click on a window from the application that you want to terminate.
 If you do not want to terminate an application after you have clicked on the 
 <guibutton>Force Quit</guibutton> button, press <keycap>Esc</keycap>.</para>
     </section>
-    <section id="panel-lock-screen">
-      <title>Lock Screen Button</title>
+
+    <section xml:id="panel-lock-screen"><info><title>Lock Screen Button</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-21"/>         
+      <anchor xml:id="gospanel-21"/>
+
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -1075,8 +1062,7 @@ on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then c
       <para>Right-click on the <guibutton>Lock Screen</guibutton> button to open a menu
 of screensaver-related commands. <xref linkend="gosstartsession-TBL-83"/> describes
 the commands that are available from the menu.</para>
-      <table frame="topbot" id="gosstartsession-TBL-83">
-        <title>Lock Screen Menu Items</title>
+      <table frame="topbot" xml:id="gosstartsession-TBL-83"><info><title>Lock Screen Menu Items</title></info>
         <tgroup cols="2" colsep="0" rowsep="0">
           <colspec colname="colspec0" colwidth="43.55*"/>
           <colspec colname="colspec1" colwidth="56.45*"/>
@@ -1128,8 +1114,8 @@ the same function as when you click on the <guibutton>Lock Screen</guibutton> bu
         </tgroup>
       </table>
     </section>
-    <section id="gospanel-20">
-      <title>Log Out Button</title>
+
+    <section xml:id="gospanel-20"><info><title>Log Out Button</title></info>
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -1161,8 +1147,8 @@ See <xref linkend="panels-addobject"/> for more on this.</para>
       <guibutton>Log Out</guibutton> button and then click on the appropriate 
       button in the dialog that appears. </para>
     </section>
-    <section id="gospanel-555">
-      <title>Run Button</title>
+
+    <section xml:id="gospanel-555"><info><title>Run Button</title></info>
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -1196,8 +1182,8 @@ See <xref linkend="panels-addobject"/> for more on this.</para>
       <para>For more information on the <guilabel>Run Application</guilabel> dialog,
 see <xref linkend="gospanel-23"/>.</para>
     </section>
-    <section id="gospanel-554">
-      <title>Search Button</title>
+
+    <section xml:id="gospanel-554"><info><title>Search Button</title></info>
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -1227,10 +1213,10 @@ on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then c
       <para>To open the <application>Search Tool</application>, click on
 the <guibutton>Search</guibutton> button. </para>
       <para>For more information on the <application>Search Tool</application>,
-see the <ulink type="help" url="help:mate-search-tool">Search Tool Manual</ulink>.</para>
+see the <link xlink:href="help:mate-search-tool">Search Tool Manual</link>.</para>
     </section>
-    <section id="gospanel-564">
-      <title>Show Desktop Button</title>
+
+    <section xml:id="gospanel-564"><info><title>Show Desktop Button</title></info>
       <indexterm>
         <primary>buttons</primary>
         <secondary>Minimize Windows</secondary>
@@ -1264,12 +1250,12 @@ See <xref linkend="panels-addobject"/> for more on this.</para>
       their previous state, click it again.</para>
     </section>
   </section>
-  <section id="panel-menus">
-    <title>Menus</title>
 
+  <section xml:id="panel-menus"><info><title>Menus</title></info>
     <!-- Desktop Overview / Menus -->
-    <anchor id="gosoverview-42"/>
-    <anchor id="gospanel-37"/>
+    <anchor xml:id="gosoverview-42"/>
+    <anchor xml:id="gospanel-37"/>
+
     <indexterm>
       <primary>menus</primary>
       <secondary>adding to panel</secondary>
@@ -1307,10 +1293,9 @@ See <xref linkend="panels-addobject"/> for more on this.</para>
 <menuchoice><guimenu>Entire menu</guimenu><guimenuitem>Add this as menu to panel</guimenuitem></menuchoice>. </para>
       </listitem>
     </itemizedlist>
-
   </section>
-  <section id="gospanel-18">
-    <title>Drawers</title>
+
+  <section xml:id="gospanel-18"><info><title>Drawers</title></info>
     <indexterm>
       <primary>panel objects</primary>
       <secondary>drawers</secondary>
@@ -1336,8 +1321,8 @@ the objects in the same way that you use objects on a panel. </para>
 or menu.</para>
     <para>You can add, move, and remove objects from drawers in the same way that
 you add, move, and remove objects from panels. </para>
-    <section id="gospanel-42">
-      <title>To Open and Close a Drawer</title>
+
+    <section xml:id="gospanel-42"><info><title>To Open and Close a Drawer</title></info>
       <indexterm>
         <primary>drawers</primary>
         <secondary>opening</secondary>
@@ -1357,8 +1342,8 @@ a drawer in the following ways: </para>
         </listitem>
       </itemizedlist>
     </section>
-    <section id="gospanel-420">
-      <title>To Add a Drawer to a Panel</title>
+
+    <section xml:id="gospanel-420"><info><title>To Add a Drawer to a Panel</title></info>
       <indexterm>
         <primary>drawers</primary>
         <secondary>adding to panel</secondary>
@@ -1387,8 +1372,8 @@ Right-click on any launcher in the menu, then choose <menuchoice><guimenu>Entire
       </varlistentry>
       </variablelist>
     </section>
-    <section id="gospanel-54">
-      <title>To Add an Object to a Drawer</title>
+
+    <section xml:id="gospanel-54"><info><title>To Add an Object to a Drawer</title></info>
       <indexterm>
         <primary>drawers</primary>
         <secondary>adding objects to</secondary>
@@ -1396,8 +1381,8 @@ Right-click on any launcher in the menu, then choose <menuchoice><guimenu>Entire
       <para>You add an object to a drawer in the same way that you add
 objects to panels. For more information, see <xref linkend="panels-addobject"/>.</para>
     </section>
-    <section id="gospanel-550">
-      <title>To Modify Drawer Properties</title>
+
+    <section xml:id="gospanel-550"><info><title>To Modify Drawer Properties</title></info>
       <indexterm>
         <primary>drawers</primary>
         <secondary>modifying properties</secondary>
@@ -1490,16 +1475,16 @@ to set the color or image as the background of the drawer. For more information,
       </orderedlist>
     </section>
   </section>
-  <section id="panel-default">
+
+  <section xml:id="panel-default"><info><title>Default Panel Objects</title></info>
     <!-- a temporary home for things that should one day be in a greater list of panel objects -->
-    <title>Default Panel Objects</title>
     
     <para>This section covers the panel objects that appear in the default MATE desktop.</para>
     
-    <section id="panel-windowselector"> 
-      <title>Window Selector Applet</title>
+    <section xml:id="panel-windowselector"><info><title>Window Selector Applet</title></info> 
       <!-- preserve for backwards compatibility: 2.12 -->
-      <anchor id="gosmarco-27"/>   
+      <anchor xml:id="gosmarco-27"/>
+
       <indexterm>
         <primary>top edge panel</primary>
         <secondary>window selector icon</secondary>
@@ -1528,10 +1513,10 @@ all workspaces. The windows in all workspaces other than the current workspace
 are listed under a separator line.</para>
     </section>  
 
-    <section id="panels-notification-area">
-      <title>Notification Area Applet</title>
+    <section xml:id="panels-notification-area"><info><title>Notification Area Applet</title></info>
       <!-- preserve id for backwards compatibility: 2.12 -->
-      <anchor id="gospanel-567"/>         
+      <anchor xml:id="gospanel-567"/>
+
       <indexterm>
         <primary>applets</primary>
         <secondary>Notification Area</secondary>
@@ -1562,8 +1547,7 @@ applet. The graphic above illustrates the CD icon in the <application>Notificati
 Area</application> applet. </para>
     </section>
      
-    <section id="goseditmainmenu-65">
-      <title>Menu Bar</title>
+    <section xml:id="goseditmainmenu-65"><info><title>Menu Bar</title></info>
       <screenshot>
         <mediaobject>
           <imageobject>
@@ -1584,9 +1568,7 @@ Area</application> applet. </para>
 <!-- This has been pasted from the Window List manual so that the Window List applet help is integrated into the GUG. -->
 <!-- This section needs gross refactoring (making task-based for starters) -->
 
- <section id="windowlist">
-  <title>Window List</title>
-
+ <section xml:id="windowlist"><info><title>Window List</title></info>
 	 <para>The <application>Window List</application> applet enables you to manage the windows that are open on the MATE desktop. Window List uses a button to represent each window or group of windows that is open. The state of the buttons in the applet varies depending on the state of the window that the button represents. The following table explains the possible states of the <application>Window List</application> buttons.</para>
 	<informaltable>
 	<tgroup cols="2">
@@ -1620,8 +1602,7 @@ Area</application> applet. </para>
 	</informaltable>
 
 <!-- ================ Usage ================================ -->
-  <section id="windowlist-usage"> 
-	 <title>Usage</title> 
+  <section xml:id="windowlist-usage"><info><title>Usage</title></info>
 	 <para>You can use <application>Window List</application> to perform the following tasks:</para>
 	<itemizedlist>
 	<listitem>
@@ -1642,15 +1623,14 @@ Area</application> applet. </para>
 	
   </section>
 <!-- ============= Preferences ============================= -->
-  <section id="windowlist-prefs"> 
-	 <title>Preferences</title> 
+  <section xml:id="windowlist-prefs"><info><title>Preferences</title></info> 
 	 <para>To configure the <application>Window List</application>, right-click 
 	 on the handle to the left of the window buttons, then choose <guimenuitem>Preferences</guimenuitem>. 
 	 The following preferences can be changed:</para>
     
     <!-- Maintained for compatibility -->
-    <anchor id="windowlist-prefs-behavior"/>
-    <anchor id="windowlist-prefs-size"/>
+    <anchor xml:id="windowlist-prefs-behavior"/>
+    <anchor xml:id="windowlist-prefs-size"/>
     
 	 <variablelist>
 	 <varlistentry><term><guilabel>Window List Content</guilabel> </term>

--- a/mate-user-guide/C/gosstartsession.xml
+++ b/mate-user-guide/C/gosstartsession.xml
@@ -1,8 +1,12 @@
-<chapter id="sessions">
-  <title>Desktop Sessions</title>
-
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         version="5.0" xml:id="sessions" xml:lang="en">
+    <info><title>Desktop Sessions</title></info>
+  
   <!-- Maintained for 2.8 compatibility -->
-  <anchor id="gosgetstarted-1"/>
+  <anchor xml:id="gosgetstarted-1"/>
 
   <remark>Needs better intro</remark>
   <remark>This chapter needs work</remark>
@@ -11,8 +15,7 @@
     <para>This chapter provides the information you need to log in to and shut down MATE, and to start, manage, and end a desktop session.</para>
   </highlights>
 
-  <sect1 id="gosgetstarted-69">
-    <title>Starting a Session</title>
+  <section xml:id="gosgetstarted-69"><info><title>Starting a Session</title></info>
     <indexterm>
       <primary>sessions</primary>
       <secondary>starting</secondary>
@@ -41,8 +44,7 @@ manager cannot restore your editing session. </para>
     -->
     
     
-    <sect2 id="gosstartsession-85">
-      <title>Logging in to MATE</title>
+    <section xml:id="gosstartsession-85"><info><title>Logging in to MATE</title></info>
       <indexterm>
         <primary>sessions</primary>
         <secondary>logging in</secondary>
@@ -85,9 +87,9 @@ Select the option that you require, then click <guibutton>OK</guibutton>.</para>
       <guilabel>Other</guilabel> icon, or by clicking a separate 
       <guibutton>Shut Down</guibutton> button.</para>
 <!--What about failsafe mate?-->
-    </sect2>
-    <sect2 id="gosstartsession-86">
-      <title>Using a Different Language</title>
+    </section>
+
+    <section xml:id="gosstartsession-86"><info><title>Using a Different Language</title></info>
       <indexterm>
         <primary>sessions</primary>
         <secondary>different language, logging
@@ -127,12 +129,12 @@ To choose a different keyboard layout, use the
         screen so that it no longer has a <guilabel>Language</guilabel> icon. 
         In this case, the option to change the session's language may be found by clicking the <guilabel>Other</guilabel> icon.</para>
       </tip>
-    </sect2>
-  </sect1>
-  <sect1 id="lock-screen">
-    <title>Locking Your Screen</title>
+    </section>
+  </section>
+
+  <section xml:id="lock-screen"><info><title>Locking Your Screen</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="gosstartsession-1"/>        
+    <anchor xml:id="gosstartsession-1"/>        
     <screenshot>
       <mediaobject>
         <imageobject>
@@ -170,10 +172,9 @@ panel, click on the <guibutton>Lock Screen</guibutton> button.</para>
     <para>To unlock the screen, move your mouse or press any key, enter your password in the locked screen dialog, then press <keycap>Return</keycap>.</para>
     <para>If another user wants to use the computer while it is locked, they can move the mouse or press a key and then click <guibutton>Switch User</guibutton>. The login screen will be displayed, and they can log in using their user account. They will not be able to access any of your applications or information. When they log out, the screen will be locked again and you can access your session by unlocking the screen.</para>
   <para>You can leave a message for a user who has locked their screen. Move the mouse or press any key and then click <guibutton>Leave Message</guibutton>. Type your message into the box and press <guibutton>Save</guibutton>. Your message will be displayed when the user unlocks their screen.</para>
-  </sect1>
+  </section>
 
-  <sect1 id="gosstartsession-2">
-    <title>Setting Programs to Start Automatically When You Log In</title>
+  <section xml:id="gosstartsession-2"><info><title>Setting Programs to Start Automatically When You Log In</title></info>
     <indexterm>
       <primary>preference tools</primary>
       <secondary>Sessions</secondary>
@@ -193,11 +194,10 @@ panel, click on the <guibutton>Lock Screen</guibutton> button.</para>
   tabs, the <guilabel>Startup Programs</guilabel> tab and the 
   <guilabel>Options</guilabel> tab.</para>
 
-    <sect2 id="gosstartsession-21">
-      <title>Startup Programs Tab</title>
+    <section xml:id="gosstartsession-21"><info><title>Startup Programs Tab</title></info>
         <!-- Preserve IDs for backwards compatibility -->
-        <anchor id="gosstartsession-6"/>
-        <anchor id="gosstartsession-10"/>
+        <anchor xml:id="gosstartsession-6"/>
+        <anchor xml:id="gosstartsession-10"/>
       <para>You can use the Startup Programs tab to add, modify, and 
       remove startup programs.</para>
       <para>A list of startup programs is displayed on this tab. The list shows 
@@ -205,15 +205,14 @@ panel, click on the <guibutton>Lock Screen</guibutton> button.</para>
       whether the startup program is enabled or not. Programs which are not 
       enabled will not be started automatically when you log in.</para>
 
-      <sect3 id="gosstartsession-211">
-       <title>Enabling/Disabling Startup Programs</title>
+      <section xml:id="gosstartsession-211"><info><title>Enabling/Disabling Startup Programs</title></info>
        <para>To enable a program to start up automatically, check the checkbox 
        corresponding to that program.</para>
        <para>To disable a program from starting automatically, uncheck the 
        checkbox.</para>
-      </sect3>
-      <sect3 id="gosstartsession-212">
-       <title>Adding A New Startup Program</title>
+      </section>
+
+      <section xml:id="gosstartsession-212"><info><title>Adding A New Startup Program</title></info>
        <para>To add a new startup program, perform the following steps:</para>
        <procedure>
         <step>
@@ -242,27 +241,26 @@ panel, click on the <guibutton>Lock Screen</guibutton> button.</para>
          (enabled) state.</para>
         </step>
        </procedure>
-      </sect3>
-      <sect3 id="gosstartsession-213">
-       <title>Removing A Startup Program</title>
+      </section>
+
+      <section xml:id="gosstartsession-213"><info><title>Removing A Startup Program</title></info>
        <para>To remove a startup program, select it from the list of startup 
        programs and click <guibutton>Remove</guibutton>.</para>
-      </sect3>
-      <sect3 id="gosstartsession-214">
-       <title>Editing A Startup Program</title>
+      </section>
+
+      <section xml:id="gosstartsession-214"><info><title>Editing A Startup Program</title></info>
        <para>To edit an existing startup program, select it from the list of 
        startup programs and click <guibutton>Edit</guibutton>. A dialog will 
        appear which allows you to edit the properties of the program. See 
        <xref linkend="gosstartsession-212"/> for more information on the 
        options available in this dialog.</para>
-      </sect3>
-    </sect2>
+      </section>
+    </section>
     
-    <sect2 id="gosstartsession-22">
-      <title>Session Options Tab</title>
-        <!-- Preserve IDs for backwards compatibility -->
-        <anchor id="gosstartsession-9"/>
-        <anchor id="gosgetstarted-74"/>
+    <section xml:id="gosstartsession-22"><info><title>Session Options Tab</title></info>
+      <!-- Preserve IDs for backwards compatibility -->
+      <anchor xml:id="gosstartsession-9"/>
+      <anchor xml:id="gosgetstarted-74"/>
       <para>The session manager can remember which applications you have 
       running when you log out and can automatically restart them when you log 
       in again. If you would like this to happen every time you log out, check 
@@ -270,13 +268,12 @@ panel, click on the <guibutton>Lock Screen</guibutton> button.</para>
       logging out</guilabel>. If you would like this to happen only once, click 
       <guibutton>Remember Currently Running Application</guibutton> before 
       logging out.</para>
-    </sect2>
-  </sect1>
+    </section>
+  </section>
   
-  <sect1 id="shutdown">
-    <title>Ending a Session</title>
+  <section xml:id="shutdown"><info><title>Ending a Session</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="gosgetstarted-73"/>        
+    <anchor xml:id="gosgetstarted-73"/>        
     <indexterm>
       <primary>sessions</primary>
       <secondary>ending</secondary>
@@ -329,5 +326,5 @@ panel, click on the <guibutton>Lock Screen</guibutton> button.</para>
     <para>Before you end a session, you might want to save your current
 settings so that you can restore the session later. In the <link linkend="prefs-sessions"><application>Sessions</application></link> preference tool, you can select an option to automatically
 save your current settings.</para>
-  </sect1>
+  </section>
 </chapter>

--- a/mate-user-guide/C/gostools.xml
+++ b/mate-user-guide/C/gostools.xml
@@ -1,15 +1,18 @@
-<!-- -*- indent-tabs-mode: nil -*- -->
-<chapter id="tools">
-  <title>Tools and Utilities</title>
+<?xml version="1.0" encoding="utf-8"?>
+<?db.chunk.max_depth 3?>
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         version="5.0" xml:id="tools" xml:lang="en">
+    <info><title>Tools and Utilities</title></info>
 
   <highlights>
     <para>This section describes some tools and utilities in the MATE Desktop.</para>
   </highlights>
 
-  <section id="tools-run-app">
-    <title>Running Applications</title>
+  <section xml:id="tools-run-app"><info><title>Running Applications</title></info>
     <!-- preserve id for backwards compatibility: 2.12 -->
-    <anchor id="gospanel-23"/>
+    <anchor xml:id="gospanel-23"/>
     <indexterm>
       <primary>Run Application dialog, using</primary>
     </indexterm>
@@ -64,12 +67,11 @@
       <para>Click on the <guibutton>Run</guibutton> button on the <guilabel>Run Application</guilabel> dialog. </para>
     </listitem>
       </orderedlist>
-    </section>
+  </section>
 
-<section id="tools-screenshot">
-  <title>Taking Screenshots</title>
+<section xml:id="tools-screenshot"><info><title>Taking Screenshots</title></info>
   <!-- preserve id for backwards compatibility: 2.12 -->
-  <anchor id="goseditmainmenu-53"/>   
+  <anchor xml:id="goseditmainmenu-53"/>
   <indexterm>
     <primary>screenshots, taking</primary>
   </indexterm>
@@ -254,16 +256,13 @@ a screenshot of the entire screen.</para>
 </section>
 
 <!-- ============= Yelp ============================= -->
-<section id="yelp">
-  <title>Yelp Help Browser</title>
+<section xml:id="yelp"><info><title>Yelp Help Browser</title></info>
   <indexterm>
     <primary>Yelp</primary>
   </indexterm>
   <!-- ============= Introduction ============================== -->
 
-  <section id="yelp-introduction">
-    <title>Introduction</title>
-
+  <section xml:id="yelp-introduction"><info><title>Introduction</title></info>
     <para>The <application>Yelp Help Browser</application> application allows you to view documentation
     regarding MATE and other components through a variety of formats. These
     formats include docbook files, HTML help pages, man pages and info pages
@@ -279,12 +278,9 @@ a screenshot of the entire screen.</para>
 
   <!-- ============= Getting Started  ================================ -->
 
-  <section id="yelp-getting-started">
-    <title>Starting Yelp</title>
-
-    <section>
-      <title>To Start <application>Yelp Help Browser</application></title>
-
+  <section xml:id="yelp-getting-started"><info><title>Starting Yelp</title></info>
+  
+    <section><info><title>To Start <application>Yelp Help Browser</application></title></info>
       <para>You can start <application>Yelp Help Browser</application> in the following ways:</para>
 
       <para><variablelist>
@@ -307,22 +303,17 @@ a screenshot of the entire screen.</para>
         </variablelist></para>
     </section>
 
-    <section>
-      <title>Interface</title>
-
+    <section><info><title>Interface</title></info>
       <para>When you start <application>Yelp Help Browser</application>, you will see the following
       window appear.</para>
 
-      <para><figure id="fig-yelp-window">
-          <title><application>Yelp Help Browser</application> Window</title>
-
+      <para><figure xml:id="fig-yelp-window"><info><title><application>Yelp Help Browser</application> Window</title></info>
           <mediaobject>
             <imageobject>
-              <imagedata fileref="figures/yelp_window.png" />
+              <imagedata fileref="figures/yelp_window.png"/>
             </imageobject>
           </mediaobject>
-        </figure><application>Yelp Help Browser</application> contains the following elements in <xref
-      linkend="fig-yelp-window" /></para>
+        </figure><application>Yelp Help Browser</application> contains the following elements in <xref linkend="fig-yelp-window"/></para>
 
       <variablelist>
         <varlistentry>
@@ -412,14 +403,14 @@ a screenshot of the entire screen.</para>
 
                   <listitem>
                     <para>Use this button to return to the main table of
-                    contents (shown in <xref linkend="fig-yelp-window" />).</para>
+                    contents (shown in <xref linkend="fig-yelp-window"/>).</para>
                   </listitem>
                 </varlistentry>
               </variablelist></para>
           </listitem>
         </varlistentry>
 
-        <varlistentry id="yelp-browser-pane" xreflabel="Yelp Browser Pane">
+        <varlistentry xml:id="yelp-browser-pane" xreflabel="Yelp Browser Pane">
           <term><interface>Browser Pane</interface></term>
 
           <listitem>
@@ -434,12 +425,9 @@ a screenshot of the entire screen.</para>
 
   <!--===================== Usage ========================-->
 
-  <section id="yelp-usage">
-    <title>Using Yelp</title>
+  <section xml:id="yelp-usage"><info><title>Using Yelp</title></info>
 
-    <section>
-      <title>Open a Document</title>
-
+    <section><info><title>Open a Document</title></info>
       <para>To open a document in <application>Yelp Help Browser</application>:
 	  
 	  <itemizedlist>
@@ -464,13 +452,10 @@ a screenshot of the entire screen.</para>
 	  </itemizedlist></para>
 	  
       <para>Alternatively, you may view a particular document by invoking Yelp
-      Help Browser from the command line or dragging files to Yelp. See <xref
-      linkend="yelp-open-specific" /> for more on this.</para>
+      Help Browser from the command line or dragging files to Yelp. See <xref linkend="yelp-open-specific"/> for more on this.</para>
     </section>
 
-    <section>
-      <title>Open a New Window</title>
-
+    <section><info><title>Open a New Window</title></info>
       <para>To open a new window:</para>
 	  
       <para><itemizedlist>
@@ -489,9 +474,7 @@ a screenshot of the entire screen.</para>
         </itemizedlist></para>
     </section>
 
-    <section>
-      <title>About This Document</title>
-
+    <section><info><title>About This Document</title></info>
       <para>To view information about the currently open document:</para>
 
       <para><itemizedlist>
@@ -509,9 +492,7 @@ a screenshot of the entire screen.</para>
         </note></para>
     </section>
 
-    <section>
-      <title>Print a Page</title>
-
+    <section><info><title>Print a Page</title></info>
       <para>To print any page that you are able to view in <application>Yelp Help Browser</application>:</para>
 
       <para><itemizedlist>
@@ -525,9 +506,7 @@ a screenshot of the entire screen.</para>
         </itemizedlist></para>
     </section>
 
-    <section>
-      <title>Print a Document</title>
-
+    <section><info><title>Print a Document</title></info>
       <para>To print an entire document:</para>
 
       <para><itemizedlist>
@@ -544,9 +523,7 @@ a screenshot of the entire screen.</para>
         </note></para>
     </section>
 
-    <section>
-      <title>Close a Window</title>
-
+    <section><info><title>Close a Window</title></info>
       <para>To close a window in <application>Yelp Help Browser</application>, do the following:</para>
 
       <para><itemizedlist>
@@ -565,9 +542,7 @@ a screenshot of the entire screen.</para>
         </itemizedlist></para>
     </section>
 
-    <section>
-      <title>Set Preferences</title>
-
+    <section><info><title>Set Preferences</title></info>
       <para>To set your preferences in <application>Yelp Help Browser</application>:</para>
 
       <para><itemizedlist>
@@ -578,15 +553,12 @@ a screenshot of the entire screen.</para>
                 <guimenuitem>Preferences</guimenuitem>
               </menuchoice></para>
           </listitem>
-        </itemizedlist>A window will appear that looks like <xref
-      linkend="yelp-preferences" />:</para>
+        </itemizedlist>A window will appear that looks like <xref linkend="yelp-preferences"/>:</para>
 
-      <para><figure id="yelp-preferences">
-          <title><application>Yelp Help Browser</application> Preferences Window</title>
-
+      <para><figure xml:id="yelp-preferences"><info><title><application>Yelp Help Browser</application> Preferences Window</title></info>
           <mediaobject>
             <imageobject>
-              <imagedata fileref="figures/yelp_preferences.png" />
+              <imagedata fileref="figures/yelp_preferences.png"/>
             </imageobject>
           </mediaobject>
         </figure>The options that are available in this dialog have the
@@ -635,7 +607,7 @@ a screenshot of the entire screen.</para>
 
             <listitem>
               <para>Click this option if you would like see a caret or cursor
-              in the <xref linkend="yelp-browser-pane" />. This allows you to
+              in the <xref linkend="yelp-browser-pane"/>. This allows you to
               browse the document more easily by showing where the cursor is
               located in the document.</para>
             </listitem>
@@ -643,9 +615,7 @@ a screenshot of the entire screen.</para>
         </variablelist></para>
     </section>
 
-    <section>
-      <title>Go Back in Document History</title>
-
+    <section><info><title>Go Back in Document History</title></info>
       <para>To go back in the document history:</para>
 
       <para><itemizedlist>
@@ -669,9 +639,7 @@ a screenshot of the entire screen.</para>
         </itemizedlist></para>
     </section>
 
-    <section>
-      <title>Go Forward in Document History</title>
-
+    <section><info><title>Go Forward in Document History</title></info>
       <para>To go forward in the document history:</para>
 
       <para><itemizedlist>
@@ -695,9 +663,7 @@ a screenshot of the entire screen.</para>
         </itemizedlist></para>
     </section>
 
-    <section>
-      <title>Go to Help Topics</title>
-
+    <section><info><title>Go to Help Topics</title></info>
       <para>To go to the Help Topics:</para>
 
       <para><itemizedlist>
@@ -721,9 +687,7 @@ a screenshot of the entire screen.</para>
         </itemizedlist></para>
     </section>
 
-    <section>
-      <title>Go to Previous Section</title>
-
+    <section><info><title>Go to Previous Section</title></info>
       <para>To go to the previous section:</para>
 
       <para><itemizedlist>
@@ -745,8 +709,8 @@ a screenshot of the entire screen.</para>
         </note></para>
     </section>
 
-    <section>
-      <title>Go to Next Section</title>
+    <section><info><title>Go to Next Section</title></info>
+      
 
       <para>To go to the next section:</para>
 
@@ -769,8 +733,8 @@ a screenshot of the entire screen.</para>
         </note></para>
     </section>
 
-    <section>
-      <title>Go to Contents</title>
+    <section><info><title>Go to Contents</title></info>
+      
 
       <para>To go to the contents for a document:</para>
 
@@ -788,8 +752,8 @@ a screenshot of the entire screen.</para>
         </note></para>
     </section>
 
-    <section>
-      <title>Add a Bookmark</title>
+    <section><info><title>Add a Bookmark</title></info>
+      
 
       <para>To add a bookmark for a particular document:</para>
 
@@ -806,15 +770,12 @@ a screenshot of the entire screen.</para>
             <para>Use the key combination
             <keycombo><keycap>Ctrl</keycap><keycap>D</keycap></keycombo></para>
           </listitem>
-        </itemizedlist>A window will appear that looks like <xref
-      linkend="yelp-add-bookmark" />.</para>
+        </itemizedlist>A window will appear that looks like <xref linkend="yelp-add-bookmark"/>.</para>
 
-      <para><figure id="yelp-add-bookmark">
-          <title>Add Bookmark Window</title>
-
+      <para><figure xml:id="yelp-add-bookmark"><info><title>Add Bookmark Window</title></info>
           <mediaobject>
             <imageobject>
-              <imagedata fileref="figures/yelp_add_bookmark.png" />
+              <imagedata fileref="figures/yelp_add_bookmark.png"/>
             </imageobject>
           </mediaobject>
         </figure>Enter your desired bookmark title in to the
@@ -823,9 +784,7 @@ a screenshot of the entire screen.</para>
       <guibutton>Cancel</guibutton> to cancel the request.</para>
     </section>
 
-    <section>
-      <title>Edit Bookmarks</title>
-
+    <section><info><title>Edit Bookmarks</title></info>
       <para>To edit your collection of bookmarks:</para>
 
       <para><itemizedlist>
@@ -840,15 +799,12 @@ a screenshot of the entire screen.</para>
             <para>Use the key combination
             <keycombo><keycap>Ctrl</keycap><keycap>B</keycap></keycombo></para>
           </listitem>
-        </itemizedlist>A window will appear that looks like <xref
-      linkend="yelp-edit-bookmarks" />.</para>
+        </itemizedlist>A window will appear that looks like <xref linkend="yelp-edit-bookmarks"/>.</para>
 
-      <para><figure id="yelp-edit-bookmarks">
-          <title>Edit Bookmarks Window</title>
-
+      <para><figure xml:id="yelp-edit-bookmarks"><info><title>Edit Bookmarks Window</title></info>
           <mediaobject>
             <imageobject>
-              <imagedata fileref="figures/yelp_edit_bookmarks.png" />
+              <imagedata fileref="figures/yelp_edit_bookmarks.png"/>
             </imageobject>
           </mediaobject>
         </figure>You can manage your bookmarks using this window in the
@@ -886,9 +842,7 @@ a screenshot of the entire screen.</para>
       Bookmarks Window</interface>.</para>
     </section>
 
-    <section>
-      <title>Get Help</title>
-
+    <section><info><title>Get Help</title></info>
       <para>To get help to use <application>Yelp Help Browser</application> (and see this
       document):</para>
 
@@ -906,23 +860,16 @@ a screenshot of the entire screen.</para>
 
   <!--=============== Advanced Features ====================-->
 
-  <section id="yelp-advanced">
-    <title>Advanced Features</title>
+  <section xml:id="yelp-advanced"><info><title>Advanced Features</title></info>
 
-   <section id="yelp-open-specific"
-        xreflabel="Opening Specific Documents">
-    <title>Opening Specific Documents</title>
+   <section xml:id="yelp-open-specific" xreflabel="Opening Specific Documents"><info><title>Opening Specific Documents</title></info>
 
-    <section id="yelp-open-drag">
-      <title>Opening Documents from the File Manager</title>
+    <section xml:id="yelp-open-drag"><info><title>Opening Documents from the File Manager</title></info>
         <para>To open a document, such as an XML file, from the file manager, open the document in <application>Caja</application> File Manager, or drag the icon from <application>Caja</application> to the <application>Yelp</application> document pane
         or launcher.</para>
     </section>
 
-    <section id="yelp-advanced-cmdline"
-           xreflabel="Using the Command Line to Open Documents">
-      <title>Using the Command Line to Open Documents</title>
-
+    <section xml:id="yelp-advanced-cmdline" xreflabel="Using the Command Line to Open Documents"><info><title>Using the Command Line to Open Documents</title></info>
       <para>Yelp Help Browser supports opening documents from the command
       line. There are a number of URIs (Uniform Resource Identifiers) that can
       be used. These include:</para>
@@ -988,12 +935,9 @@ a screenshot of the entire screen.</para>
           </varlistentry>
         </variablelist>
     </section>
-
    </section>
 
-    <section>
-      <title>Refreshing Content on Demand</title>
-
+    <section><info><title>Refreshing Content on Demand</title></info>
       <para><application>Yelp Help Browser</application> supports the
       <keycombo><keycap>Ctrl</keycap><keycap>R</keycap></keycombo> shortcut keys, which will reload the DocBook
       document that is currently open. This allows developers to view changes
@@ -1001,24 +945,18 @@ a screenshot of the entire screen.</para>
     </section>
   </section>
 
-  <section id="yelp-moreinfo">
-    <title>More Information</title>
-
+  <section xml:id="yelp-moreinfo"><info><title>More Information</title></info>
     <para>This section details some helper applications which 
     <application>Yelp Help Browser</application> uses, and provides resources where you can get more information
     about <application>Yelp Help Browser</application>.</para>
 
-    <section>
-      <title>Scrollkeeper</title>
-
+    <section><info><title>Scrollkeeper</title></info>
       <para><application>Yelp Help Browser</application> uses scrollkeeper to generate the table of
       contents for DocBook and HTML documentation, and also keep track of
       translations for each document.</para>
     </section>
 
-    <section>
-      <title>MATE Documentation Utilites</title>
-
+    <section><info><title>MATE Documentation Utilites</title></info>
       <para>The documentation distributed with MATE uses this set of
       utilities for a variety of things:</para>
 
@@ -1037,26 +975,20 @@ a screenshot of the entire screen.</para>
             <para>Perform conversion from DocBook format to a format suitable
             for display.</para>
           </listitem>
-        </itemizedlist><application>Yelp Help Browser</application> relies on <ulink url="help:mate-doc-xslt">MATE XSLT
-      Stylesheets</ulink> to perform conversion from DocBook to HTML.  <ulink url="help:mate-doc-make">MATE Documentation
-      Build Utilities</ulink> are relied upon by application authors to install and register documentation within the help system.</para>
+        </itemizedlist><application>Yelp Help Browser</application> relies on <link xlink:href="help:mate-doc-xslt">MATE XSLT
+      Stylesheets</link> to perform conversion from DocBook to HTML.  <link xlink:href="help:mate-doc-make">MATE Documentation
+      Build Utilities</link> are relied upon by application authors to install and register documentation within the help system.</para>
     </section>
 
-    <section>
-      <title>Homepage and Mailing List</title>
-
-      <para>For further information on <application>Yelp Help Browser</application>, please visit the Documentation Project homepage, <ulink url="http://mate-desktop.org"></ulink>, or subscribe to
-      the mailing list, <ulink type="http" url="http://ml.mate-desktop.org/listinfo/mate-dev"></ulink>.</para>
+    <section><info><title>Homepage and Mailing List</title></info>
+      <para>For further information on <application>Yelp Help Browser</application>, please visit the Documentation Project homepage, <uri xlink:href="http://mate-desktop.org">http://mate-desktop.org</uri>, or subscribe to
+      the mailing list, <uri xlink:href="http://ml.mate-desktop.org/listinfo/mate-dev">http://ml.mate-desktop.org/listinfo/mate-dev</uri>.</para>
     </section>
   </section>
 
-  <section id="yelp-joininggdp">
-    <title>Joining the MATE Documentation Project</title>
-
+  <section xml:id="yelp-joininggdp"><info><title>Joining the MATE Documentation Project</title></info>
     <para>If you are interested in helping produce and update documentation
-    for the MATE project, please visit the Documentation Project homepage: <ulink url="http://wiki.mate-desktop.org/dev-doc:doc-team-guide?s[]=users[]=guide#mate_documentation_team"></ulink></para>
+    for the MATE project, please visit the Documentation Project homepage: <uri xlink:href="http://wiki.mate-desktop.org/dev-doc:doc-team-guide?s[]=users[]=guide#mate_documentation_team">http://wiki.mate-desktop.org/dev-doc:doc-team-guide?s[]=users[]=guide#mate_documentation_team</uri></para>
   </section>
-
 </section>
-
 </chapter>

--- a/mate-user-guide/C/index.docbook
+++ b/mate-user-guide/C/index.docbook
@@ -1,15 +1,12 @@
-<?xml version="1.0"?><!-- -*- indent-tabs-mode: nil -*- -->
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" [
-  <!ENTITY mateversion "1.10">
-  <!ENTITY manrevision "1.10.0">
-  <!ENTITY LEGAL SYSTEM             "legal.xml">
-]>
+<?xml version="1.0" encoding="utf-8"?>
 <?db.chunk.max_depth 3?>
-<book id="index"> 
-  <title>Desktop User Guide</title> 
-  <bookinfo>
-    <abstract role="description">
+<book xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0" xml:id="index" xml:lang="en">
+  <title>Desktop User Guide</title>
+  <info>
+    <abstract>
       <para>The MATE User Guide is a collection of documentation which details general use of the
       MATE Desktop environment.  Topics covered include sessions, panels, menus, file management,
       and preferences.</para>
@@ -30,119 +27,138 @@
       <year>2003</year>
       <holder>Sun Microsystems</holder>
     </copyright>
-    <!-- translators: uncomment this:
-    <copyright>
-      <year>2002</year>
-      <holder>ME-THE-TRANSLATOR (Latin translation)</holder>
-    </copyright>
-    -->
+
     <publisher role="maintainer">
       <publishername>MATE Documentation Project</publishername>
     </publisher>
 
-    &LEGAL;
+    <xi:include href="legal.xml"/>
 
     <authorgroup>
-      <author>
-        <surname>MATE Documentation Team</surname>
-        <affiliation>
-          <orgname>MATE DESKTOP</orgname>
-        </affiliation>
-      </author>
-      <author>
-        <firstname>Wolfgang</firstname>
-        <surname>Ulbrich</surname>
-        <affiliation>
-          <orgname>Dark Side of the Moon</orgname>
-        </affiliation>
-      </author>
-      <author>
-        <firstname>Sun</firstname>
-        <surname>GNOME Documentation Team</surname>
-        <affiliation>
-          <orgname>Sun Microsystems</orgname>
-        </affiliation>
-      </author>
-      <author>
-        <firstname>Shaun</firstname>
-        <surname>McCance</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>shaunm@gnome.org</email>
-      </author>
-      <author>
-        <surname>Karderio</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>karderio at gmail dot com</email>
-      </author>
-      <author>
-        <firstname>Joachim</firstname>
-        <surname>Noreiko</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>jnoreiko at yahoo dot com</email>
-      </author>
-      <author>
-        <firstname>Daniel</firstname>
-        <surname>Espinosa Ortiz</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>esodan at gmail dot com</email>
-      </author>      
-      <author>
-        <firstname>Brent</firstname>
-        <surname>Smith</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>mate at nextreality dot net</email>
-      </author>
-      <author>
-        <firstname>Tim</firstname>
-        <surname>Littlemore</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>tim at tjl2 dot com</email>
-      </author>      
-      <author>
-        <firstname>John</firstname>
-        <surname>Stowers</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>john dot stowers at gmail dot com</email>
-      </author>
-      <author>
-        <firstname>Nigel</firstname>
-        <surname>Tao</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-        </affiliation>
-        <email>nigel dot tao at myrealbox dot com</email>
-      </author>      
-      <author>
-        <firstname>Matthew</firstname>
-        <surname>East</surname>
-        <affiliation>
-          <orgname>Ubuntu Documentation Project</orgname>
-        </affiliation>
-        <email>mdke at ubuntu dot com</email>
-      </author>
-      <author>
-        <firstname>Carlos</firstname>
-        <surname>Garnacho Parro</surname>
-        <affiliation>
-          <orgname>GNOME Project</orgname>
-        </affiliation>
-        <email>carlosg@gnome.org</email>
-      </author>
-      </authorgroup>
+        <author>
+            <orgname>MATE Documentation Project</orgname>
+            <affiliation>
+                <orgname>MATE Desktop</orgname>
+            </affiliation>
+        </author>
+        <author>
+            <personname>
+                <firstname>Wolfgang</firstname>
+                <surname>Ulbrich</surname>
+            </personname>
+            <affiliation>
+                <orgname>Dark Side of the Moon</orgname>
+            </affiliation>
+        </author>
+        <author>
+            <personname>
+                <firstname>Sun</firstname>
+                <surname>GNOME Documentation Team</surname>
+            </personname>
+            <affiliation>
+                <orgname>Sun Microsystems</orgname>
+            </affiliation>
+        </author>
+        <author>
+            <personname>
+                <firstname>Shaun</firstname>
+                <surname>McCance</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>shaunm@gnome.org</email>
+        </author>
+        <author>
+            <personname>
+                <surname>Karderio</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>karderio@gmail.com</email>
+        </author>
+        <author>
+            <personname>
+                <firstname>Joachim</firstname>
+                <surname>Noreiko</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>jnoreiko@yahoo.com</email>
+        </author>
+        <author>
+            <personname>
+                <firstname>Daniel</firstname>
+                <surname>Espinosa Ortiz</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>esodan@gmail.com</email>
+        </author>      
+        <author>
+            <personname>
+                <firstname>Brent</firstname>
+                <surname>Smith</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>mate@nextreality.net</email>
+        </author>
+        <author>
+            <personname>
+                <firstname>Tim</firstname>
+                <surname>Littlemore</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>tim@tjl2.com</email>
+        </author>      
+        <author>
+            <personname>
+                <firstname>John</firstname>
+                <surname>Stowers</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>john.stowers@gmail.com</email>
+        </author>
+        <author>
+            <personname>
+                <firstname>Nigel</firstname>
+                <surname>Tao</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Documentation Project</orgname>
+            </affiliation>
+            <email>nigel.tao@myrealbox.com</email>
+        </author>      
+        <author>
+            <personname>
+                <firstname>Matthew</firstname>
+                <surname>East</surname>
+            </personname>
+            <affiliation>
+                <orgname>Ubuntu Documentation Project</orgname>
+            </affiliation>
+            <email>mdke@ubuntu.com</email>
+        </author>
+        <author>
+            <personname>
+                <firstname>Carlos</firstname>
+                <surname>Garnacho Parro</surname>
+            </personname>
+            <affiliation>
+                <orgname>GNOME Project</orgname>
+            </affiliation>
+            <email>carlosg@gnome.org</email>
+        </author>
+    </authorgroup>
 	  
 	 <releaseinfo revision="2.15" role="review">
      </releaseinfo>
@@ -173,14 +189,14 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.8 Desktop User Guide V2.8</revnumber>
+        <revnumber>2.8</revnumber>
         <date>September 2004</date>
         <revdescription>
           <para role="publisher">GNOME Documentation Project</para>
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.4 Desktop User Guide V2.7</revnumber>
+        <revnumber>2.7</revnumber>
         <date>September 2003</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -188,7 +204,7 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.4 Desktop User Guide V2.6</revnumber>
+        <revnumber>2.6</revnumber>
         <date>August 2003</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -196,7 +212,7 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.2.1 Desktop User Guide V2.5</revnumber>
+        <revnumber>2.5</revnumber>
         <date>March 2003</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -204,7 +220,7 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.2 Desktop User Guide V2.4</revnumber>
+        <revnumber>2.4</revnumber>
         <date>January 2003</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -212,7 +228,7 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.0 Desktop User Guide V2.3</revnumber>
+        <revnumber>2.3</revnumber>
         <date>October 2002</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -220,7 +236,7 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.0 Desktop User Guide V2.2</revnumber>
+        <revnumber>2.2</revnumber>
         <date>August 2002</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -228,7 +244,7 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.0 Desktop User Guide V2.1</revnumber>
+        <revnumber>2.1</revnumber>
         <date>August 2002</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -236,7 +252,7 @@
         </revdescription>
       </revision>
       <revision>
-        <revnumber>MATE 2.0 Desktop User Guide V1.0</revnumber>
+        <revnumber>1.0</revnumber>
         <date>May 2002</date>
         <revdescription>
           <para role="author">Sun Microsystems</para>
@@ -245,26 +261,20 @@
       </revision>
     </revhistory>
 
-    <releaseinfo>This manual describes version &mateversion; of the
-    MATE desktop.</releaseinfo>
+    <releaseinfo>This manual describes version 1.10 of the MATE desktop.</releaseinfo>
 
-    <legalnotice>
-      <title>Feedback</title>
-      <para>To report a bug or make a suggestion regarding the MATE
-      desktop or this manual, follow the directions in the <xref linkend="feedback"/>.</para>
-    </legalnotice>
-  </bookinfo>
+  </info>
 
-  <include href="gosbasic.xml" xmlns="http://www.w3.org/2001/XInclude" />       <!-- Basic skills -->
-  <include href="gosoverview.xml" xmlns="http://www.w3.org/2001/XInclude" />    <!-- Overview-->
-  <include href="gosstartsession.xml" xmlns="http://www.w3.org/2001/XInclude" /><!-- Sessions -->
-  <include href="gospanel.xml" xmlns="http://www.w3.org/2001/XInclude" />       <!-- Panels -->
-  <include href="goseditmainmenu.xml" xmlns="http://www.w3.org/2001/XInclude" /><!-- Menus -->
-  <include href="goscaja.xml" xmlns="http://www.w3.org/2001/XInclude" />    <!-- Caja -->
-  <include href="gostools.xml" xmlns="http://www.w3.org/2001/XInclude" />       <!-- Tools & utilities -->
-  <include href="goscustdesk.xml" xmlns="http://www.w3.org/2001/XInclude" />    <!-- Preferences -->
-  <include href="gosdconf.xml" xmlns="http://www.w3.org/2001/XInclude" />	<!-- dconf -->
-  <include href="glossary.xml" xmlns="http://www.w3.org/2001/XInclude" />       <!-- Glossary -->
-  <include href="gosfeedback.xml" xmlns="http://www.w3.org/2001/XInclude" />    <!-- Feedback -->
-    
+  <xi:include href="gosbasic.xml"/>       <!-- Basic skills -->
+  <xi:include href="gosoverview.xml"/>    <!-- Overview -->
+  <xi:include href="gosstartsession.xml"/><!-- Sessions -->
+  <xi:include href="gospanel.xml"/>       <!-- Panels -->
+  <xi:include href="goseditmainmenu.xml"/><!-- Menus -->
+  <xi:include href="goscaja.xml"/>        <!-- Caja -->
+  <xi:include href="gostools.xml"/>       <!-- Tools & utilities -->
+  <xi:include href="goscustdesk.xml"/>    <!-- Preferences -->
+  <xi:include href="gosdconf.xml"/>       <!-- dconf -->
+  <xi:include href="glossary.xml"/>       <!-- Glossary -->
+  <xi:include href="gosfeedback.xml"/>    <!-- Feedback -->
+
 </book>

--- a/mate-user-guide/C/index.docbook
+++ b/mate-user-guide/C/index.docbook
@@ -261,7 +261,7 @@
       </revision>
     </revhistory>
 
-    <releaseinfo>This manual describes version 1.10 of the MATE desktop.</releaseinfo>
+    <releaseinfo>This manual describes version 1.22 of the MATE desktop.</releaseinfo>
 
   </info>
 

--- a/mate-user-guide/C/index.docbook
+++ b/mate-user-guide/C/index.docbook
@@ -12,7 +12,7 @@
       and preferences.</para>
     </abstract>
     <copyright>
-      <year>2015</year>
+      <year>2019</year>
       <holder>MATE Documentation Project</holder>
     </copyright>
     <copyright>

--- a/mate-user-guide/C/legal.xml
+++ b/mate-user-guide/C/legal.xml
@@ -1,12 +1,13 @@
-  <legalnotice id="legalnotice">
+<legalnotice xmlns="http://docbook.org/ns/docbook"
+             xmlns:xlink="http://www.w3.org/1999/xlink"
+             version="5.0" xml:id="legalnotice" xml:lang="en">
 	<para>
 	  Permission is granted to copy, distribute and/or modify this
 	  document under the terms of the GNU Free Documentation
 	  License (GFDL), Version 1.1 or any later version published
 	  by the Free Software Foundation with no Invariant Sections,
 	  no Front-Cover Texts, and no Back-Cover Texts.  You can find
-	  a copy of the GFDL at this <ulink type="help"
-	  url="help:fdl">link</ulink> or in the file COPYING-DOCS
+	  a copy of the GFDL at this <link xlink:href="https://www.gnu.org/licenses/fdl-1.1.html">link</link> or in the file COPYING-DOCS
 	  distributed with this manual.
          </para>
          <para> This manual is part of a collection of MATE manuals
@@ -72,5 +73,8 @@
 		</listitem>
 	  </orderedlist>
 	</para>
-  </legalnotice>
-
+        <formalpara>
+            <title>Feedback</title>
+            <para>To report a bug or make a suggestion regarding the MATE Desktop or this manual, follow the directions in the <link xlink:href="help:mate-user-guide/feedback">MATE Feedback Page</link>.</para>
+        </formalpara>
+</legalnotice>

--- a/mate-user-guide/mate-user-guide.pot
+++ b/mate-user-guide/mate-user-guide.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2019-02-07 19:35+0100\n"
+"POT-Creation-Date: 2019-03-09 23:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 
 #. (itstool) path: info/copyright
 #: C/index.docbook:14
-msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
+msgid "<year>2019</year> <holder>MATE Documentation Project</holder>"
 msgstr ""
 
 #. (itstool) path: info/copyright
@@ -220,7 +220,7 @@ msgstr ""
 
 #. (itstool) path: info/releaseinfo
 #: C/index.docbook:264
-msgid "This manual describes version 1.10 of the MATE desktop."
+msgid "This manual describes version 1.22 of the MATE desktop."
 msgstr ""
 
 #. (itstool) path: legalnotice/para

--- a/mate-user-guide/mate-user-guide.pot
+++ b/mate-user-guide/mate-user-guide.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2018-11-19 08:53+0100\n"
+"POT-Creation-Date: 2019-02-07 19:35+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,164 +15,125 @@ msgid "translator-credits"
 msgstr ""
 
 #. (itstool) path: book/title
-#: C/index.docbook:10
+#: C/index.docbook:7
 msgid "Desktop User Guide"
 msgstr ""
 
 #. (itstool) path: abstract/para
-#: C/index.docbook:13
+#: C/index.docbook:10
 msgid "The MATE User Guide is a collection of documentation which details general use of the MATE Desktop environment. Topics covered include sessions, panels, menus, file management, and preferences."
 msgstr ""
 
-#. (itstool) path: bookinfo/copyright
-#: C/index.docbook:17
+#. (itstool) path: info/copyright
+#: C/index.docbook:14
 msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
 msgstr ""
 
-#. (itstool) path: bookinfo/copyright
-#: C/index.docbook:21
+#. (itstool) path: info/copyright
+#: C/index.docbook:18
 msgid "<year>2005</year> <holder>Shaun McCance</holder>"
 msgstr ""
 
-#. (itstool) path: bookinfo/copyright
-#: C/index.docbook:25
+#. (itstool) path: info/copyright
+#: C/index.docbook:22
 msgid "<year>2004</year> <holder>Sun Microsystems</holder>"
 msgstr ""
 
-#. (itstool) path: bookinfo/copyright
-#: C/index.docbook:29
+#. (itstool) path: info/copyright
+#: C/index.docbook:26
 msgid "<year>2003</year> <holder>Sun Microsystems</holder>"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
 #. (itstool) path: revdescription/para
-#. (itstool) path: para/ulink
-#: C/index.docbook:40
-#: C/index.docbook:156
-#: C/gosfeedback.xml:72
+#: C/index.docbook:32
+#: C/index.docbook:172
 msgid "MATE Documentation Project"
 msgstr ""
 
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:2
-msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <ulink type=\"help\" url=\"help:fdl\">link</ulink> or in the file COPYING-DOCS distributed with this manual."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:12
-#: C/legal.xml:12
-msgid "This manual is part of a collection of MATE manuals distributed under the GFDL. If you want to distribute this manual separately from the collection, you can do so by adding a copy of the license to the manual, as described in section 6 of the license."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:19
-#: C/legal.xml:19
-msgid "Many of the names used by companies to distinguish their products and services are claimed as trademarks. Where those names appear in any MATE documentation, and the members of the MATE Documentation Project are made aware of those trademarks, then the names are in capital letters or initial capital letters."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:35
-#: C/legal.xml:35
-msgid "DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS FREE OF DEFECTS MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY, ACCURACY, AND PERFORMANCE OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS WITH YOU. SHOULD ANY DOCUMENT OR MODIFIED VERSION PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL WRITER, AUTHOR OR ANY CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER; AND"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:55
-#: C/legal.xml:55
-msgid "UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE AUTHOR, INITIAL WRITER, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER DAMAGES OR LOSSES ARISING OUT OF OR RELATING TO USE OF THE DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:28
-#: C/legal.xml:28
-msgid "DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT ARE PROVIDED UNDER THE TERMS OF THE GNU FREE DOCUMENTATION LICENSE WITH THE FURTHER UNDERSTANDING THAT: <_:orderedlist-1/>"
+#. (itstool) path: authorgroup/author
+#: C/index.docbook:38
+msgid "<orgname>MATE Documentation Project</orgname> <affiliation> <orgname>MATE Desktop</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:46
-msgid "<surname>MATE Documentation Team</surname> <affiliation> <orgname>MATE DESKTOP</orgname> </affiliation>"
+#: C/index.docbook:44
+msgid "<personname> <firstname>Wolfgang</firstname> <surname>Ulbrich</surname> </personname> <affiliation> <orgname>Dark Side of the Moon</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:52
-msgid "<firstname>Wolfgang</firstname> <surname>Ulbrich</surname> <affiliation> <orgname>Dark Side of the Moon</orgname> </affiliation>"
+#: C/index.docbook:53
+msgid "<personname> <firstname>Sun</firstname> <surname>GNOME Documentation Team</surname> </personname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:59
-msgid "<firstname>Sun</firstname> <surname>GNOME Documentation Team</surname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation>"
+#: C/index.docbook:62
+msgid "<personname> <firstname>Shaun</firstname> <surname>McCance</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>shaunm@gnome.org</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:66
-msgid "<firstname>Shaun</firstname> <surname>McCance</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>shaunm@gnome.org</email>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:74
-msgid "<surname>Karderio</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>karderio at gmail dot com</email>"
+#: C/index.docbook:72
+msgid "<personname> <surname>Karderio</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>karderio@gmail.com</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
 #: C/index.docbook:81
-msgid "<firstname>Joachim</firstname> <surname>Noreiko</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>jnoreiko at yahoo dot com</email>"
+msgid "<personname> <firstname>Joachim</firstname> <surname>Noreiko</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>jnoreiko@yahoo.com</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:89
-msgid "<firstname>Daniel</firstname> <surname>Espinosa Ortiz</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>esodan at gmail dot com</email>"
+#: C/index.docbook:91
+msgid "<personname> <firstname>Daniel</firstname> <surname>Espinosa Ortiz</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>esodan@gmail.com</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:97
-msgid "<firstname>Brent</firstname> <surname>Smith</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>mate at nextreality dot net</email>"
+#: C/index.docbook:101
+msgid "<personname> <firstname>Brent</firstname> <surname>Smith</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>mate@nextreality.net</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:105
-msgid "<firstname>Tim</firstname> <surname>Littlemore</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>tim at tjl2 dot com</email>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:113
-msgid "<firstname>John</firstname> <surname>Stowers</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>john dot stowers at gmail dot com</email>"
+#: C/index.docbook:111
+msgid "<personname> <firstname>Tim</firstname> <surname>Littlemore</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>tim@tjl2.com</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
 #: C/index.docbook:121
-msgid "<firstname>Nigel</firstname> <surname>Tao</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>nigel dot tao at myrealbox dot com</email>"
+msgid "<personname> <firstname>John</firstname> <surname>Stowers</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>john.stowers@gmail.com</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:129
-msgid "<firstname>Matthew</firstname> <surname>East</surname> <affiliation> <orgname>Ubuntu Documentation Project</orgname> </affiliation> <email>mdke at ubuntu dot com</email>"
+#: C/index.docbook:131
+msgid "<personname> <firstname>Nigel</firstname> <surname>Tao</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>nigel.tao@myrealbox.com</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:137
-msgid "<firstname>Carlos</firstname> <surname>Garnacho Parro</surname> <affiliation> <orgname>GNOME Project</orgname> </affiliation> <email>carlosg@gnome.org</email>"
+#: C/index.docbook:141
+msgid "<personname> <firstname>Matthew</firstname> <surname>East</surname> </personname> <affiliation> <orgname>Ubuntu Documentation Project</orgname> </affiliation> <email>mdke@ubuntu.com</email>"
+msgstr ""
+
+#. (itstool) path: authorgroup/author
+#: C/index.docbook:151
+msgid "<personname> <firstname>Carlos</firstname> <surname>Garnacho Parro</surname> </personname> <affiliation> <orgname>GNOME Project</orgname> </affiliation> <email>carlosg@gnome.org</email>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:155
+#: C/index.docbook:171
 msgid "Wolfgang Ulbrich"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:151
+#: C/index.docbook:167
 msgid "<revnumber>2.15</revnumber> <date>2015-07-01</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:163
+#: C/index.docbook:179
 msgid "Karderio"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:164
-#: C/index.docbook:172
-#: C/index.docbook:179
-#: C/index.docbook:187
+#: C/index.docbook:180
+#: C/index.docbook:188
 #: C/index.docbook:195
 #: C/index.docbook:203
 #: C/index.docbook:211
@@ -180,152 +141,174 @@ msgstr ""
 #: C/index.docbook:227
 #: C/index.docbook:235
 #: C/index.docbook:243
+#: C/index.docbook:251
+#: C/index.docbook:259
 msgid "GNOME Documentation Project"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:159
+#: C/index.docbook:175
 msgid "<revnumber>2.14</revnumber> <date>2006-02-03</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:171
+#: C/index.docbook:187
 msgid "Shaun McCance"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:167
+#: C/index.docbook:183
 msgid "<revnumber>2.10</revnumber> <date>2005-03-08</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:175
-msgid "<revnumber>MATE 2.8 Desktop User Guide V2.8</revnumber> <date>September 2004</date> <_:revdescription-1/>"
+#: C/index.docbook:191
+msgid "<revnumber>2.8</revnumber> <date>September 2004</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:186
-#: C/index.docbook:194
 #: C/index.docbook:202
 #: C/index.docbook:210
 #: C/index.docbook:218
 #: C/index.docbook:226
 #: C/index.docbook:234
 #: C/index.docbook:242
+#: C/index.docbook:250
+#: C/index.docbook:258
 msgid "Sun Microsystems"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:182
-msgid "<revnumber>MATE 2.4 Desktop User Guide V2.7</revnumber> <date>September 2003</date> <_:revdescription-1/>"
-msgstr ""
-
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:190
-msgid "<revnumber>MATE 2.4 Desktop User Guide V2.6</revnumber> <date>August 2003</date> <_:revdescription-1/>"
-msgstr ""
-
-#. (itstool) path: revhistory/revision
 #: C/index.docbook:198
-msgid "<revnumber>MATE 2.2.1 Desktop User Guide V2.5</revnumber> <date>March 2003</date> <_:revdescription-1/>"
+msgid "<revnumber>2.7</revnumber> <date>September 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
 #: C/index.docbook:206
-msgid "<revnumber>MATE 2.2 Desktop User Guide V2.4</revnumber> <date>January 2003</date> <_:revdescription-1/>"
+msgid "<revnumber>2.6</revnumber> <date>August 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
 #: C/index.docbook:214
-msgid "<revnumber>MATE 2.0 Desktop User Guide V2.3</revnumber> <date>October 2002</date> <_:revdescription-1/>"
+msgid "<revnumber>2.5</revnumber> <date>March 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
 #: C/index.docbook:222
-msgid "<revnumber>MATE 2.0 Desktop User Guide V2.2</revnumber> <date>August 2002</date> <_:revdescription-1/>"
+msgid "<revnumber>2.4</revnumber> <date>January 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
 #: C/index.docbook:230
-msgid "<revnumber>MATE 2.0 Desktop User Guide V2.1</revnumber> <date>August 2002</date> <_:revdescription-1/>"
+msgid "<revnumber>2.3</revnumber> <date>October 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
 #: C/index.docbook:238
-msgid "<revnumber>MATE 2.0 Desktop User Guide V1.0</revnumber> <date>May 2002</date> <_:revdescription-1/>"
+msgid "<revnumber>2.2</revnumber> <date>August 2002</date> <_:revdescription-1/>"
 msgstr ""
 
-#. (itstool) path: bookinfo/releaseinfo
-#: C/index.docbook:248
+#. (itstool) path: revhistory/revision
+#: C/index.docbook:246
+msgid "<revnumber>2.1</revnumber> <date>August 2002</date> <_:revdescription-1/>"
+msgstr ""
+
+#. (itstool) path: revhistory/revision
+#: C/index.docbook:254
+msgid "<revnumber>1.0</revnumber> <date>May 2002</date> <_:revdescription-1/>"
+msgstr ""
+
+#. (itstool) path: info/releaseinfo
+#: C/index.docbook:264
 msgid "This manual describes version 1.10 of the MATE desktop."
 msgstr ""
 
-#. (itstool) path: legalnotice/title
-#. (itstool) path: appendix/title
-#: C/index.docbook:252
-#: C/gosfeedback.xml:2
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:4
+msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <link xlink:href=\"https://www.gnu.org/licenses/fdl-1.1.html\">link</link> or in the file COPYING-DOCS distributed with this manual."
+msgstr ""
+
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:13
+msgid "This manual is part of a collection of MATE manuals distributed under the GFDL. If you want to distribute this manual separately from the collection, you can do so by adding a copy of the license to the manual, as described in section 6 of the license."
+msgstr ""
+
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:20
+msgid "Many of the names used by companies to distinguish their products and services are claimed as trademarks. Where those names appear in any MATE documentation, and the members of the MATE Documentation Project are made aware of those trademarks, then the names are in capital letters or initial capital letters."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/legal.xml:36
+msgid "DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS FREE OF DEFECTS MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY, ACCURACY, AND PERFORMANCE OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS WITH YOU. SHOULD ANY DOCUMENT OR MODIFIED VERSION PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL WRITER, AUTHOR OR ANY CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER; AND"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/legal.xml:56
+msgid "UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE AUTHOR, INITIAL WRITER, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER DAMAGES OR LOSSES ARISING OUT OF OR RELATING TO USE OF THE DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES."
+msgstr ""
+
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:29
+msgid "DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT ARE PROVIDED UNDER THE TERMS OF THE GNU FREE DOCUMENTATION LICENSE WITH THE FURTHER UNDERSTANDING THAT: <_:orderedlist-1/>"
+msgstr ""
+
+#. (itstool) path: formalpara/title
+#. (itstool) path: info/title
+#: C/legal.xml:77
+#: C/gosfeedback.xml:7
 msgid "Feedback"
 msgstr ""
 
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:253
-msgid "To report a bug or make a suggestion regarding the MATE desktop or this manual, follow the directions in the <xref linkend=\"feedback\"/>."
+#. (itstool) path: formalpara/para
+#: C/legal.xml:78
+msgid "To report a bug or make a suggestion regarding the MATE Desktop or this manual, follow the directions in the <link xlink:href=\"help:mate-user-guide/feedback\">MATE Feedback Page</link>."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/legal.xml:9
-msgid "link"
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/legal.xml:2
-msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <_:ulink-1/> or in the file COPYING-DOCS distributed with this manual."
-msgstr ""
-
-#. (itstool) path: chapter/title
-#: C/gosbasic.xml:3
+#. (itstool) path: info/title
+#: C/gosbasic.xml:6
 msgid "Basic Skills"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/gosbasic.xml:11
+#: C/gosbasic.xml:14
 msgid "This chapter introduces you to the basic skills that you need to work with the MATE Desktop."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:16
+#. (itstool) path: info/title
+#: C/gosbasic.xml:18
 msgid "Mouse Skills"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:21
+#: C/gosbasic.xml:23
 msgid "<primary>basic skills</primary> <secondary>mouse skills</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:25
+#: C/gosbasic.xml:27
 msgid "<primary>mouse</primary> <secondary>basic skills</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:39
+#: C/gosbasic.xml:41
 msgid "This section describes what the mouse buttons do, and what the different pointers mean."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:43
+#: C/gosbasic.xml:45
 msgid "A mouse is a pointing device that lets you move the mouse pointer on the screen. The mouse pointer is usually a small arrow with which you point to objects on your screen. Pressing a mouse button will perform a particular action on the object over which your mouse pointer is situated, depending on which button you press."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:49
+#. (itstool) path: info/title
+#: C/gosbasic.xml:50
 msgid "Mouse Button Conventions"
 msgstr ""
 
-#. (itstool) path: section/titleabbrev
-#. (itstool) path: section/title
+#. (itstool) path: info/titleabbrev
+#. (itstool) path: info/title
 #: C/gosbasic.xml:50
-#: C/gospanel.xml:988
+#: C/gospanel.xml:974
 msgid "Buttons"
 msgstr ""
 
@@ -356,7 +339,7 @@ msgstr ""
 
 #. (itstool) path: varlistentry/term
 #: C/gosbasic.xml:78
-#: C/gosbasic.xml:246
+#: C/gosbasic.xml:244
 msgid "Left mouse button"
 msgstr ""
 
@@ -367,7 +350,7 @@ msgstr ""
 
 #. (itstool) path: varlistentry/term
 #: C/gosbasic.xml:85
-#: C/gosbasic.xml:257
+#: C/gosbasic.xml:255
 msgid "Middle mouse button"
 msgstr ""
 
@@ -378,7 +361,7 @@ msgstr ""
 
 #. (itstool) path: varlistentry/term
 #: C/gosbasic.xml:91
-#: C/gosbasic.xml:267
+#: C/gosbasic.xml:265
 msgid "Right mouse button"
 msgstr ""
 
@@ -392,236 +375,236 @@ msgstr ""
 msgid "Use <application>Mouse Preferences</application> to reverse the orientation of your mouse device. You will then need to reverse the mouse button conventions used in this manual and other MATE documentation. See <xref linkend=\"prefs-mouse\"/> for more information about setting your mouse preferences."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:104
+#. (itstool) path: info/title
+#: C/gosbasic.xml:103
 msgid "Mouse Actions"
 msgstr ""
 
-#. (itstool) path: section/titleabbrev
-#: C/gosbasic.xml:105
+#. (itstool) path: info/titleabbrev
+#: C/gosbasic.xml:103
 msgid "Actions"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:111
+#: C/gosbasic.xml:109
 msgid "<primary>mouse</primary> <secondary>action conventions</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:115
+#: C/gosbasic.xml:113
 msgid "<primary>mouse</primary> <secondary>action terminology</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:120
+#: C/gosbasic.xml:118
 msgid "The following conventions are used in this manual to describe actions that you take with the mouse:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:131
-#: C/gosbasic.xml:872
-#: C/gosbasic.xml:965
-#: C/goscaja.xml:767
-#: C/goscaja.xml:1503
-#: C/goscaja.xml:1628
-#: C/gospanel.xml:884
-#: C/gospanel.xml:935
+#: C/gosbasic.xml:129
+#: C/gosbasic.xml:855
+#: C/gosbasic.xml:948
+#: C/goscaja.xml:759
+#: C/goscaja.xml:1483
+#: C/goscaja.xml:1604
+#: C/gospanel.xml:870
+#: C/gospanel.xml:921
 msgid "Action"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:134
+#: C/gosbasic.xml:132
 msgid "Definition"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:141
+#: C/gosbasic.xml:139
 msgid "Click"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:144
+#: C/gosbasic.xml:142
 msgid "Press and release the left mouse button, without moving the mouse."
 msgstr ""
 
 #. (itstool) path: entry/para
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:150
-#: C/gospanel.xml:410
+#: C/gosbasic.xml:148
+#: C/gospanel.xml:409
 msgid "Left-click"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:153
+#: C/gosbasic.xml:151
 msgid "Same as <emphasis>click</emphasis>. The term 'left-click' is used where there might be confusion with <emphasis>right-click</emphasis>."
 msgstr ""
 
 #. (itstool) path: entry/para
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:160
-#: C/gospanel.xml:416
+#: C/gosbasic.xml:158
+#: C/gospanel.xml:415
 msgid "Middle-click"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:163
+#: C/gosbasic.xml:161
 msgid "Press and release the middle mouse button, without moving the mouse."
 msgstr ""
 
 #. (itstool) path: entry/para
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:169
-#: C/gospanel.xml:423
+#: C/gosbasic.xml:167
+#: C/gospanel.xml:422
 msgid "Right-click"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:172
+#: C/gosbasic.xml:170
 msgid "Press and release the right mouse button, without moving the mouse."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:178
+#: C/gosbasic.xml:176
 msgid "Double-click"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:181
+#: C/gosbasic.xml:179
 msgid "Press and release the left mouse button twice in rapid succession without moving the mouse. You can configure the sensitivity to double-clicks by changing the <emphasis>Double-click Timeout</emphasis> setting: see <xref linkend=\"prefs-mouse\"/> for more information."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:190
+#: C/gosbasic.xml:188
 msgid "Click-and-drag"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:193
+#: C/gosbasic.xml:191
 msgid "Press and do not release the left mouse button, and then move the mouse with the button still held down, and finally release the button."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:198
+#: C/gosbasic.xml:196
 msgid "Dragging with the mouse is used in many different contexts. This moves an object around the screen with the mouse. The object is <emphasis>dropped</emphasis> at the location where the mouse button is released. This action is also called <emphasis>drag-and-drop</emphasis>. Clicking on an element of the interface to move it is sometimes called a <emphasis>grab</emphasis>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:209
+#: C/gosbasic.xml:207
 msgid "For example, you can change the position of a window by dragging on its title bar, or move a file by dragging its icon from one window and dropping it on another."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:213
+#: C/gosbasic.xml:211
 msgid "The left mouse buttons is usually used to perform drag actions, although the middle mouse button is sometimes used for an alternate drag action."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:221
+#: C/gosbasic.xml:219
 msgid "Click-and-hold"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:224
+#: C/gosbasic.xml:222
 msgid "Press and do not release the left mouse button."
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:232
+#: C/gosbasic.xml:230
 msgid "<primary>mouse</primary> <secondary>actions</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:237
+#: C/gosbasic.xml:235
 msgid "You can perform the following actions with the mouse:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:249
+#: C/gosbasic.xml:247
 msgid "Select text."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:250
+#: C/gosbasic.xml:248
 msgid "Select items."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:251
+#: C/gosbasic.xml:249
 msgid "Drag items."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:252
+#: C/gosbasic.xml:250
 msgid "Activate items."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:260
+#: C/gosbasic.xml:258
 msgid "Paste text."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:261
+#: C/gosbasic.xml:259
 msgid "Move items."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:262
+#: C/gosbasic.xml:260
 msgid "Move windows to the back."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:268
+#: C/gosbasic.xml:266
 msgid "Use the right mouse button to open a context menu for an item, if a menu applies. For most items, you can also use the <keycombo><keycap>Shift</keycap><keycap>F10</keycap></keycombo> keyboard shortcut to open the context menu once the item has been selected."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:276
+#: C/gosbasic.xml:274
 msgid "For example, when viewing files in the file manager, you select a file by clicking with the left mouse button and open a file by double-clicking with the left mouse button. Clicking with the right mouse button will bring up a context menu for that file."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosbasic.xml:281
+#: C/gosbasic.xml:279
 msgid "In most applications, you can select text with your left mouse button and paste it in another application using the middle mouse button. This is called primary selection paste, and works separately from your normal clipboard operations."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosbasic.xml:286
+#: C/gosbasic.xml:284
 msgid "To select more than one item, you can hold the <keycap>Ctrl</keycap> key to select multiple items, or hold the <keycap>Shift</keycap> key to select a contiguous range of items. You can also drag a <firstterm>bounding box</firstterm> to select several items by starting the drag in the empty space around items and dragging out a rectangle."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:297
+#. (itstool) path: info/title
+#: C/gosbasic.xml:294
 msgid "Mouse Pointers"
 msgstr ""
 
-#. (itstool) path: section/titleabbrev
-#: C/gosbasic.xml:298
+#. (itstool) path: info/titleabbrev
+#: C/gosbasic.xml:294
 msgid "Pointers"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:303
+#: C/gosbasic.xml:299
 msgid "<primary>mouse</primary> <secondary>pointers</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:307
+#: C/gosbasic.xml:303
 msgid "<primary>pointers</primary> <see>mouse pointers</see>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:312
+#: C/gosbasic.xml:308
 msgid "As you use the mouse, the appearance of the mouse pointer can change. The appearance of the pointer provides feedback about a particular operation, location, or state."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:316
+#: C/gosbasic.xml:312
 msgid "The following mouse pointers are shown as your mouse passes over different elements of the screen:"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosbasic.xml:319
+#: C/gosbasic.xml:315
 msgid "Your mouse pointers will differ from those shown here if you are using a different pointer theme. Your distributor or vendor may have set a different default theme."
 msgstr ""
 
@@ -630,18 +613,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:327
+#: C/gosbasic.xml:322
 msgctxt "_"
 msgid "external ref='figures/normal_pointer.png' md5='47960823c1883b50400d4fb7be857c72'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:323
+#: C/gosbasic.xml:319
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/normal_pointer.png\"/> </imageobject> <textobject> <phrase>Normal pointer.</phrase> </textobject> </inlinemediaobject> Normal pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:335
+#: C/gosbasic.xml:330
 msgid "This pointer appears during normal use of the mouse."
 msgstr ""
 
@@ -650,18 +633,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:343
+#: C/gosbasic.xml:337
 msgctxt "_"
 msgid "external ref='figures/busy_pointer.png' md5='99db6994613731ca7687bd700c471b2d'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:339
+#: C/gosbasic.xml:334
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/busy_pointer.png\"/> </imageobject> <textobject> <phrase>Busy pointer.</phrase> </textobject> </inlinemediaobject> Busy pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:351
+#: C/gosbasic.xml:345
 msgid "This pointer appears over a window that is busy performing a task. You cannot use the mouse to give this window any input, but you can move to another window and work with that."
 msgstr ""
 
@@ -670,18 +653,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:358
+#: C/gosbasic.xml:351
 msgctxt "_"
 msgid "external ref='figures/resize_pointer.png' md5='43e8186584e1879ba078caedf0a9f33f'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:354
+#: C/gosbasic.xml:348
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/resize_pointer.png\"/> </imageobject> <textobject> <phrase>Resize pointer.</phrase> </textobject> </inlinemediaobject> Resize pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:366
+#: C/gosbasic.xml:359
 msgid "This pointer indicates that you can grab the control to resize parts of the interface. This appears over the borders of windows and over resize handles between panes in a window. The direction of the arrows indicates in which direction you can resize."
 msgstr ""
 
@@ -690,18 +673,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:376
+#: C/gosbasic.xml:368
 msgctxt "_"
 msgid "external ref='figures/hyperlink_pointer.png' md5='41030ede726c6f3d9f1bd1f05456f3f6'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:372
+#: C/gosbasic.xml:365
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/hyperlink_pointer.png\"/> </imageobject> <textobject> <phrase>Hand pointer</phrase> </textobject> </inlinemediaobject> Hand pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:384
+#: C/gosbasic.xml:376
 msgid "This pointer appears when you hover over a <glossterm>hypertext link</glossterm>, in a web page for example. This pointer indicates that you can click on the link to load a new document or perform an action."
 msgstr ""
 
@@ -710,23 +693,23 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:394
+#: C/gosbasic.xml:385
 msgctxt "_"
 msgid "external ref='figures/ibeam_pointer.png' md5='77aa93e74d640173c96801747bf564d1'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:390
+#: C/gosbasic.xml:382
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/ibeam_pointer.png\"/> </imageobject> <textobject> <phrase>I-beam pointer</phrase> </textobject> </inlinemediaobject> I-beam pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:402
+#: C/gosbasic.xml:393
 msgid "This pointer is shown when the mouse is over text that you can select or edit. Click to place the cursor where you want to type text, or drag to select text."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:407
+#: C/gosbasic.xml:398
 msgid "The following mouse pointers are shown when dragging an item such as a file, or a piece of text. They indicate the result of releasing the mouse button to drop the object being moved."
 msgstr ""
 
@@ -735,19 +718,19 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:417
-#: C/goscaja.xml:1647
+#: C/gosbasic.xml:407
+#: C/goscaja.xml:1623
 msgctxt "_"
 msgid "external ref='figures/move_pointer.png' md5='1a4e4a188a0132fc783c465d42c52426'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:413
+#: C/gosbasic.xml:404
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/move_pointer.png\"/> </imageobject> <textobject> <phrase>Move pointer.</phrase> </textobject> </inlinemediaobject> Move pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:425
+#: C/gosbasic.xml:415
 msgid "This pointer indicates that when you drop the object, the object is moved from the old location to the new location."
 msgstr ""
 
@@ -756,19 +739,19 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:434
-#: C/goscaja.xml:1667
+#: C/gosbasic.xml:423
+#: C/goscaja.xml:1643
 msgctxt "_"
 msgid "external ref='figures/copy_pointer.png' md5='228984e885befffd71ae4eadd7ee790e'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:430
+#: C/gosbasic.xml:420
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/copy_pointer.png\"/> </imageobject> <textobject> <phrase>Copy pointer.</phrase> </textobject> </inlinemediaobject> Copy pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:442
+#: C/gosbasic.xml:431
 msgid "This pointer indicates that when you drop the object, a copy of the object is created where you drop it."
 msgstr ""
 
@@ -777,19 +760,19 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:451
-#: C/goscaja.xml:1690
+#: C/gosbasic.xml:439
+#: C/goscaja.xml:1665
 msgctxt "_"
 msgid "external ref='figures/link_pointer.png' md5='8fb4e2d2fcaea8b59a653a3d8fc85b5a'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:447
+#: C/gosbasic.xml:436
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/link_pointer.png\"/> </imageobject> <textobject> <phrase>Symbolic link pointer.</phrase> </textobject> </inlinemediaobject> Symbolic link pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:459
+#: C/gosbasic.xml:447
 msgid "This pointer indicates that when you drop the object, a <firstterm>symbolic link</firstterm> to the object is created where you drop the object. A symbolic link is a special type of file that points to another file or folder. For more on this, see <xref linkend=\"caja-symlink\"/>."
 msgstr ""
 
@@ -798,19 +781,19 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:470
-#: C/goscaja.xml:1746
+#: C/gosbasic.xml:457
+#: C/goscaja.xml:1720
 msgctxt "_"
 msgid "external ref='figures/ask_pointer.png' md5='bd23edcf2659006110ce30a14f0abb35'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:466
+#: C/gosbasic.xml:454
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/ask_pointer.png\"/> </imageobject> <textobject> <phrase>Ask pointer.</phrase> </textobject> </inlinemediaobject> Ask pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:478
+#: C/gosbasic.xml:465
 msgid "This pointer indicates that when you drop the object, you will be given a choice of what to do. A menu will open to allow you to choose which operation you would like to perform. For instance, you may be able to move, copy, or create a symbolic link."
 msgstr ""
 
@@ -819,18 +802,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:488
+#: C/gosbasic.xml:474
 msgctxt "_"
 msgid "external ref='figures/not_available_pointer.png' md5='19601aaf360da25b8a0d1d18b45ed99e'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:484
+#: C/gosbasic.xml:471
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/not_available_pointer.png\"/> </imageobject> <textobject> <phrase>Not available pointer.</phrase> </textobject> </inlinemediaobject> Not available pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:496
+#: C/gosbasic.xml:482
 msgid "This pointer indicates that you cannot drop the object at the current location. Releasing the mouse button now will have no effect: the dragged object will be returned to its starting location."
 msgstr ""
 
@@ -839,18 +822,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:504
+#: C/gosbasic.xml:489
 msgctxt "_"
 msgid "external ref='figures/move_panel_object_pointer.png' md5='e4244fb77b0df2b0c451328dce6fa175'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:500
+#: C/gosbasic.xml:486
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/move_panel_object_pointer.png\"/> </imageobject> <textobject> <phrase>Move panel object pointer.</phrase> </textobject> </inlinemediaobject> Move panel object pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:512
+#: C/gosbasic.xml:497
 msgid "This pointer appears when you drag a panel or a panel object with the middle mouse button. See <xref linkend=\"panels\"/> for more information on panels."
 msgstr ""
 
@@ -859,4144 +842,4133 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosbasic.xml:521
+#: C/gosbasic.xml:505
 msgctxt "_"
 msgid "external ref='figures/movewindow_pointer.png' md5='8496a1d62cbfbe5272f8f5fa6f173c4c'"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosbasic.xml:517
+#: C/gosbasic.xml:502
 msgid "<inlinemediaobject> <imageobject> <imagedata format=\"PNG\" fileref=\"figures/movewindow_pointer.png\"/> </imageobject> <textobject> <phrase>Move window pointer.</phrase> </textobject> </inlinemediaobject> Move window pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosbasic.xml:529
+#: C/gosbasic.xml:513
 msgid "This pointer appears when you drag a window to move it. See <xref linkend=\"windows-manipulating\"/> for more information on moving windows."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:538
+#. (itstool) path: info/title
+#: C/gosbasic.xml:521
 msgid "Keyboard Skills"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:543
+#: C/gosbasic.xml:527
 msgid "<primary>basic skills</primary> <secondary>keyboard skills</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:547
+#: C/gosbasic.xml:531
 msgid "<primary>keyboard</primary> <secondary>basic skills</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:552
+#: C/gosbasic.xml:536
 msgid "For almost every task that you can perform with the mouse, you can use the keyboard to perform the same task. <firstterm>Shortcut keys</firstterm> are keys that provide you with a quick way to perform a task."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:556
+#: C/gosbasic.xml:540
 msgid "You can use shortcut keys to perform general MATE Desktop tasks and to work with interface items such as panels and windows. You can also use shortcut keys in applications. To customize your shortcut keys, use the <application>Keyboard Shortcuts</application> preference tool. See <xref linkend=\"prefs-keyboard-shortcuts\"/> for more information about configuring keyboard shortcuts."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosbasic.xml:563
+#: C/gosbasic.xml:547
 msgid "Many PC keyboards come with two special keys for the Windows operating system: a key with a Microsoft Windows™ logo and a key for accessing context menus."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosbasic.xml:564
+#: C/gosbasic.xml:548
 msgid "In MATE, the Windows key is often configured to act as an additional modifier key, called the <firstterm>Super key</firstterm>. The context menu key can be used to access the context menu of the selected item, just as the <keycombo><keycap>Shift</keycap><keycap>F10</keycap></keycombo> keyboard shortcut can."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:570
+#: C/gosbasic.xml:554
 msgid "You can also modify the MATE Desktop preferences to use keyboard accessibility features. See <xref linkend=\"prefs-keyboard-a11y\"/> for more information about the keyboard accessibility features."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:574
+#: C/gosbasic.xml:558
 msgid "The following sections describe the shortcut keys that you can use throughout the desktop and applications."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:578
+#. (itstool) path: info/title
+#: C/gosbasic.xml:561
 msgid "Global Shortcut Keys"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:583
+#: C/gosbasic.xml:567
 msgid "<primary>shortcut keys</primary> <secondary>global</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:588
+#: C/gosbasic.xml:572
 msgid "Global shortcut keys enable you to use the keyboard to perform tasks related to your desktop, rather than tasks on the currently selected window or application. The following table lists some global shortcut keys:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:599
-#: C/gosbasic.xml:728
-#: C/gosbasic.xml:869
+#: C/gosbasic.xml:583
+#: C/gosbasic.xml:711
+#: C/gosbasic.xml:852
 msgid "Shortcut Key"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:602
-#: C/gosbasic.xml:731
-#: C/gospanel.xml:1089
-#: C/gostools.xml:96
-#: C/gostools.xml:152
+#: C/gosbasic.xml:586
+#: C/gosbasic.xml:714
+#: C/gospanel.xml:1075
+#: C/gostools.xml:98
+#: C/gostools.xml:154
 msgid "Function"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:609
+#: C/gosbasic.xml:593
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F1</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:614
+#: C/gosbasic.xml:598
 msgid "Open the <guimenu>Applications Menu</guimenu>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:619
+#: C/gosbasic.xml:603
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F2</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:624
+#: C/gosbasic.xml:608
 msgid "Display the <guilabel>Run Application</guilabel> dialog. See <xref linkend=\"tools-run-app\"/> for more information."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:631
-#: C/gostools.xml:103
+#: C/gosbasic.xml:615
+#: C/gostools.xml:105
 msgid "<keycap>Print Screen</keycap>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:636
+#: C/gosbasic.xml:620
 msgid "Take a screenshot of the entire desktop. See <xref linkend=\"tools-screenshot\"/> for more information."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:642
+#: C/gosbasic.xml:626
 msgid "<keycombo> <keycap>Alt</keycap><keycap>Print Screen</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:647
+#: C/gosbasic.xml:631
 msgid "Take a screenshot of the currently focused window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:652
+#: C/gosbasic.xml:636
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>Alt</keycap> <keycap>Arrow keys</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:658
+#: C/gosbasic.xml:642
 msgid "Switch to the workspace to the specified direction of the current workspace. See <xref linkend=\"overview-workspaces\"/> for more information on working with multiple workspaces."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:665
+#: C/gosbasic.xml:649
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>Alt</keycap> <keycap>D</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:671
+#: C/gosbasic.xml:655
 msgid "Minimize all windows and give focus to the desktop."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:676
-#: C/gosbasic.xml:738
+#: C/gosbasic.xml:660
+#: C/gosbasic.xml:721
 msgid "<keycombo> <keycap>Alt</keycap><keycap>Tab</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:681
-#: C/gosbasic.xml:743
+#: C/gosbasic.xml:665
+#: C/gosbasic.xml:726
 msgid "Switch between windows. A list of windows that you can select is displayed. Release the keys to select a window. You can press the <keycap>Shift</keycap> key to cycle through the windows in reverse order."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:689
+#: C/gosbasic.xml:673
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>Alt</keycap> <keycap>Tab</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:695
+#: C/gosbasic.xml:679
 msgid "Switch the focus between the panels and the desktop. A list of items that you can select is displayed. Release the keys to select an item. You can press the <keycap>Shift</keycap> key to cycle through the items in reverse order."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:707
+#. (itstool) path: info/title
+#: C/gosbasic.xml:690
 msgid "Window Shortcut Keys"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:712
+#: C/gosbasic.xml:695
 msgid "<primary>shortcut keys</primary> <secondary>window</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:717
+#: C/gosbasic.xml:700
 msgid "Window shortcut keys allow you to use the keyboard to perform tasks on the currently focused window. The following table lists some window shortcut keys:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:751
+#: C/gosbasic.xml:734
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F4</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:756
+#: C/gosbasic.xml:739
 msgid "Close the currently focused window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:761
+#: C/gosbasic.xml:744
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F5</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:766
+#: C/gosbasic.xml:749
 msgid "Unmaximize the current window, if it is maximized."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:771
+#: C/gosbasic.xml:754
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F7</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:776
+#: C/gosbasic.xml:759
 msgid "Move the currently focused window. After pressing this shortcut, you can move the window using either the mouse or the arrow keys. To finish the move, click the mouse or press any key on the keyboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:784
+#: C/gosbasic.xml:767
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F8</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:789
+#: C/gosbasic.xml:772
 msgid "Resize the currently focused window. After pressing this shortcut, you can resize the window using either the mouse or the arrow keys. To finish resizing, click the mouse or press any key on the keyboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:797
+#: C/gosbasic.xml:780
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F9</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:802
+#: C/gosbasic.xml:785
 msgid "Minimize the current window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:807
+#: C/gosbasic.xml:790
 msgid "<keycombo> <keycap>Alt</keycap><keycap>F10</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:812
+#: C/gosbasic.xml:795
 msgid "Maximize the current window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:817
+#: C/gosbasic.xml:800
 msgid "<keycombo> <keycap>Alt</keycap><keycap>spacebar</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:822
+#: C/gosbasic.xml:805
 msgid "Open the window menu for the currently selected window. The window menu allows you to perform actions on the window, such as minimizing, moving between workspaces, and closing."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:829
+#: C/gosbasic.xml:812
 msgid "<keycombo> <keycap>Shift</keycap><keycap>Ctrl</keycap><keycap>Alt</keycap> <keycap>Arrow keys</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:835
+#: C/gosbasic.xml:818
 msgid "Move the current window to another workspace in the specified direction. See <xref linkend=\"overview-workspaces\"/> for more information on working with multiple workspaces."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:846
+#. (itstool) path: info/title
+#: C/gosbasic.xml:828
 msgid "Application Keys"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:852
+#: C/gosbasic.xml:835
 msgid "<primary>shortcut keys</primary> <secondary>application</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:857
+#: C/gosbasic.xml:840
 msgid "Application shortcut keys enable you to perform application tasks. You can use shortcut keys to perform application tasks more quickly than if you use a mouse. The following table lists some common application shortcut keys:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:879
+#: C/gosbasic.xml:862
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>N</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:884
+#: C/gosbasic.xml:867
 msgid "Create a new document or window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:889
+#: C/gosbasic.xml:872
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>X</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:894
+#: C/gosbasic.xml:877
 msgid "Cut the selected text or region and place it on the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:900
+#: C/gosbasic.xml:883
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>C</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:905
+#: C/gosbasic.xml:888
 msgid "Copy the selected text or region onto the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:910
+#: C/gosbasic.xml:893
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>V</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:915
+#: C/gosbasic.xml:898
 msgid "Paste the contents of the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:920
+#: C/gosbasic.xml:903
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>Z</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:925
+#: C/gosbasic.xml:908
 msgid "Undo the last action."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:930
+#: C/gosbasic.xml:913
 msgid "<keycombo> <keycap>Ctrl</keycap><keycap>S</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:935
+#: C/gosbasic.xml:918
 msgid "Save the current document to disk."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:940
+#: C/gosbasic.xml:923
 msgid "<keycap>F1</keycap>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:943
+#: C/gosbasic.xml:926
 msgid "Load the online help document for the application."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:950
+#: C/gosbasic.xml:933
 msgid "In addition to these shortcut keys, all applications support a set of keys to navigate and work with the user interface. These keys allow you to perform operations that you might normally perform with a mouse. The following table describes some interface control keys:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:962
+#: C/gosbasic.xml:945
 msgid "Keys"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:972
+#: C/gosbasic.xml:955
 msgid "Arrow keys or <keycap>Tab</keycap>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:975
+#: C/gosbasic.xml:958
 msgid "Move between controls in the interface or items in a list."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:981
+#: C/gosbasic.xml:964
 msgid "<keycap>Enter</keycap> or <keycap>spacebar</keycap>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:984
+#: C/gosbasic.xml:967
 msgid "Activate or choose the selected item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:989
+#: C/gosbasic.xml:972
 msgid "<keycap>F10</keycap>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:992
+#: C/gosbasic.xml:975
 msgid "Activate the left-most menu of the application window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:997
+#: C/gosbasic.xml:980
 msgid "<keycombo> <keycap>Shift</keycap><keycap>F10</keycap> </keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:1002
+#: C/gosbasic.xml:985
 msgid "Activate the context menu for the selected item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:1007
+#: C/gosbasic.xml:990
 msgid "<keycap>Esc</keycap>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gosbasic.xml:1010
+#: C/gosbasic.xml:993
 msgid "Close a menu without selecting a menu item, or cancel a drag operation."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosbasic.xml:1020
+#. (itstool) path: info/title
+#: C/gosbasic.xml:1002
 msgid "Access Keys"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosbasic.xml:1025
+#: C/gosbasic.xml:1008
 msgid "<primary>access keys</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:1029
+#: C/gosbasic.xml:1012
 msgid "A <firstterm>menubar</firstterm> is a bar at the top of a window that contains the menus for the application. An <firstterm>access key</firstterm> is an underlined letter in a menubar, menu, or dialog that you can use to perform an action. On a menubar, the access key for each menu is underlined."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:1035
+#: C/gosbasic.xml:1018
 msgid "To open a menu, hold the <keycap>Alt</keycap> key, then press the access key. In the menu, the access key for each menu item is underlined. To choose a menu item when a menu is displayed, you can simply press the access key for the menu item."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:1040
+#: C/gosbasic.xml:1023
 msgid "For example, to open a new window in the <application>Help</application> application, press <keycombo><keycap>Alt</keycap><keycap>F</keycap></keycombo> to open the <guimenu>File</guimenu> menu, then press <keycap>N</keycap> to activate the <guimenuitem>New Window</guimenuitem> menu item."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosbasic.xml:1045
+#: C/gosbasic.xml:1028
 msgid "You can also use access keys to access elements in a dialog. In a dialog, one letter in most dialog elements is underlined. To access a particular dialog element, hold <keycap>Alt</keycap>, then press the access key."
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/goscustdesk.xml:2
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:6
 msgid "Configuring Your Desktop"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/goscustdesk.xml:18
+#: C/goscustdesk.xml:22
 msgid "This chapter describes how to use the preference tools to customize the MATE Desktop."
 msgstr ""
 
 #. (itstool) path: chapter/para
-#: C/goscustdesk.xml:22
+#: C/goscustdesk.xml:26
 msgid "A preference tool is a small application that allows you to change settings in the MATE Desktop. Each preference tool covers a particular aspect of your computer. For example, with the <application>Mouse</application> preference tool you can set your mouse to left-handed or right-handed use, or change the speed of the pointer on the screen. With the <application>Windows</application> preference tool you can set behavior common to all windows such as the way in which you select them with the mouse."
 msgstr ""
 
 #. (itstool) path: chapter/para
-#: C/goscustdesk.xml:23
+#: C/goscustdesk.xml:27
 msgid "To open a preference tool, choose <menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisubmenu></menuchoice> in the top panel. Choose the tool that you require from the submenu."
 msgstr ""
 
 #. (itstool) path: chapter/para
-#: C/goscustdesk.xml:24
+#: C/goscustdesk.xml:28
 msgid "With a few exceptions, the changes you make to settings in a preference tool take effect immediately, without needing to close the preference tool. You can keep the preference tool window open while you try the changes, and make further changes if you wish."
 msgstr ""
 
 #. (itstool) path: chapter/para
-#: C/goscustdesk.xml:25
+#: C/goscustdesk.xml:29
 msgid "Some applications or system components may add their own preference tools to the menu."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:26
+#: C/goscustdesk.xml:30
 msgid "Some preference tools let you modify essential parts of your system, and therefore require administrative access. When you open the preference tool, a dialog box will prompt you for your password. These are in the <menuchoice><guimenu>System</guimenu><guisubmenu>Administration</guisubmenu></menuchoice> submenu. This menu also contains more complex utility applications for managing and updating your system."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscustdesk.xml:30
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:32
 msgid "Personal"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:35
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:37
 msgid "Assistive Technologies Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:36
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:38
 msgid "<primary>accessibility</primary> <secondary>setting assistive technology preferences</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:41
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:43
 msgid "<primary>preference tools</primary> <secondary>Assistive Technologies</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:45
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:47
 msgid "Use the <application>Assistive Technologies</application> preference tool to enable assistive technologies in the MATE Desktop. You can also use the <application>Assistive Technology</application> preference tool to open other preference tools which contain preferences related to assistive technologies."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:49
+#: C/goscustdesk.xml:51
 msgid "<guibutton>Preferred Applications</guibutton> lets you specify assistive technology applications to start automatically when you log in. See <xref linkend=\"prefs-preferredapps\"/>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:52
+#: C/goscustdesk.xml:54
 msgid "<guibutton>Keyboard Accessibility</guibutton> lets you configure keyboard accessibility features such as sticky keys, slow keys or bounce keys. See <xref linkend=\"prefs-keyboard-a11y\"/>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:56
+#: C/goscustdesk.xml:58
 msgid "<guibutton>Mouse Accessibility</guibutton> lets you configure mouse accessibility features such as dwell clicking. See <xref linkend=\"goscustdesk-53\"/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:59
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:61
 msgid "<xref linkend=\"goscustaccess-TBL-14\"/> lists the assistive technology preferences that you can modify."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:62
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:63
 msgid "Assistive Technology Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:69
-#: C/goscustdesk.xml:223
-#: C/goscustdesk.xml:578
-#: C/goscustdesk.xml:979
-#: C/goscustdesk.xml:1375
-#: C/goscustdesk.xml:1521
-#: C/goscustdesk.xml:1762
-#: C/goscustdesk.xml:1898
-#: C/goscustdesk.xml:1997
-#: C/goscustdesk.xml:2070
-#: C/goscustdesk.xml:2178
-#: C/goscustdesk.xml:2339
-#: C/goscustdesk.xml:2625
-#: C/goscustdesk.xml:2695
-#: C/goscustdesk.xml:2757
-#: C/goscustdesk.xml:2887
-#: C/goscustdesk.xml:2962
-#: C/goscaja.xml:2417
-#: C/goscaja.xml:3049
-#: C/goscaja.xml:3171
-#: C/goscaja.xml:3418
-#: C/goscaja.xml:3989
-#: C/goscaja.xml:4144
-#: C/gospanel.xml:167
+#: C/goscustdesk.xml:70
+#: C/goscustdesk.xml:218
+#: C/goscustdesk.xml:566
+#: C/goscustdesk.xml:959
+#: C/goscustdesk.xml:1326
+#: C/goscustdesk.xml:1465
+#: C/goscustdesk.xml:1696
+#: C/goscustdesk.xml:1830
+#: C/goscustdesk.xml:1927
+#: C/goscustdesk.xml:1998
+#: C/goscustdesk.xml:2099
+#: C/goscustdesk.xml:2257
+#: C/goscustdesk.xml:2537
+#: C/goscustdesk.xml:2604
+#: C/goscustdesk.xml:2665
+#: C/goscustdesk.xml:2787
+#: C/goscustdesk.xml:2861
+#: C/goscaja.xml:2382
+#: C/goscaja.xml:3001
+#: C/goscaja.xml:3122
+#: C/goscaja.xml:3363
+#: C/goscaja.xml:3917
+#: C/goscaja.xml:4069
+#: C/gospanel.xml:168
 #: C/gospanel.xml:253
-#: C/gospanel.xml:1425
+#: C/gospanel.xml:1410
 msgid "Dialog Element"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:72
-#: C/goscustdesk.xml:226
-#: C/goscustdesk.xml:581
-#: C/goscustdesk.xml:982
-#: C/goscustdesk.xml:1378
-#: C/goscustdesk.xml:1524
-#: C/goscustdesk.xml:1765
-#: C/goscustdesk.xml:1901
-#: C/goscustdesk.xml:2000
-#: C/goscustdesk.xml:2073
-#: C/goscustdesk.xml:2181
-#: C/goscustdesk.xml:2342
-#: C/goscustdesk.xml:2628
-#: C/goscustdesk.xml:2698
-#: C/goscustdesk.xml:2760
-#: C/goscustdesk.xml:2890
-#: C/goscustdesk.xml:2965
-#: C/goscaja.xml:210
-#: C/goscaja.xml:399
-#: C/goscaja.xml:1236
-#: C/goscaja.xml:1402
-#: C/goscaja.xml:2079
-#: C/goscaja.xml:2420
-#: C/goscaja.xml:2684
-#: C/goscaja.xml:3052
-#: C/goscaja.xml:3174
-#: C/goscaja.xml:3309
-#: C/goscaja.xml:3421
-#: C/goscaja.xml:3646
-#: C/goscaja.xml:3794
-#: C/goscaja.xml:3938
-#: C/goscaja.xml:3992
-#: C/goscaja.xml:4079
-#: C/goscaja.xml:4147
-#: C/goscaja.xml:4230
-#: C/gospanel.xml:170
+#: C/goscustdesk.xml:73
+#: C/goscustdesk.xml:221
+#: C/goscustdesk.xml:569
+#: C/goscustdesk.xml:962
+#: C/goscustdesk.xml:1329
+#: C/goscustdesk.xml:1468
+#: C/goscustdesk.xml:1699
+#: C/goscustdesk.xml:1833
+#: C/goscustdesk.xml:1930
+#: C/goscustdesk.xml:2001
+#: C/goscustdesk.xml:2102
+#: C/goscustdesk.xml:2260
+#: C/goscustdesk.xml:2540
+#: C/goscustdesk.xml:2607
+#: C/goscustdesk.xml:2668
+#: C/goscustdesk.xml:2790
+#: C/goscustdesk.xml:2864
+#: C/goscaja.xml:209
+#: C/goscaja.xml:395
+#: C/goscaja.xml:1219
+#: C/goscaja.xml:1383
+#: C/goscaja.xml:2049
+#: C/goscaja.xml:2385
+#: C/goscaja.xml:2641
+#: C/goscaja.xml:3004
+#: C/goscaja.xml:3125
+#: C/goscaja.xml:3259
+#: C/goscaja.xml:3366
+#: C/goscaja.xml:3590
+#: C/goscaja.xml:3730
+#: C/goscaja.xml:3867
+#: C/goscaja.xml:3920
+#: C/goscaja.xml:4006
+#: C/goscaja.xml:4072
+#: C/goscaja.xml:4154
+#: C/gospanel.xml:171
 #: C/gospanel.xml:256
-#: C/gospanel.xml:584
-#: C/gospanel.xml:1428
+#: C/gospanel.xml:577
+#: C/gospanel.xml:1413
 msgid "Description"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:79
+#: C/goscustdesk.xml:80
 msgid "<guilabel>Enable assistive technologies</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:84
+#: C/goscustdesk.xml:85
 msgid "Select this option to enable assistive technologies in the MATE Desktop."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:86
+#: C/goscustdesk.xml:87
 msgid "Note that for technical reasons, you have to log in again after enabling this option for it to be fully effective."
 msgstr ""
 
-#. (itstool) path: sect2/title
+#. (itstool) path: info/title
 #: C/goscustdesk.xml:96
 msgid "Keyboard Shortcuts Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:100
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:99
 msgid "<primary>preference tools</primary> <secondary>Keyboard Shortcuts</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:104
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:103
 msgid "<primary>shortcut keys</primary> <secondary>configuring</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:109
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:107
 msgid "<primary>keyboard shortcuts</primary> <secondary>configuring</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:113
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:111
 msgid "Use the <application>Keyboard Shortcuts</application> preference tool to customize the default keyboard shortcuts to your requirements."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:115
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:113
 msgid "A <firstterm>keyboard shortcut</firstterm> is a key or combination of keys that provides an alternative to standard ways of performing an action. For more on keyboard shortcuts, and a list of the default shortcuts in MATE, see <xref linkend=\"keyboard-skills\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:118
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:116
 msgid "To edit a keyboard shortcut, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:120
+#: C/goscustdesk.xml:118
 msgid "Double-click on the shortcut that you want to edit. If you are using the keyboard, use the arrow keys to select the shortcut and press <keycap>Return</keycap>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:123
+#: C/goscustdesk.xml:121
 msgid "Press the new key or key combination you want to assign to the action."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:124
+#: C/goscustdesk.xml:122
 msgid "To clear a shortcut, press <keycap>Backspace</keycap>. The action is now marked as <guilabel>Disabled</guilabel>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:128
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:126
 msgid "To cancel assigning a shortcut, click elsewhere in the window or press <keycap>Escape</keycap>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:130
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:128
 msgid "The shortcuts you can customize are grouped as follows:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:133
-#: C/gosoverview.xml:47
+#: C/goscustdesk.xml:131
+#: C/gosoverview.xml:48
 msgid "Desktop"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:134
+#: C/goscustdesk.xml:132
 msgid "These are general shortcuts for the whole desktop, such as logging out, <link linkend=\"lock-screen\">locking the screen</link>, opening the <link linkend=\"menubar\">panel menubar</link>, or launching a web browser."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:136
+#: C/goscustdesk.xml:134
 msgid "Sound"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:137
+#: C/goscustdesk.xml:135
 msgid "Shortcuts for controlling your music player and the system volume."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:139
+#: C/goscustdesk.xml:137
 msgid "Window Management"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:140
+#: C/goscustdesk.xml:138
 msgid "Shortcuts for working with windows and workspaces, such as maximizing or moving the current window, and switching to another workspace. For more information on these kinds of actions, see <xref linkend=\"windows-manipulating\"/> and <xref linkend=\"overview-workspaces\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:142
+#: C/goscustdesk.xml:140
 msgid "Accessibility"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:143
+#: C/goscustdesk.xml:141
 msgid "Shortcuts for starting assistive technologies, such as a screen reader, a magnifier or an on-screen keyboard."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:146
+#: C/goscustdesk.xml:144
 msgid "Custom Shortcuts"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:147
+#: C/goscustdesk.xml:145
 msgid "Custom shortcuts that have been added with the <guilabel>Add</guilabel> button. This section will not be shown if there are no custom shortcuts."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:150
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:148
 msgid "To add a custom shortcut, use the <guilabel>Add</guilabel> button in the action area. You have to provide a name and a command for the new shortcut. The new custom shortcut will appear in the list of shortcuts and can be edited in the same way as the predefined shortcuts."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:153
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:151
 msgid "To remove a custom shortcut, use the <guilabel>Remove</guilabel> button."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:159
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:156
 msgid "Preferred Applications"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:162
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:159
 msgid "<primary>preference tools</primary> <secondary>Preferred Applications</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:166
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:163
 msgid "<primary>default applications</primary> <see>preferred applications</see>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:170
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:167
 msgid "Use the <application>Preferred Applications</application> preference tool to specify the applications that you want the MATE Desktop to use when the MATE Desktop starts an application for you. For example, you can specify the web browser application (<application>Epiphany </application>, <application>Mozilla Firefox</application>, <application>Opera</application> ...) to launch when you click on a link in other applications such as email clients or document viewers."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:178
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:175
 msgid "<application>Preferred Applications</application> can be found by going to <menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisubmenu><guimenuitem>Preferred Applications</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:180
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:177
 msgid "You can customize the preferences for the <application>Preferred Applications</application> preference tool in the following functional areas."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:183
+#: C/goscustdesk.xml:180
 msgid "<guilabel>Internet</guilabel> (Web, Mail)"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:188
+#: C/goscustdesk.xml:185
 msgid "<guilabel>Multimedia</guilabel> (Multimedia Player)"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:193
+#: C/goscustdesk.xml:190
 msgid "<guilabel>System</guilabel> (Terminal)"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:198
+#: C/goscustdesk.xml:195
 msgid "<guilabel>Accessibility</guilabel> (Visual, Mobility)"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:204
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:201
 msgid "For each preferred application category, a drop-down menu contains a list of possible applications you can choose from. The list depends on the applications installed on your computer."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:205
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:202
 msgid "In each category, the last item in the menu (<guimenuitem>Custom</guimenuitem>) permits you to customize the command used by the system when the specific launch action occurs."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:208
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:204
 msgid "Custom Command Options"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:209
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:205
 msgid "<primary>preferred applications</primary> <secondary>custom command</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:213
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:209
 msgid "The following table summarizes the various options you can choose from when you select <guimenuitem>Custom</guimenuitem> in the drop-down application menu."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:216
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:211
 msgid "Custom command options"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:233
+#: C/goscustdesk.xml:228
 msgid "<guilabel>Command</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:238
+#: C/goscustdesk.xml:233
 msgid "Enter the command to execute to start the custom application. For the <application>Web Browser</application> and the <application>Mail Reader</application> applications, you can include a <literal>%s</literal> after the command to tell the application to use the URL or Email address you clicked on. The exact command arguments may depend on the specific application."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:246
+#: C/goscustdesk.xml:241
 msgid "<guilabel>Run in terminal</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:251
+#: C/goscustdesk.xml:246
 msgid "Select this option to run the command in a terminal window. Select this option for an application that does not create a window in which to run."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:257
+#: C/goscustdesk.xml:252
 msgid "<guilabel>Execute flag (Terminal only)</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:262
+#: C/goscustdesk.xml:257
 msgid "Most terminal applications have an option that cause them to treat the remaining command line options as commands to run (<option>-x</option> for <application>mate-terminal</application>). Enter this option here. For example, this is used when executing a command of a launcher for which the chosen type is Application in Terminal."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:269
+#: C/goscustdesk.xml:264
 msgid "<guilabel>Run at start (Accessibility only)</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:274
+#: C/goscustdesk.xml:269
 msgid "Select this option to run the command as soon as your session begins."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscustdesk.xml:286
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:279
 msgid "Look and Feel"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:289
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:281
 msgid "Appearance Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:290
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:282
 msgid "The <application>Appearance</application> preference tool lets you configure various aspects of how your desktop looks:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:294
+#: C/goscustdesk.xml:286
 msgid "Theme,"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:297
+#: C/goscustdesk.xml:289
 msgid "Desktop Background,"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:300
+#: C/goscustdesk.xml:292
 msgid "Fonts,"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:303
+#: C/goscustdesk.xml:295
 msgid "User Interface."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:307
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:299
 msgid "Theme Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:312
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:304
 msgid "<primary>themes</primary> <secondary>setting controls options</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:316
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:308
 msgid "<primary>themes</primary> <secondary>setting window frame options</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:321
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:312
 msgid "<primary>themes</primary> <secondary>setting icons options</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:325
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:316
 msgid "<primary>windows</primary> <secondary>setting frame theme options</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:329
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:320
 msgid "<primary>preference tools</primary> <secondary>Theme</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:334
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:325
 msgid "A theme is a group of coordinated settings that specifies the visual appearance of a part of the MATE Desktop. You can choose themes to change the appearance of the MATE Desktop. Use the <application>Theme</application> tabbed section to select a theme. You can choose from a list of available themes. The list of available themes includes several themes for users with accessibility requirements."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:339
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:330
 msgid "A theme contains settings that affect different parts of the MATE Desktop, as follows:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:343
+#: C/goscustdesk.xml:333
 msgid "Controls"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:345
+#: C/goscustdesk.xml:335
 msgid "<primary>GTK+ themes</primary><see>themes, controls options</see>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:346
+#: C/goscustdesk.xml:336
 msgid "<primary>themes</primary><secondary>controls options</secondary><tertiary>introduction</tertiary>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:345
+#: C/goscustdesk.xml:335
 msgid "<_:indexterm-1/><_:indexterm-2/>The controls setting for a theme determines the visual appearance of windows, panels, and applets. The controls setting also determines the visual appearance of the MATE-compliant interface items that appear on windows, panels, and applets, such as menus, icons, and buttons. Some controls setting options that are available are designed for special accessibility needs. You can choose an option for the controls setting from the <guilabel>Controls</guilabel> tabbed section in the <guilabel>Customize Theme</guilabel> window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:356
+#: C/goscustdesk.xml:346
 msgid "Colors"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:358
+#: C/goscustdesk.xml:348
 msgid "<primary>themes</primary><secondary>color options</secondary><tertiary>introduction</tertiary>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:358
+#: C/goscustdesk.xml:348
 msgid "<primary>color themes</primary><see>themes, color options</see>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:358
+#: C/goscustdesk.xml:348
 msgid "<_:indexterm-1/><_:indexterm-2/>The color setting for a theme determines the color of various user interface elements. You can choose several pairs of colors from the <guilabel>Colors</guilabel> tabbed section in the <guilabel>Customize Theme</guilabel> window."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:360
+#: C/goscustdesk.xml:350
 msgid "It is important to choose pairs of colors that have a good contrast with each other, otherwise text may become hard to read."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:365
+#: C/goscustdesk.xml:355
 msgid "Window frame"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:367
+#: C/goscustdesk.xml:357
 msgid "<primary>themes</primary><secondary>window frame options</secondary><tertiary>introduction</tertiary>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:367
+#: C/goscustdesk.xml:357
 msgid "<primary>Marco themes</primary><see>themes, window frame options</see>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:367
+#: C/goscustdesk.xml:357
 msgid "<_:indexterm-1/><_:indexterm-2/>The window frame setting for a theme determines the appearance of the frames around windows only. You can choose an option for the window frame setting from the <guilabel>Window Border</guilabel> tabbed section in the <guilabel>Customize Theme</guilabel> window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:373
+#: C/goscustdesk.xml:363
 msgid "Icons"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:375
+#: C/goscustdesk.xml:365
 msgid "<primary>themes</primary><secondary>icons options</secondary><tertiary>introduction</tertiary>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:375
+#: C/goscustdesk.xml:365
 msgid "<primary>icon themes</primary><see>themes, icons options</see>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:375
+#: C/goscustdesk.xml:365
 msgid "<_:indexterm-1/><_:indexterm-2/>The icon setting for a theme determines the appearance of the icons on panels and the desktop background. You can choose an option for the icon setting from the <guilabel>Icons</guilabel> tabbed section in the <guilabel>Customize Theme</guilabel> window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:381
+#: C/goscustdesk.xml:371
 msgid "Pointer"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:383
+#: C/goscustdesk.xml:373
 msgid "<primary>themes</primary><secondary>pointer options</secondary><tertiary>introduction</tertiary>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscustdesk.xml:383
+#: C/goscustdesk.xml:373
 msgid "<primary>pointer themes</primary><see>themes, pointer options</see>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:383
+#: C/goscustdesk.xml:373
 msgid "<_:indexterm-1/><_:indexterm-2/>The pointer setting for a theme determines the appearance of and size of the mouse pointer. You can choose the options for setting the pointer from the <guilabel>Pointer</guilabel> tabbed section in the <guilabel>Customize Theme</guilabel> window."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:389
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:378
 msgid "To Create a Custom Theme"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:390
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:380
 msgid "The themes that are listed in the <guilabel>Theme</guilabel> tabbed section are different combinations of controls options, window frame options, and icon options. You can create a custom theme that uses different combinations of controls options, window frame options, and icon options."
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:394
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:384
 msgid "To create a custom theme, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:397
-#: C/goscustdesk.xml:447
-#: C/goscustdesk.xml:508
+#: C/goscustdesk.xml:387
+#: C/goscustdesk.xml:437
+#: C/goscustdesk.xml:498
 msgid "Start the <application>Appearance</application> preference tool. Open the <guilabel>Theme</guilabel> tabbed section."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:401
+#: C/goscustdesk.xml:391
 msgid "Select a theme in the list of themes."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:404
-#: C/goscustdesk.xml:512
+#: C/goscustdesk.xml:394
+#: C/goscustdesk.xml:502
 msgid "Click on the <guibutton>Customize</guibutton> button. A <guilabel>Customize Theme</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:407
+#: C/goscustdesk.xml:397
 msgid "Select the controls option that you want to use in the custom theme from the list in the <guilabel>Controls</guilabel> tabbed section. The list of available controls options includes several options for users with accessibility requirements."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:413
+#: C/goscustdesk.xml:403
 msgid "Click on the <guilabel>Window Border</guilabel> tab to display the <guilabel>Window Border</guilabel> tabbed section. Select the window frame option that you want to use in the custom theme from the list of available options. The list of available window frame options includes several options for users with accessibility requirements."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:420
+#: C/goscustdesk.xml:410
 msgid "Click on the <guilabel>Icons</guilabel> tab to display the <guilabel>Icons</guilabel> tabbed section. Select the icons option that you want to use in the custom theme from the list of available options. The list of available icons options includes several options for users with accessibility requirements."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:425
+#: C/goscustdesk.xml:415
 msgid "Click <guibutton>Close</guibutton> to close the <guilabel>Customize Theme</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:428
+#: C/goscustdesk.xml:418
 msgid "On the <application>Appearance</application> preferences tool, click on the <guibutton>Save As</guibutton> button. A <guilabel>Save Theme As</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:433
+#: C/goscustdesk.xml:423
 msgid "Type a name and a short description for the custom theme in the dialog, then click <guibutton>Save</guibutton>. The custom theme now appears in your list of available themes."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:440
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:430
 msgid "To Install a New Theme"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:441
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:431
 msgid "You can add a theme to the list of available themes. The new theme must be an archive file that is tarred and zipped. That is, the new theme must be a <filename>.tar.gz</filename> file."
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:444
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:434
 msgid "To install a new theme, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:451
+#: C/goscustdesk.xml:441
 msgid "Click on the <guibutton>Install</guibutton> button. A file chooser dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:455
+#: C/goscustdesk.xml:445
 msgid "Enter the location of the theme archive file in the location entry. Alternatively, select the theme archive file in the file list. When you have selected the file, click <guibutton>Open</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:459
+#: C/goscustdesk.xml:449
 msgid "Click on the <guibutton>Install</guibutton> button to install the new theme."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:502
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:492
 msgid "To Delete a Theme Option"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:503
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:493
 msgid "You can delete controls options, window frame options, or icons options."
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:504
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:494
 msgid "To delete a controls option, window frame option, or icons option, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:516
+#: C/goscustdesk.xml:506
 msgid "Click on the tab for the type of option that you want to delete."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:519
+#: C/goscustdesk.xml:509
 msgid "Select the theme option you want to delete."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:522
+#: C/goscustdesk.xml:512
 msgid "Use the <guibutton>Delete</guibutton> button to delete the selected option. Note that you can not delete system-wide theme options."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:531
-#: C/goscustdesk.xml:571
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:520
+#: C/goscustdesk.xml:559
 msgid "Desktop Background Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:534
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:523
 msgid "<primary>desktop</primary> <secondary>customizing background</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:538
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:527
 msgid "<primary>MATE Desktop preference tools</primary> <see>preference tools</see>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:542
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:531
 msgid "<primary>preference tools</primary> <secondary>Background</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:546
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:535
 msgid "<primary>backgrounds</primary> <secondary>customizing desktop background</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:550
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:539
 msgid "The <link linkend=\"overview-desktop\">desktop</link> background is the image or color that is applied to your desktop. You can open <guilabel>Background</guilabel> tabbed section in the <application>Appearance</application> preference tool by right-clicking on the desktop and choosing <guimenuitem>Change Desktop Background</guimenuitem>, as well as from the <menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisubmenu></menuchoice> menu."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:552
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:541
 msgid "You can customize the desktop background in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:555
+#: C/goscustdesk.xml:544
 msgid "Select an image for the desktop background. The image is superimposed on the desktop background color. The desktop background color is visible if you select a transparent image, or if the image does not cover the entire desktop."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:561
+#: C/goscustdesk.xml:550
 msgid "Select a color for the desktop background. You can select a solid color, or create a gradient effect with two colors. A gradient effect is a visual effect where one color blends gradually into another color."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/goscustdesk.xml:566
+#: C/goscustdesk.xml:555
 msgid "You can also drag a color or a pattern to the desktop from the <link linkend=\"caja-backgrounds-and-emblems\"><guilabel>Backgrounds and Emblems</guilabel> dialog</link> in the <application>Caja</application> file manager."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:568
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:557
 msgid "<xref linkend=\"goscustdesk-TBL-14\"/> lists the background preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:588
+#: C/goscustdesk.xml:576
 msgid "<guibutton>Desktop Background</guibutton>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:593
+#: C/goscustdesk.xml:581
 msgid "Choose an image from the list. Alternately, you can use the <guibutton>Add</guibutton> button to choose any image on your computer."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:599
+#: C/goscustdesk.xml:587
 msgid "<guilabel>Style</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:604
+#: C/goscustdesk.xml:592
 msgid "To specify how to display the image, select one of the following options from the <guilabel>Style</guilabel> drop-down list:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:608
+#: C/goscustdesk.xml:596
 msgid "<guilabel>Centered</guilabel>: Displays the image in the middle of the desktop, respecting the image's original size."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:612
+#: C/goscustdesk.xml:600
 msgid "<guilabel>Fill Screen</guilabel>: Enlarges the image to cover the desktop, altering its proportions if needed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:616
+#: C/goscustdesk.xml:604
 msgid "<guilabel>Scaled</guilabel>: Enlarges the image until the image meets the screen edges, and maintains the proportions of the image."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:620
+#: C/goscustdesk.xml:608
 msgid "<guilabel>Zoom</guilabel>: Enlarges the smaller dimension of the image until it meets the screen edges; the image may be cropped in the other dimension."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:624
+#: C/goscustdesk.xml:612
 msgid "<guilabel>Tiled</guilabel>: Duplicates the original-sized image as often as necessary and print the images next to another so as they entirely cover the desktop."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:632
+#: C/goscustdesk.xml:620
 msgid "<guilabel>Add</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:638
+#: C/goscustdesk.xml:626
 msgid "Click on the <guibutton>Add</guibutton> to browse for an image on your computer. A standard file selector will be presented. Choose the image you want and click <guibutton>Open</guibutton>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:645
+#: C/goscustdesk.xml:633
 msgid "<guilabel>Remove</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:650
+#: C/goscustdesk.xml:638
 msgid "Choose the image that you want to remove, then click <guilabel>Remove</guilabel>. This removes the image from the list of available wallpapers; however, it does not delete the image from your computer."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:657
+#: C/goscustdesk.xml:644
 msgid "<guilabel>Colors</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:662
+#: C/goscustdesk.xml:649
 msgid "To specify a color scheme, use the options in the <guilabel>Style</guilabel> drop-down list, and the color selector buttons."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:665
+#: C/goscustdesk.xml:652
 msgid "You can specify a color scheme in one of the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:669
+#: C/goscustdesk.xml:656
 msgid "Choose <guilabel>Solid color</guilabel> from the <guilabel>Background Style</guilabel> drop-down list to specify a single color for the desktop background."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:671
+#: C/goscustdesk.xml:658
 msgid "To choose the color that you require, click on the <guibutton>Color</guibutton> button. The <guilabel>Pick a Color</guilabel> dialog is displayed. Choose a color, then click <guibutton>OK</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:675
+#: C/goscustdesk.xml:662
 msgid "Choose <guilabel>Horizontal gradient</guilabel> from the <guilabel>Background Style</guilabel> drop-down list. This option creates a gradient effect from the left screen edge to the right screen edge."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:677
+#: C/goscustdesk.xml:664
 msgid "Click on the <guibutton>Left Color</guibutton> button to display the <guilabel>Pick a Color</guilabel> dialog. Choose the color that you want to appear at the left edge."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:679
+#: C/goscustdesk.xml:666
 msgid "Click on the <guibutton>Right Color</guibutton> button. Choose the color that you want to appear at the right edge."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:683
+#: C/goscustdesk.xml:670
 msgid "Choose <guilabel>Vertical gradient</guilabel> from the <guilabel>Background Style</guilabel> drop-down list. This creates a gradient effect from the top screen edge to the bottom screen edge."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:685
+#: C/goscustdesk.xml:672
 msgid "Click on the <guibutton>Top Color</guibutton> button to display the <guilabel>Pick a Color</guilabel> dialog. Choose the color that you want to appear at the top edge."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:687
+#: C/goscustdesk.xml:674
 msgid "Click on the <guibutton>Bottom Color</guibutton> button. Choose the color that you want to appear at the bottom edge."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:699
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:685
 msgid "Font Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:704
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:690
 msgid "<primary>preference tools</primary> <secondary>Font</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:708
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:694
 msgid "<primary>fonts</primary> <secondary>desktop</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:712
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:698
 msgid "<primary>fonts</primary> <secondary>applications</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:716
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:702
 msgid "<primary>fonts</primary> <secondary>window title</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:720
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:706
 msgid "<primary>fonts</primary> <secondary>terminal</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:724
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:710
 msgid "<primary>fonts</primary> <secondary>rendering</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:728
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:714
 msgid "Use the <guilabel>Fonts</guilabel> tabbed section in the <application>Appearance</application> preference tool to choose which fonts are used in different parts of the desktop, and the way in which fonts are displayed on the screen."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:732
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:717
 msgid "Choosing Fonts"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:733
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:718
 msgid "The font selector button shows the name of the font and its point size. The name is also shown in bold, italic, or regular type."
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:734
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:719
 msgid "To change the font, click the font selector button. The font picker dialog opens. Select the font family, style, and point size from the lists. The preview area shows your current choice. Click <guibutton>OK</guibutton> to accept the change and update the desktop."
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:735
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:720
 msgid "You can choose fonts for the following parts of the desktop:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:739
+#: C/goscustdesk.xml:724
 msgid "<guilabel>Application font</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:741
+#: C/goscustdesk.xml:726
 msgid "This font is used in the menus, toolbars, and dialog boxes of applications."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:745
+#: C/goscustdesk.xml:730
 msgid "<guilabel>Document font</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:747
+#: C/goscustdesk.xml:732
 msgid "This font is used to display documents in applications."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:748
+#: C/goscustdesk.xml:733
 msgid "In some applications, you can override this choice in the application's preferences dialog."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:752
+#: C/goscustdesk.xml:737
 msgid "<guilabel>Desktop font</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:754
+#: C/goscustdesk.xml:739
 msgid "This font is used in icon labels on the desktop."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:758
+#: C/goscustdesk.xml:743
 msgid "<guilabel>Window title font</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:760
+#: C/goscustdesk.xml:745
 msgid "This font is used in the titlebars of windows."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:764
+#: C/goscustdesk.xml:749
 msgid "<guilabel>Fixed width font</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:766
+#: C/goscustdesk.xml:751
 msgid "This font is used in the <application>Terminal</application> application and applications to do with programming."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:773
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:757
 msgid "Font Rendering"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:774
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:758
 msgid "You can set the following options relating to how fonts are displayed on the screen:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:778
+#: C/goscustdesk.xml:762
 msgid "<guilabel>Rendering</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:780
+#: C/goscustdesk.xml:764
 msgid "To specify how to render fonts on your screen, select one of the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:784
+#: C/goscustdesk.xml:768
 msgid "<guilabel>Monochrome</guilabel>: Renders fonts in black and white only. The edges of characters might appear jagged in some cases because the characters are not antialiased. <firstterm>Antialiasing</firstterm> is an effect that is applied to the edges of characters to make the characters look smoother."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:791
+#: C/goscustdesk.xml:775
 msgid "<guilabel>Best shapes</guilabel>: Antialiases fonts where possible. Use this option for standard Cathode Ray Tube (CRT) monitors."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:795
+#: C/goscustdesk.xml:779
 msgid "<guilabel>Best contrast</guilabel>: Adjusts fonts to give the sharpest possible contrast, and also antialiases fonts, so that characters have smooth edges. This option might enhance the accessibility of the MATE Desktop to users with visual impairments."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:801
+#: C/goscustdesk.xml:785
 msgid "<guilabel>Subpixel smoothing (LCDs)</guilabel>: Uses techniques that exploit the shape of individual Liquid Crystal Display (LCD) pixels to render fonts smoothly. Use this option for LCD or flat-screen displays."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:809
+#: C/goscustdesk.xml:793
 msgid "<guibutton>Details</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:811
+#: C/goscustdesk.xml:795
 msgid "Click on this button to specify further details of how to render fonts on your screen."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:815
+#: C/goscustdesk.xml:799
 msgid "<guilabel>Resolution (dots per inch)</guilabel>: Use the spin box to specify the resolution to use when your screen renders fonts."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:819
+#: C/goscustdesk.xml:803
 msgid "<guilabel>Smoothing</guilabel>: Select one of the options to specify how to antialias fonts."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:823
+#: C/goscustdesk.xml:807
 msgid "<guilabel>Hinting</guilabel>: <firstterm>Hinting</firstterm> is a font-rendering technique that improves the quality of fonts at small sizes and an at low screen resolutions. Select one of the options to specify how to apply hinting your fonts."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:829
+#: C/goscustdesk.xml:813
 msgid "<guilabel>Subpixel order</guilabel>: Select one of the options to specify the subpixel color order for your fonts. Use this option for LCD or flat-screen displays."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:886
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:870
 msgid "Interface Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:889
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:873
 msgid "<primary>toolbars, customizing appearance</primary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:892
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:876
 msgid "<primary>preference tools</primary> <secondary>Menus &amp; Toolbars</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:896
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:880
 msgid "<primary>menus</primary> <secondary>in applications, customizing appearance</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:901
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:884
 msgid "You can use the <guilabel>Interface</guilabel> tabbed section in the <application>Appearance</application> preference tool to customize the appearance of menus, menubars, and toolbars for applications that are part of MATE."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:903
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:886
 msgid "As you make changes to the settings, the preview display in the window updates. This allows you to see the changes if no application windows are currently open."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:906
+#: C/goscustdesk.xml:889
 msgid "<guilabel>Show icons in menus</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:908
+#: C/goscustdesk.xml:891
 msgid "Select this option to display an icon beside items in application menus and the panel menu. Not all menu items have an icon."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:913
+#: C/goscustdesk.xml:896
 msgid "<guilabel>Editable menu shortcut keys</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:914
+#: C/goscustdesk.xml:897
 msgid "Selecting this option allows you to define new keyboard shortcuts for menu items."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:915
+#: C/goscustdesk.xml:898
 msgid "To change an application shortcut key, open the menu, and with the mouse pointer on the menu item you wish to change, press the new combination of keys. To remove a shortcut key, press <keycap>Backspace</keycap> or <keycap>Delete</keycap>."
 msgstr ""
 
 #. (itstool) path: warning/para
-#: C/goscustdesk.xml:917
+#: C/goscustdesk.xml:900
 msgid "When using this feature, you will not be warned if assigning a new shortcut key to a command also removes it from another command."
 msgstr ""
 
 #. (itstool) path: warning/para
-#: C/goscustdesk.xml:918
+#: C/goscustdesk.xml:901
 msgid "There is no way to restore the original, default keyboard shortcut for a command."
 msgstr ""
 
 #. (itstool) path: warning/para
-#: C/goscustdesk.xml:919
+#: C/goscustdesk.xml:902
 msgid "This feature does not maintain shortcuts that are normally common to all applications, such as <keycombo><keycap>Ctrl</keycap><keycap>C</keycap></keycombo> for Copy. This may lead to inconsistencies in your MATE applications."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:924
+#: C/goscustdesk.xml:907
 msgid "<guilabel>Toolbar button labels</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:926
+#: C/goscustdesk.xml:909
 msgid "Choose one of the following options to specify what to display on the toolbars in your MATE-compliant applications:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:930
+#: C/goscustdesk.xml:913
 msgid "<guilabel>Text Below Icons</guilabel>: Select this option to display toolbars with text as well as an icon on each button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:934
+#: C/goscustdesk.xml:917
 msgid "<guilabel>Text Beside Icons</guilabel>: Select this option to display toolbars with an icon only on each button, and with text on the most important buttons."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:939
+#: C/goscustdesk.xml:922
 msgid "<guilabel>Icons Only</guilabel>: Select this option to display toolbars with an icon only on each button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:943
+#: C/goscustdesk.xml:926
 msgid "<guilabel>Text Only</guilabel>: Select this option to display toolbars with text only on each button."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:954
-#: C/goscustdesk.xml:972
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:936
+#: C/goscustdesk.xml:952
 msgid "Windows Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:959
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:940
 msgid "<primary>window manager</primary> <secondary>customizing</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:963
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:944
 msgid "<primary>preference tools</primary> <secondary>Windows</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:967
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:948
 msgid "Use the <application>Windows</application> preference tool to customize window behavior for the MATE Desktop."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:969
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:950
 msgid "<xref linkend=\"goscustwindows-TBL-14\"/> lists the windows preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:989
+#: C/goscustdesk.xml:969
 msgid "<guilabel>Select windows when the mouse moves over them</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:994
+#: C/goscustdesk.xml:974
 msgid "Select this option to give focus to a window when you point to the window. The window retains focus until you point to another window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1001
+#: C/goscustdesk.xml:981
 msgid "<guilabel>Raise selected windows after an interval</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1006
+#: C/goscustdesk.xml:986
 msgid "Select this option to raise windows a short time after the window receives focus."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1012
+#: C/goscustdesk.xml:992
 msgid "<guilabel>Interval before raising</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1017
+#: C/goscustdesk.xml:997
 msgid "Specify the interval to wait before raising a window that has received focus."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1023
+#: C/goscustdesk.xml:1003
 msgid "<guilabel>Double-click titlebar to perform this action</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1028
+#: C/goscustdesk.xml:1008
 msgid "Select the behavior that you want to occur when you double-click on a window titlebar. Select one of the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1033
+#: C/goscustdesk.xml:1013
 msgid "<guilabel>Maximize</guilabel>: Maximizes the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1036
+#: C/goscustdesk.xml:1016
 msgid "<guilabel>Maximize Vertically</guilabel>: Maximizes the window vertically without changing its width."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1039
+#: C/goscustdesk.xml:1019
 msgid "<guilabel>Maximize Horizontally</guilabel>: Maximizes the window horizontally without changing its height."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1042
+#: C/goscustdesk.xml:1022
 msgid "<guilabel>Minimize</guilabel>: Minimizes the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1045
+#: C/goscustdesk.xml:1025
 msgid "<guilabel>Roll up</guilabel>: Roll up the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1048
+#: C/goscustdesk.xml:1028
 msgid "<guilabel>None</guilabel>: Do nothing."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1051
+#: C/goscustdesk.xml:1031
 msgid "If a window is already maximized or rolled up, double-clicking on the titlebar will return it to its normal state."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1057
+#: C/goscustdesk.xml:1037
 msgid "<guilabel>To move a window, press-and-hold this key then grab the window</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1062
+#: C/goscustdesk.xml:1042
 msgid "Select the key to press-and-hold when you drag a window to move the window."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:1070
+#: C/goscustdesk.xml:1050
 msgid "The position of the Control, Alt and Super keys on the keyboard can be modified in the Keyboard Layout Options dialog, see <xref linkend=\"prefs-keyboard-layoutoptions\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:1077
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1056
 msgid "Screensaver Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1078
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1057
 msgid "<primary>preference tools</primary> <secondary>screensaver</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1082
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1061
 msgid "A <firstterm>screensaver</firstterm> displays moving images on your screen when your computer is not being used. Screensavers also help prevent older monitors being damaged by the same image being displayed for long periods of time. To stop the screensaver and return to the desktop, move the mouse or press a key on the keyboard."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1083
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1062
 msgid "Use the <application>Screensaver</application> preference tool to set the type of screensaver, the time before the screensaver starts, and whether to require a password to return to the desktop."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1084
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1063
 msgid "You can modify the following settings:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1087
+#: C/goscustdesk.xml:1066
 msgid "Screensaver"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1088
+#: C/goscustdesk.xml:1067
 msgid "Select the <guilabel>Screensaver theme</guilabel> from the list. A reduced version of the selected screensaver theme is shown. Press <guibutton>Preview</guibutton> to show the selected theme on the whole screen. During preview, use the arrow buttons at the top of the screen to go through the list of screensaver themes."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1090
+#: C/goscustdesk.xml:1069
 msgid "The <guilabel>Blank screen</guilabel> theme displays no image and only shows a black screen."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1091
+#: C/goscustdesk.xml:1070
 msgid "The <guilabel>Random</guilabel> theme selects a screensaver to display from the list at random."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1093
+#: C/goscustdesk.xml:1072
 msgid "Which screensavers are shown in the remainder of the list depends on your distributor or vendor."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1096
+#: C/goscustdesk.xml:1075
 msgid "Regard the computer as idle after..."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1097
+#: C/goscustdesk.xml:1076
 msgid "Your computer becomes idle after this amount of time has passed with no input from you, such as moving the mouse or typing. This may affect power management (the monitor may power down for example) or instant messaging (chat applications may set your status as \"away\"). Use the slider to set the length of time in minutes or hours."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1100
+#: C/goscustdesk.xml:1079
 msgid "Activate screensaver when computer is idle"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1101
+#: C/goscustdesk.xml:1080
 msgid "Select this option to have the screensaver start after the set length of time."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1104
+#: C/goscustdesk.xml:1083
 msgid "Lock screen when screensaver is active"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1105
+#: C/goscustdesk.xml:1084
 msgid "When this option is selected, the screensaver will prompt you for your password when you try to return to the desktop. For more on locking your screen, see <xref linkend=\"lock-screen\"/>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscustdesk.xml:1113
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1090
 msgid "Internet and Network"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:1116
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1092
 msgid "Network Settings"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1118
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1093
 msgid "The <application>Network Settings</application> allows you to specify the way your system connects to other computers and to internet."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1119
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1094
 msgid "You will be prompted for the administrator password when you start <application>Network Settings</application>. This is because the changes done with this tool will affect the whole system."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:1122
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1096
 msgid "Getting started"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1126
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1097
 msgid "The <application>Network Settings</application> main window contains four tabbed sections:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1130
+#: C/goscustdesk.xml:1100
 msgid "<guilabel>Connections</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1132
+#: C/goscustdesk.xml:1102
 msgid "Shows all network interfaces, it also allows you to modify their settings."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1137
+#: C/goscustdesk.xml:1107
 msgid "<guilabel>General</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1139
+#: C/goscustdesk.xml:1109
 msgid "Allows you to modify your system host name and domain name."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1144
+#: C/goscustdesk.xml:1114
 msgid "<guilabel>DNS</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1146
+#: C/goscustdesk.xml:1116
 msgid "Contains two sections, the <guilabel>DNS servers</guilabel> are what your computer use for resolving the IP addresses from the domain names. The <guilabel>search domains</guilabel> are the default domains in which your system will search any host when no domain is specified."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1151
+#: C/goscustdesk.xml:1121
 msgid "<guilabel>Hosts</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1153
+#: C/goscustdesk.xml:1123
 msgid "Shows the list of aliases for accessing other computers."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#. (itstool) path: section/title
-#: C/goscustdesk.xml:1160
-#: C/gospanel.xml:1624
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1129
+#: C/gospanel.xml:1605
 msgid "Usage"
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1163
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1131
 msgid "To modify a connection settings"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1164
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1132
 msgid "In the <guilabel>Connections</guilabel> section, select the interface you want to modify and press the <guilabel>Properties</guilabel> button, depending on the interface type you will be able to modify different data."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1168
+#: C/goscustdesk.xml:1136
 msgid "Ethernet and IRLAN interfaces"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1170
+#: C/goscustdesk.xml:1138
 msgid "You can modify the way the interface is configured (DHCP or manually), if the interface is configured manually, you can also modify the interface IP address, netmask and gateway."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1175
+#: C/goscustdesk.xml:1143
 msgid "Wireless interfaces"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1177
+#: C/goscustdesk.xml:1145
 msgid "You can modify the way the interface is configured (DHCP or manually), if the interface is configured manually, you can also modify the interface IP address, netmask and gateway, you can also modify the network name (ESSID) for this interface."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1182
+#: C/goscustdesk.xml:1150
 msgid "Parallel line interfaces"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1184
+#: C/goscustdesk.xml:1152
 msgid "You can modify the interface IP address, as well as the remote IP address."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1189
+#: C/goscustdesk.xml:1157
 msgid "PPP/Modem interfaces"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1191
+#: C/goscustdesk.xml:1159
 msgid "You can modify the modem device, whether you want it to dial using tones or pulses, the modem volume, the phone number, the username and password that your ISP provided and other advanced settings for PPP."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1198
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1165
 msgid "To activate or deactivate an interface"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1199
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1166
 msgid "In the <guilabel>Connections</guilabel> section, enable or disable the checkbox beside the interface."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1203
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1169
 msgid "To change your host name and domain name"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1204
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1170
 msgid "In the <guilabel>General</guilabel> section, change the hostname or domain name text boxes."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1208
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1173
 msgid "To add a new domain name server"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1209
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1174
 msgid "In the <guilabel>DNS Servers</guilabel> section, press the <guilabel>Add</guilabel> button and fill in the new list row with the new domain name server."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1213
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1177
 msgid "To delete a domain name server"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1214
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1178
 msgid "In the <guilabel>DNS Servers</guilabel> section, select a DNS IP address from the list and press the <guilabel>Delete</guilabel> button."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1218
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1181
 msgid "To add a new search domain"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1219
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1182
 msgid "In the <guilabel>Search Domains</guilabel> section, press the <guilabel>Add</guilabel> button and fill in the new list row with the new search domain."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1223
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1185
 msgid "To delete a search domain"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1224
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1186
 msgid "In the <guilabel>Search Domains</guilabel> section, select a search domain from the list and press the <guilabel>Delete</guilabel> button."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1228
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1189
 msgid "To add a new host alias"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1229
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1190
 msgid "In the <guilabel>Hosts</guilabel> section, press the <guilabel>Add</guilabel> button and type an IP address and the aliases that will point to in the window that pops up."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1233
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1193
 msgid "To modify a host alias"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1234
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1194
 msgid "In the <guilabel>Hosts</guilabel> section, select an alias, press the <guilabel>Properties</guilabel> button from the list and modify the alias settings in the window that pops up."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1238
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1197
 msgid "To delete a host alias"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1239
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1198
 msgid "In the <guilabel>Hosts</guilabel> section, select an alias from the list and press the <guilabel>Delete</guilabel> button."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1243
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1201
 msgid "To save your current network configuration as a \"Location\""
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1244
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1202
 msgid "Press the <guilabel>Add</guilabel> button besides the <guilabel>Locations</guilabel> menu, specify the location name in the window that pops up."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1248
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1205
 msgid "To delete a location"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1249
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1206
 msgid "Press the <guilabel>Remove</guilabel> button besides the <guilabel>Locations</guilabel> menu, the selected profile will be deleted."
 msgstr ""
 
-#. (itstool) path: sect4/title
-#: C/goscustdesk.xml:1253
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1209
 msgid "To switch to a location"
 msgstr ""
 
-#. (itstool) path: sect4/para
-#: C/goscustdesk.xml:1254
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1210
 msgid "Select one location from the <guilabel>Locations</guilabel> menu, all the configuration will be switched automatically to the chosen location."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:1261
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1216
 msgid "Network Proxy Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1264
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1219
 msgid "<primary>preference tools</primary> <secondary>Network Proxy</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1269
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1223
 msgid "<primary>network proxy</primary> <secondary>setting preferences</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1273
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1227
 msgid "<primary>Internet</primary> <secondary>configuring connection</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1277
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1231
 msgid "<primary>proxy</primary> <secondary>setting preferences</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1281
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1235
 msgid "The <application>Network Proxy Preferences</application> enables you to configure how your system connects to the Internet."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1283
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1237
 msgid "You can configure the MATE Desktop to connect to a <firstterm>proxy server</firstterm>, and specify the details of the proxy server. A proxy server is a server that intercepts requests to another server, and fulfills the request itself, if it can. You can enter the domain name or the Internet Protocol (IP) address of the proxy server. A <firstterm>domain name</firstterm> is a unique alphabetic identifier for a computer on a network. An <firstterm>IP address</firstterm> is a unique numeric identifier for a computer on a network."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1292
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1246
 msgid "Since it is possible that you need to use a different proxy configuration in different places, <application>Network Proxy Preferences</application> allows you to define separate proxy configurations and switch between them using the <guilabel>Location</guilabel> drop-down box at the top of the window. Choose <guilabel>New Location</guilabel> to create a proxy configuration for a new location. Locations can be removed using the <guilabel>Delete Location</guilabel> button at the bottom of the window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1300
+#: C/goscustdesk.xml:1254
 msgid "<guilabel>Direct internet connection</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1301
+#: C/goscustdesk.xml:1255
 msgid "Select this option to connect to the Internet without a proxy server."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1305
+#: C/goscustdesk.xml:1259
 msgid "<guilabel>Manual proxy configuration</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1306
+#: C/goscustdesk.xml:1260
 msgid "Select this option to connect to the Internet through a proxy server and configure the proxy settings manually."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1311
+#: C/goscustdesk.xml:1265
 msgid "<guilabel>HTTP proxy</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1313
+#: C/goscustdesk.xml:1267
 msgid "Enter the domain name or IP address of the proxy server to use when you request an HTTP service. Enter the port number of the HTTP service on the proxy server in the <guilabel>Port</guilabel> field."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1316
+#: C/goscustdesk.xml:1270
 msgid "If the HTTP proxy server requires authentication, click the <guibutton>Details</guibutton> button to enter your username and password."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1321
+#: C/goscustdesk.xml:1275
 msgid "<guilabel>Secure HTTP proxy</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1322
+#: C/goscustdesk.xml:1276
 msgid "Enter the domain name or IP address of the proxy server to use when you request a secure HTTP service. Enter the port number of the secure HTTP service on the proxy server in the <guilabel>Port</guilabel> field."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1327
+#: C/goscustdesk.xml:1281
 msgid "<guilabel>FTP proxy</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1328
+#: C/goscustdesk.xml:1282
 msgid "Enter the domain name or IP address of the proxy server to use when you request an FTP service. Enter the port number of the FTP service on the proxy server in the <guilabel>Port</guilabel> field."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1333
+#: C/goscustdesk.xml:1287
 msgid "<guilabel>Socks host</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1334
+#: C/goscustdesk.xml:1288
 msgid "Enter the domain name or IP address of the Socks host to use. Enter the port number for the Socks protocol on the proxy server in the <guilabel>Port</guilabel> field."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1339
+#: C/goscustdesk.xml:1293
 msgid "<guilabel>Automatic proxy configuration</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1340
+#: C/goscustdesk.xml:1294
 msgid "Select this option if you want to connect to the Internet through a proxy server, and you want to configure the proxy server automatically."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1342
+#: C/goscustdesk.xml:1296
 msgid "Automatic proxy configuration works by means of a so-called PAC file, which your browser downloads from a web server. If you don't specify the URL for a PAC file in the <guilabel>Autoconfiguration URL</guilabel> entry, your browser will try to locate one automatically."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1345
+#: C/goscustdesk.xml:1299
 msgid "<guilabel>Autoconfiguration URL</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1346
+#: C/goscustdesk.xml:1300
 msgid "Enter the URL of a PAC file that contains the information required to configure the proxy server automatically."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1351
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1305
 msgid "Set which hosts should not use the proxy in the <guilabel>Ignore Host List</guilabel> in the <guilabel>Ignored Hosts</guilabel> tabbed section. When you access these hosts, you will connect to the Internet directly without a proxy."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:1356
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1308
 msgid "Remote Desktop Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1359
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1311
 msgid "<primary>setting session sharing preferences</primary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1362
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1314
 msgid "The <application>Remote Desktop</application> preference tool enables you to share a MATE Desktop session between multiple users, and to set session-sharing preferences."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1364
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1316
 msgid "<xref linkend=\"goscustdesk-TBL-91\"/> lists the session-sharing preferences that you can set. These preferences have a direct impact on the security of your system."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:1368
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1319
 msgid "Session Sharing Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1385
+#: C/goscustdesk.xml:1336
 msgid "<guilabel>Allow other users to view your desktop</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1391
+#: C/goscustdesk.xml:1341
 msgid "Select this option to enable remote users to view your session. All keyboard, pointer, and clipboard events from the remote user are ignored."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1398
+#: C/goscustdesk.xml:1348
 msgid "<guilabel>Allow other users to control your desktop</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1404
+#: C/goscustdesk.xml:1353
 msgid "Select this option to enable other to access and control your session from a remote location."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1425
+#: C/goscustdesk.xml:1374
 msgid "<guilabel>When a user tries to view or control your desktop</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1432
+#: C/goscustdesk.xml:1381
 msgid "<guilabel>Ask you for confirmation:</guilabel> Select this option if you want remote users to ask you for confirmation when they want to share your session. This option enables you to be aware of other users who connect to your session. You can also decide what time is suitable for the remote user to connect to your session."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1436
+#: C/goscustdesk.xml:1385
 msgid "<guilabel>Require the user to enter this password:</guilabel> Select this option to authenticate the remote user if authentication is used. This option provides an extra level of security."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1431
+#: C/goscustdesk.xml:1380
 msgid "Select the following security considerations when a user tries to view or control your session:<_:itemizedlist-1/>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1443
+#: C/goscustdesk.xml:1392
 msgid "<guilabel>Password</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1448
+#: C/goscustdesk.xml:1397
 msgid "Enter the password that the client who attempts to view or control your session must enter."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscustdesk.xml:1461
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1407
 msgid "Hardware"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#. (itstool) path: sect3/title
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:1464
-#: C/goscustdesk.xml:1508
-#: C/goscustdesk.xml:1514
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1409
+#: C/goscustdesk.xml:1451
+#: C/goscustdesk.xml:1457
 msgid "Keyboard Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1467
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1412
 msgid "<primary>preference tools</primary> <secondary>Keyboard</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:1471
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1416
 msgid "<primary>keyboard</primary> <secondary>configuring general preferences</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1476
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1420
 msgid "Use the <application>Keyboard</application> preference tool to modify the autorepeat preferences for your keyboard, and to configure typing break settings."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:1506
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1450
 msgid "To open the <link linkend=\"prefs-keyboard-a11y\"><application>Keyboard <emphasis>Accessibility</emphasis></application> preference tool</link>, click the <guibutton>Accessibility</guibutton> button."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1509
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1453
 msgid "Use the <guilabel>General</guilabel> tabbed section to set general keyboard preferences."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1511
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1455
 msgid "<xref linkend=\"goscustperiph-TBL-3\"/> lists the keyboard preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1531
+#: C/goscustdesk.xml:1475
 msgid "<guilabel>Key presses repeat when key is held down</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1537
+#: C/goscustdesk.xml:1480
 msgid "Select this option to enable keyboard repeat. If keyboard repeat is enabled, when you press-and-hold a key, the action associated with the key is performed repeatedly. For example, if you press-and-hold a character key, the character is typed repeatedly."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1545
-#: C/goscustdesk.xml:1828
-#: C/goscustdesk.xml:1855
-#: C/goscustdesk.xml:2043
+#: C/goscustdesk.xml:1488
+#: C/goscustdesk.xml:1762
+#: C/goscustdesk.xml:1789
+#: C/goscustdesk.xml:1973
 msgid "<guilabel>Delay</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1550
+#: C/goscustdesk.xml:1493
 msgid "Select the delay from the time you press a key to the time that the action repeats."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1556
-#: C/goscustdesk.xml:1577
-#: C/goscustdesk.xml:2031
+#: C/goscustdesk.xml:1499
+#: C/goscustdesk.xml:1520
+#: C/goscustdesk.xml:1961
 msgid "<guilabel>Speed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1561
+#: C/goscustdesk.xml:1504
 msgid "Select the speed at which the action is repeated."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1566
+#: C/goscustdesk.xml:1509
 msgid "<guilabel>Cursor blinks in text boxes and fields</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1571
+#: C/goscustdesk.xml:1514
 msgid "Select this option to enable the cursor to blink in fields and text boxes."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1582
+#: C/goscustdesk.xml:1525
 msgid "Use the slider to specify the speed at which the cursor blinks in fields and text boxes."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1588
-#: C/goscustdesk.xml:1866
+#: C/goscustdesk.xml:1531
+#: C/goscustdesk.xml:1800
 msgid "<guilabel>Type to test settings</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1594
-#: C/goscustdesk.xml:1871
+#: C/goscustdesk.xml:1536
+#: C/goscustdesk.xml:1805
 msgid "The test area is an interactive interface so you can see how the keyboard settings affect the display as you type. Type text in the test area to test the effect of your settings."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:1604
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1546
 msgid "Keyboard Layouts Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1607
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1549
 msgid "Use the <guilabel>Layouts</guilabel> tabbed section to set your keyboard's language, and also the make and model of keyboard you are using."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1608
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1550
 msgid "This will allow MATE to make use of special media keys on your keyboard, and to show the correct characters for your keyboard's language."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1612
+#: C/goscustdesk.xml:1554
 msgid "<guilabel>Keyboard model</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1613
+#: C/goscustdesk.xml:1555
 msgid "Use the browse button (labeled with the currently selected keyboard model) to choose another keyboard make and model."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1616
+#: C/goscustdesk.xml:1558
 msgid "<guilabel>Separate layout for each window</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1617
+#: C/goscustdesk.xml:1559
 msgid "When this option is selected, each window has its own keyboard layout. Changing to a different layout will only affect the current window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1619
+#: C/goscustdesk.xml:1561
 msgid "This allows you to type with a Russian keyboard layout in a word processor, then switch to your web browser and type with an English keyboard layout, for example."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1622
+#: C/goscustdesk.xml:1564
 msgid "<guilabel>Selected Layouts</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1623
+#: C/goscustdesk.xml:1565
 msgid "You can switch between selected layouts to change the characters your keyboard produces when you type. To add a layout, click <guibutton>Add</guibutton>. You can have up to four layouts. To remove a layout, select it and press <guibutton>Remove</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1624
+#: C/goscustdesk.xml:1566
 msgid "To switch between keyboard layouts, use the <application>Keyboard Indicator</application> panel applet."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1625
+#: C/goscustdesk.xml:1567
 msgid "To add a layout to the list of selected layouts, click the <guibutton>Add</guibutton> button. It opens a layout chooser dialog, which lets you select a layout by country or by language."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1630
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1572
 msgid "Click <guibutton>Reset to Defaults</guibutton> to restore all keyboard layout settings to their initial state for your system and locale."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1632
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1574
 msgid "Click the <guibutton>Layout Options</guibutton> button to open the <guilabel>Keyboard Layout Options</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:1636
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1577
 msgid "Keyboard Layout Options"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1639
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1580
 msgid "The <guilabel>Keyboard Layout Options</guilabel> dialog has options for the behavior of keyboard modifier keys and certain shortcut options."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1640
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1581
 msgid "Expand each group label to show the available options. A label in boldface indicates that the options in the group have been changed from the default setting."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:1641
+#: C/goscustdesk.xml:1582
 msgid "The options shown in this dialog depend on the X windowing system you are using. Not all the following options might be listed on your system, and not all the options shown might work on your system."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1649
+#: C/goscustdesk.xml:1590
 msgid "<guilabel>Adding the EuroSign to certain keys</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1651
+#: C/goscustdesk.xml:1592
 msgid "Use these options to add the Euro currency symbol € to a key as a third-level character. To access this symbol, you must assign a <guilabel>third level chooser</guilabel>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1655
+#: C/goscustdesk.xml:1596
 msgid "<guilabel>Alt/Win key behavior</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1656
+#: C/goscustdesk.xml:1597
 msgid "This group of options allows you to assign the behavior of Unix modifier keys Super, Meta, and Hyper to the <keycap>Alt</keycap> and <keycap>Windows</keycap> keys on your keyboard."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1661
+#: C/goscustdesk.xml:1602
 msgid "<guilabel>CapsLock key behavior</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1662
+#: C/goscustdesk.xml:1603
 msgid "This group has several options for the <keycap>Caps Lock</keycap> key."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1667
+#: C/goscustdesk.xml:1608
 msgid "<guilabel>Compose key position</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1669
+#: C/goscustdesk.xml:1610
 msgid "The Compose key allows you to combine two keypresses to make a single character. This is used to create an accented character that might not be on your keyboard layout. For example, press the Compose key, then <keycap>'</keycap>, then <keycap>e</keycap> to obtain e-acute character."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1673
+#: C/goscustdesk.xml:1614
 msgid "<guilabel>Control key position</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1674
+#: C/goscustdesk.xml:1615
 msgid "Use this group of options to set the location of the <keycap>Ctrl</keycap> key to match the layout on older keyboards."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1679
+#: C/goscustdesk.xml:1620
 msgid "<guilabel>Group Shift/Lock behavior</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1680
+#: C/goscustdesk.xml:1621
 msgid "Select keys or key combinations to switch your keyboard layout when pressed."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1686
+#: C/goscustdesk.xml:1626
 msgid "<guilabel>Miscellaneous compatibility options</guilabel>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1690
+#: C/goscustdesk.xml:1630
 msgid "<guilabel>Shift with numpad keys works as in MS Windows.</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1692
+#: C/goscustdesk.xml:1632
 msgid "With this option selected, using <keycap>Shift</keycap> with keys on the numerical pad when <keycap>NumLock</keycap> is off extends the current selection."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1693
+#: C/goscustdesk.xml:1633
 msgid "With this option unselected, use <keycap>Shift</keycap> with keys on the numerical pad to obtain the reverse of the current behavior for that key. For example, when <keycap>NumLock</keycap> is off, the <keycap>8</keycap> key acts as an up-arrow. Press <keycombo><keycap>Shift</keycap><keycap>8</keycap></keycombo> to type an '8'."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1695
+#: C/goscustdesk.xml:1635
 msgid "<guilabel>Special keys (Ctrl+Alt+&lt;key&gt;) handled in a server.</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1696
+#: C/goscustdesk.xml:1636
 msgid "Select this option to have certain keyboard shortcuts passed to the X windowing system instead of being handled by MATE."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1702
+#: C/goscustdesk.xml:1642
 msgid "<guilabel>Third level choosers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1704
+#: C/goscustdesk.xml:1644
 msgid "A <firstterm>third level</firstterm> key allows you to obtain a third character from a key, in the same way that pressing <keycap>Shift</keycap> with a key produces a different character to pressing the key alone."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1705
+#: C/goscustdesk.xml:1645
 msgid "Use this group to select a key you want to act as a third level modifier key."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1706
+#: C/goscustdesk.xml:1646
 msgid "Pressing the third-level key and <keycap>Shift</keycap> produces a fourth character from a key."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1707
+#: C/goscustdesk.xml:1647
 msgid "The third and fourth level characters for your keyboard layout are shown in the <application>Keyboard Indicator</application> Layout View Window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:1712
+#: C/goscustdesk.xml:1652
 msgid "<guilabel>Use keyboard LED to show alternative group.</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:1714
+#: C/goscustdesk.xml:1654
 msgid "Use this option to specify that one of the light indicators on your keyboard should indicate when an alternative keyboard layout is in use."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:1715
+#: C/goscustdesk.xml:1655
 msgid "The selected keyboard light will no longer indicate its standard function. For example, the Caps Lock light will not react to the <keycap>Caps Lock key</keycap>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:1723
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1661
 msgid "Keyboard Accessibility Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:1725
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1662
 msgid "<primary>AccessX</primary> <see>preference tools, Keyboard Accessibility</see>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:1729
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1666
 msgid "<primary>keyboard</primary> <secondary>configuring accessibility options</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:1734
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1670
 msgid "<primary>accessibility</primary> <secondary>configuring keyboard</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:1738
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:1674
 msgid "<primary>preference tools</primary> <secondary>Keyboard Accessibility</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1748
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1683
 msgid "The <guilabel>Accessibility</guilabel> tabbed section allows you to set options such as filtering out accidental keypresses and using shortcut keys without having to hold down several keys at once. These features are also known as AccessX."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1750
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1685
 msgid "This section describes each of the preferences you can set. For a more task-oriented description of keyboard accessibility, see the <citetitle>MATE Desktop Accessibility Guide</citetitle>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1752
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1687
 msgid "<xref linkend=\"goscustdesk-TBL-85\"/> lists the accessibility preferences that you can modify."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:1755
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1689
 msgid "Accessibility Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1772
+#: C/goscustdesk.xml:1706
 msgid "<guilabel>Accessibility features can be toggled with keyboard shortcuts</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1777
+#: C/goscustdesk.xml:1711
 msgid "Select this option to show an icon in the notification area that offers quick access to accessibility features."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1785
+#: C/goscustdesk.xml:1719
 msgid "<guilabel>Simulate simultaneous keypresses</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/indexterm
-#: C/goscustdesk.xml:1788
+#: C/goscustdesk.xml:1722
 msgid "<primary>accessibility</primary> <secondary>sticky keys</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1794
+#: C/goscustdesk.xml:1728
 msgid "Select this option to perform multiple simultaneous keypress operations by pressing the keys in sequence. Alternatively, to enable the sticky keys feature, press <keycap>Shift</keycap> five times."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1801
+#: C/goscustdesk.xml:1735
 msgid "<guilabel>Disable sticky keys if two keys are pressed together</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1806
+#: C/goscustdesk.xml:1740
 msgid "Select this option to specify that when you press two keys simultaneously, you can no longer press keys in sequence to perform multiple simultaneous keypresses."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1813
+#: C/goscustdesk.xml:1747
 msgid "<guilabel>Only accept long keypresses</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/indexterm
-#: C/goscustdesk.xml:1816
+#: C/goscustdesk.xml:1750
 msgid "<primary>accessibility</primary> <secondary>slow keys</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1822
+#: C/goscustdesk.xml:1756
 msgid "Select this option to control the period that you must press-and-hold a key before acceptance. Alternatively, to enable the slow keys feature, press-and-hold <keycap>Shift</keycap> for eight seconds."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1833
+#: C/goscustdesk.xml:1767
 msgid "Use the slider to specify the period that you must press-and-hold a key before acceptance."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1840
+#: C/goscustdesk.xml:1774
 msgid "<guilabel>Ignore fast duplicate keypresses</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/indexterm
-#: C/goscustdesk.xml:1843
+#: C/goscustdesk.xml:1777
 msgid "<primary>accessibility</primary> <secondary>bounce keys</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1849
+#: C/goscustdesk.xml:1783
 msgid "Select this option to accept a key input and to control the key repeat characteristics of the keyboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1860
+#: C/goscustdesk.xml:1794
 msgid "Use the slider to specify the interval to wait after the first keypress before the automatic repeat of a pressed key."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1880
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1814
 msgid "To configure audio feedback for keyboard accessibility features, click the <guibutton>Audio Feedback</guibutton> button. It opens the <guilabel>Keyboard Accessibility Audio Feedback</guilabel> window."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:1886
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1819
 msgid "Keyboard Accessibility Audio Feedback"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1887
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1820
 msgid "Configure audio feedback for keyboard accessibility features."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1888
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1821
 msgid "<xref linkend=\"goscustdesk-TBL-86\"/> lists the audio feedback preferences that you can modify."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:1891
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1823
 msgid "Audio Feedback Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1908
+#: C/goscustdesk.xml:1840
 msgid "<guilabel>Beep when accessibility features are turned on or off</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1913
+#: C/goscustdesk.xml:1845
 msgid "Select this option for an audible indication when a feature such as sticky keys or slow keys is activated, or deactivated."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1919
+#: C/goscustdesk.xml:1851
 msgid "<guilabel>Beep when a toggle key is pressed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/indexterm
-#: C/goscustdesk.xml:1922
+#: C/goscustdesk.xml:1854
 msgid "<primary>accessibility</primary> <secondary>toggle keys</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1928
+#: C/goscustdesk.xml:1860
 msgid "Select this option for an audible indication of a toggle keypress. You hear one beep when a toggle key is turned on. You hear two beeps when a toggle key is turned off."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1935
+#: C/goscustdesk.xml:1867
 msgid "<guilabel>Beep when a modifier key is pressed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1940
+#: C/goscustdesk.xml:1872
 msgid "Select this option for an audible indication when you press a modifier key."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1946
+#: C/goscustdesk.xml:1878
 msgid "<guilabel>Beep when a key is pressed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1951
+#: C/goscustdesk.xml:1883
 msgid "Select this option for an audible indication when a key is pressed."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1957
+#: C/goscustdesk.xml:1889
 msgid "<guilabel>Beep when a key is accepted</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1962
+#: C/goscustdesk.xml:1894
 msgid "Select this option for an audible indication when a key is accepted."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1968
+#: C/goscustdesk.xml:1900
 msgid "<guilabel>Beep when a key is rejected</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:1973
+#: C/goscustdesk.xml:1905
 msgid "Select this option for an audible indication when a key is rejected."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:1983
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1914
 msgid "Mouse Keys Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1985
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1916
 msgid "The options in the <guilabel>Mouse Keys</guilabel> tabbed section let you configure the keyboard as a substitute for the mouse."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:1987
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1918
 msgid "<xref linkend=\"goscustdesk-TBL-88\"/> lists the mouse keys preferences that you can modify."
 msgstr ""
 
-#. (itstool) path: table/title
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:1990
-#: C/goscustdesk.xml:2058
-#: C/goscustdesk.xml:2063
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:1920
+#: C/goscustdesk.xml:1987
+#: C/goscustdesk.xml:1991
 msgid "Typing Break Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2007
+#: C/goscustdesk.xml:1937
 msgid "<guilabel>Pointer can be controlled using the keypad</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/indexterm
-#: C/goscustdesk.xml:2010
+#: C/goscustdesk.xml:1940
 msgid "<primary>accessibility</primary> <secondary>mouse keys</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2016
+#: C/goscustdesk.xml:1946
 msgid "Select this option to make the numeric keypad emulate mouse actions. The list of keys and their equivalences is in the <citetitle>MATE Desktop Accessibility Guide</citetitle> under the heading <citetitle>To Enable the Keyboard to Emulate the Mouse</citetitle>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2021
-#: C/goscustdesk.xml:2227
+#: C/goscustdesk.xml:1951
+#: C/goscustdesk.xml:2148
 msgid "<guilabel>Acceleration</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2026
+#: C/goscustdesk.xml:1956
 msgid "Use the slider to specify how long it takes the pointer to accelerate to maximum speed."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2036
+#: C/goscustdesk.xml:1966
 msgid "Use the slider to specify the maximum speed that the pointer moves across the screen."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2048
+#: C/goscustdesk.xml:1978
 msgid "Use the slider to specify the period that must pass after a keypress before the pointer moves."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2059
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1989
 msgid "Configure the Typing Break Preferences to make MATE remind you to rest after you have been using the keyboard and mouse for a long time. During a Typing Break, the screen will be locked."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2060
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:1990
 msgid "<xref linkend=\"goscustdesk-TBL-87\"/> lists the typing break preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2080
+#: C/goscustdesk.xml:2008
 msgid "<guilabel>Lock screen to enforce typing break</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2085
+#: C/goscustdesk.xml:2013
 msgid "Select this option to lock the screen when you are due a typing break."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2091
+#: C/goscustdesk.xml:2018
 msgid "<guilabel>Work interval lasts</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2096
+#: C/goscustdesk.xml:2023
 msgid "Use the spin box to specify how long you can work before a typing break occurs."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2102
+#: C/goscustdesk.xml:2029
 msgid "<guilabel>Break interval lasts</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2107
+#: C/goscustdesk.xml:2034
 msgid "Use the spin box to specify the length of your typing breaks."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2113
+#: C/goscustdesk.xml:2040
 msgid "<guilabel>Allow postponing of breaks</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2118
+#: C/goscustdesk.xml:2045
 msgid "Select this option if you want to be able to postpone typing breaks."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:2125
+#: C/goscustdesk.xml:2052
 msgid "If you stop using the keyboard and mouse for a length of time equal to the <guilabel>Break interval</guilabel> setting, the current work interval will be reset."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:2134
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2058
 msgid "Mouse Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2137
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2061
 msgid "<primary>preference tools</primary> <secondary>Mouse</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2141
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2065
 msgid "<primary>mouse</primary> <secondary>configuring</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2146
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2070
 msgid "With the <application>Mouse</application> preference tool you can:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2150
+#: C/goscustdesk.xml:2074
 msgid "configure your mouse for right-hand use or for left-hand use,"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2153
+#: C/goscustdesk.xml:2077
 msgid "specify the speed and sensitivity of mouse movement,"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2156
+#: C/goscustdesk.xml:2080
 msgid "configure mouse accessibility features."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:2162
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2084
 msgid "General Mouse Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2163
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2085
 msgid "Use the <guilabel>General</guilabel> tabbed section to specify whether the mouse buttons are configured for left-hand or right-hand use and configure the speed and sensitivity of your mouse."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2166
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2088
 msgid "<xref linkend=\"goscustperiph-TBL-6\"/> lists the general mouse preferences that you can modify."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:2171
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2092
 msgid "Mouse Button Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2188
+#: C/goscustdesk.xml:2109
 msgid "<guilabel>Right-handed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2193
+#: C/goscustdesk.xml:2114
 msgid "Select this option to configure your mouse for right-hand use. When you configure your mouse for right-hand use, the left mouse button is the primary button and the right mouse button is the secondary button."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2198
+#: C/goscustdesk.xml:2119
 msgid "<guilabel>Left-handed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2203
+#: C/goscustdesk.xml:2124
 msgid "Select this option to configure your mouse for left-hand use. When you configure your mouse for left-hand use, the functions of the left mouse button and the right mouse button are swapped."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2210
+#: C/goscustdesk.xml:2131
 msgid "<guilabel>Show position of pointer when the Control key is pressed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2215
+#: C/goscustdesk.xml:2136
 msgid "Select this option to enable a mouse pointer animation when you press and release the Control key. This feature can assist you to locate the mouse pointer."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:2219
+#: C/goscustdesk.xml:2140
 msgid "The position of the Control key on the keyboard can be modified in the Keyboard Layout Options dialog, see <xref linkend=\"prefs-keyboard-layoutoptions\"/>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2232
+#: C/goscustdesk.xml:2153
 msgid "Use the slider to specify the speed at which your mouse pointer moves on your screen when you move your mouse."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2238
+#: C/goscustdesk.xml:2159
 msgid "<guilabel>Sensitivity</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2243
+#: C/goscustdesk.xml:2164
 msgid "Use the slider to specify how sensitive your mouse pointer is to movements of your mouse."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2249
+#: C/goscustdesk.xml:2170
 msgid "<guilabel>Threshold</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2254
+#: C/goscustdesk.xml:2175
 msgid "Use the slider to specify the distance that you must move an item before the move action is interpreted as a drag-and-drop action."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2261
+#: C/goscustdesk.xml:2182
 msgid "<guilabel>Timeout</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2266
+#: C/goscustdesk.xml:2187
 msgid "Use the slider to specify the amount of time that can pass between clicks when you double-click. If the interval between the first and second clicks exceeds the time that is specified here, the action is not interpreted as a double-click."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2271
+#: C/goscustdesk.xml:2191
 msgid "Use the light bulb icon to check double-click sensitivity: the light will light up briefly for a click, but stay lit for a double-click."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:2280
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2199
 msgid "Mouse Accessibility Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2281
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2200
 msgid "Use the <guilabel>Accessibility</guilabel> tabbed section to configure accessibility features that can help people who have difficulty with exact positioning of the pointer or with pressing the mouse buttons:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2285
+#: C/goscustdesk.xml:2204
 msgid "Open a contextual menu by clicking and holding the primary mouse button; this is useful for users that can manipulate only one button."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2294
+#: C/goscustdesk.xml:2213
 msgid "Single click"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2296
+#: C/goscustdesk.xml:2215
 msgid "A single click of the primary mouse button"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2302
+#: C/goscustdesk.xml:2221
 msgid "Double click"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2304
+#: C/goscustdesk.xml:2223
 msgid "A double click of the primary mouse button"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2310
+#: C/goscustdesk.xml:2229
 msgid "Drag click"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2312
+#: C/goscustdesk.xml:2231
 msgid "A click that begins a drag operation"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2318
+#: C/goscustdesk.xml:2237
 msgid "Secondary click"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2320
+#: C/goscustdesk.xml:2239
 msgid "A single click of the secondary mouse button"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2290
+#: C/goscustdesk.xml:2209
 msgid "Perform different types of mouse button click by software; this useful for users that are not able to manipulate any buttons. The types of click that can be performed are: <_:variablelist-1/>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2329
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2248
 msgid "<xref linkend=\"goscustdesk-TBL-47\"/> lists the mouse accessibility preferences that you can modify:"
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:2332
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2250
 msgid "Mouse Motion Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2349
+#: C/goscustdesk.xml:2267
 msgid "<guilabel>Trigger secondary click by holding down the primary button</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2354
+#: C/goscustdesk.xml:2272
 msgid "Select this option to enable simulated secondary clicks by pressing the primary mouse button for an extended time."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2359
+#: C/goscustdesk.xml:2277
 msgid "<guilabel>Delay</guilabel> slider in the <guilabel>Simulated Secondary Click</guilabel> section"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2364
+#: C/goscustdesk.xml:2282
 msgid "Use the slider to specify how long the primary button must be pressed to simulate a secondary click."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2369
+#: C/goscustdesk.xml:2287
 msgid "<guilabel>Initiate click when stopping pointer movement</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2374
+#: C/goscustdesk.xml:2292
 msgid "Select this option to enable automatic clicks when the mouse stops. Use the additional preferences in the <guilabel>Dwell Click</guilabel> section to configure how the type of click is chosen."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2379
+#: C/goscustdesk.xml:2297
 msgid "<guilabel>Delay</guilabel> slider in the <guilabel>Dwell Click</guilabel> section"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2384
+#: C/goscustdesk.xml:2302
 msgid "Use the slider to specify how long the pointer must remain at rest before an automatic click will be triggered."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2389
+#: C/goscustdesk.xml:2307
 msgid "<guilabel>Motion threshold</guilabel> slider"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2394
+#: C/goscustdesk.xml:2312
 msgid "Use the slider to specify how much the pointer may move to still be considered at rest."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2399
+#: C/goscustdesk.xml:2317
 msgid "<guilabel>Choose type of click beforehand</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2404
+#: C/goscustdesk.xml:2322
 msgid "Select this option to pick the type of click to perform from a window or panel applet."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2410
+#: C/goscustdesk.xml:2328
 msgid "<guilabel>Show click type window</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2415
+#: C/goscustdesk.xml:2333
 msgid "When this option is enabled, the different types of click (single click, double click, drag click or secondary click) can be selected in a window."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:2417
+#: C/goscustdesk.xml:2335
 msgid "The <guilabel>Dwell Click</guilabel> panel applet can be used instead of the window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2423
+#: C/goscustdesk.xml:2341
 msgid "<guilabel>Choose type of click with mouse gestures</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2428
+#: C/goscustdesk.xml:2346
 msgid "Select this option to pick the type of click by moving the mouse in a certain direction. The four combo boxes below this option allow to assign directions to the different types of click. Note that each direction can be used only for one type of click."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2434
+#: C/goscustdesk.xml:2351
 msgid "<guilabel>Single click</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2439
+#: C/goscustdesk.xml:2356
 msgid "Choose the direction to trigger a single click."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2446
+#: C/goscustdesk.xml:2363
 msgid "<guilabel>Double click</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2451
+#: C/goscustdesk.xml:2368
 msgid "Choose the direction to trigger a double click."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2458
+#: C/goscustdesk.xml:2375
 msgid "<guilabel>Drag click</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2463
+#: C/goscustdesk.xml:2380
 msgid "Choose the direction to trigger a drag click."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2470
+#: C/goscustdesk.xml:2387
 msgid "<guilabel>Secondary click</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2475
+#: C/goscustdesk.xml:2392
 msgid "Choose the direction to trigger a secondary click."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:2487
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2403
 msgid "Monitors"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2488
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2404
 msgid "<primary>preference tools</primary> <secondary>Display</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2492
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2408
 msgid "Use <application>Monitor Preferences</application> to configure the monitors that your computer uses."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:2494
+#: C/goscustdesk.xml:2410
 msgid "On most laptop keyboards, you can use the key combination <keycombo><keycap>Fn</keycap><keycap>F7</keycap></keycombo> to cycle between several typical monitor configurations without starting <application>Monitor Preferences</application>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2498
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2414
 msgid "Drag the graphical representations of the monitors in the upper left part of the window to set how your monitors are arranged. <application>Monitor Preferences</application> displays small labels in the top left corner of each monitor to help you identify which rectangle corresponds to which monitor."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2503
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2419
 msgid "Changes you make in <application>Monitor Preferences</application> don't take effect until you click the <guibutton>Apply</guibutton> button. Settings will revert to their previous settings unless you confirm the changes. This is to prevent bad display settings from rendering your computer unusable."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2510
+#: C/goscustdesk.xml:2426
 msgid "<guilabel>Same image in all monitors</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2511
+#: C/goscustdesk.xml:2427
 msgid "When this option is selected, your entire desktop will fit on a single monitor, and every monitor will show the same copy of your desktop. When it is not selected, your desktop spans multiple monitors, and each monitor shows only a part of your entire desktop."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2517
+#: C/goscustdesk.xml:2433
 msgid "<guilabel>Detect monitors</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2518
+#: C/goscustdesk.xml:2434
 msgid "Click this button to find monitors that have been recently added or plugged in."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2522
+#: C/goscustdesk.xml:2438
 msgid "<guilabel>Show monitors in panel</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2523
+#: C/goscustdesk.xml:2439
 msgid "When this option is selected, an icon will be placed on your panel allowing you to quickly change certain settings without opening <application>Monitor Preferences</application>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2529
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2445
 msgid "The following list explains the options you can set for each monitor. The currently selected monitor is the one whose graphical representation has a bold black outline. It is also indicated by the background color of the section label."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2536
+#: C/goscustdesk.xml:2452
 msgid "<guilabel>On</guilabel> / <guilabel>Off</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2537
+#: C/goscustdesk.xml:2453
 msgid "Individual monitors can be completely disabled by selecting <guilabel>Off</guilabel>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2541
+#: C/goscustdesk.xml:2457
 msgid "<guilabel>Resolution</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2542
+#: C/goscustdesk.xml:2458
 msgid "Select the resolution to use for the currently selected monitor from the drop-down list. <emphasis>Resolution</emphasis> refers to the pixel dimensions of the screen. A larger resolution means that more things fit on the screen, but everything will be smaller."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2550
+#: C/goscustdesk.xml:2466
 msgid "<guilabel>Refresh rate</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2551
+#: C/goscustdesk.xml:2467
 msgid "Select the refresh rate to use for the currently selected monitor from the drop-down list. The <emphasis>refresh rate</emphasis> determines how often the computer redraws the screen. A too low refresh rate (below 60) makes the monitor flicker and can cause discomfort to your eyes. This is less of a problem on LCDs."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscustdesk.xml:2560
+#: C/goscustdesk.xml:2476
 msgid "<guilabel>Rotation</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2561
+#: C/goscustdesk.xml:2477
 msgid "Select the rotation for the currently selected monitor. This option may not be supported on all graphics cards."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:2568
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2483
 msgid "Sound Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2569
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2485
 msgid "<primary>preference tools</primary> <secondary>Sound</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2573
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2489
 msgid "<primary>sound</primary> <secondary>setting preferences</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2577
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2493
 msgid "<primary>sound</primary> <secondary>associating events with sounds</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2582
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2497
 msgid "<primary>events, associating sounds with</primary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2586
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2500
 msgid "<primary>volume</primary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2589
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2503
 msgid "The <application>Sound</application> preference tool enables you to control devices and volume for sound input and output. You can also specify which sounds to play when particular events occur."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2592
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2506
 msgid "You can customize the settings for the <application>Sound</application> preference tool in the following functional areas:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2596
+#: C/goscustdesk.xml:2510
 msgid "<guilabel>Sound Events</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2601
+#: C/goscustdesk.xml:2515
 msgid "<guilabel>Input</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2606
+#: C/goscustdesk.xml:2520
 msgid "<guilabel>Output</guilabel>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2611
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2525
 msgid "You can change the overall output volume using the <guilabel>Output volume</guilabel> slider at the top of the window. The <guilabel>Mute</guilabel> checkbox allows to temporarily suppress all output without disturbing the current volume."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:2613
-#: C/goscustdesk.xml:2618
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2527
+#: C/goscustdesk.xml:2530
 msgid "Sound Effects Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2614
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2528
 msgid "A sound theme is collection of sound effects that are associated to various events, such as opening a dialog, clicking a button or selecting an item in a menu. One of the most prominent event sounds is the <emphasis>System Bell</emphasis> sound that often played to indicate a keyboard input error. Use the <guilabel>Sound Effects</guilabel> tabbed section of the <application>Sound</application> preference tool to choose a sound theme and modify the bell sound."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2615
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2529
 msgid "<xref linkend=\"goscustmulti-TBL-6\"/> lists the sound effects preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2635
+#: C/goscustdesk.xml:2547
 msgid "<guilabel>Alert Volume</guilabel> slider"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2638
+#: C/goscustdesk.xml:2550
 msgid "Use the <guilabel>Alert Volume</guilabel> slider to control the volume for event sounds."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2640
+#: C/goscustdesk.xml:2552
 msgid "The <guilabel>Mute</guilabel> checkbox allows to temporarily suppress event sounds without modifying the current volume."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2647
+#: C/goscustdesk.xml:2559
 msgid "<guilabel>Sound Theme </guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2652
+#: C/goscustdesk.xml:2564
 msgid "Use this combobox to select a different sound theme."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2653
+#: C/goscustdesk.xml:2565
 msgid "Choose <guilabel>No sounds</guilabel> to turn off all event sounds."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2658
+#: C/goscustdesk.xml:2570
 msgid "<guilabel>Choose an alert sound </guilabel> list"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2661
+#: C/goscustdesk.xml:2573
 msgid "Choose an alternative sound for the System Bell from this list."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2663
+#: C/goscustdesk.xml:2574
 msgid "Selecting a list element plays the sound."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2668
+#: C/goscustdesk.xml:2579
 msgid "<guilabel>Enable window and button sounds </guilabel> checkbox"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2671
+#: C/goscustdesk.xml:2582
 msgid "Uncheck this option if you don't want to hear sounds for window-related events (such as a dialog or a menu appearing) and button clicks."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:2682
-#: C/goscustdesk.xml:2688
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2593
+#: C/goscustdesk.xml:2597
 msgid "Sound Input Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2683
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2594
 msgid "Use the <guilabel>Input</guilabel> tabbed section to set your preferences for sound input."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2685
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2596
 msgid "<xref linkend=\"goscustdesk-TBL-1\"/> lists the sound input preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2705
+#: C/goscustdesk.xml:2614
 msgid "<guilabel>Input volume </guilabel> slider"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2710
+#: C/goscustdesk.xml:2619
 msgid "Use the input volume slider to control the input level."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2711
+#: C/goscustdesk.xml:2620
 msgid "The <guilabel>Mute </guilabel> checkbox allows to temporarily suppress all input without disturbing the current input level."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2716
+#: C/goscustdesk.xml:2625
 msgid "<guilabel>Input level</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2721
+#: C/goscustdesk.xml:2630
 msgid "The <guilabel>Input level</guilabel> display provides visual feedback that helps to select a suitable input volume."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2727
+#: C/goscustdesk.xml:2636
 msgid "<guilabel>Choose a device for sound input </guilabel> list"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2732
+#: C/goscustdesk.xml:2641
 msgid "Choose the device that you want to receive sound input from."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:2739
+#: C/goscustdesk.xml:2648
 msgid "Note that the input volume can also be controlled with the microphone icon that is shown in the notification area of the panel when an application is listening for sound input."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:2744
-#: C/goscustdesk.xml:2750
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2653
+#: C/goscustdesk.xml:2658
 msgid "Sound Output Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2745
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2654
 msgid "Use the <guilabel>Output</guilabel> tabbed section to set your preferences for sound output."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2747
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2656
 msgid "<xref linkend=\"goscustdesk-TBL-2\"/> lists the sound output preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2767
+#: C/goscustdesk.xml:2675
 msgid "<guilabel>Output volume </guilabel> slider"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2772
+#: C/goscustdesk.xml:2680
 msgid "Use the output volume slider to control the overall output volume."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2773
+#: C/goscustdesk.xml:2681
 msgid "The <guilabel>Mute </guilabel> checkbox allows to temporarily suppress all output without disturbing the current volume."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2774
+#: C/goscustdesk.xml:2682
 msgid "Note that the <guilabel>Output volume</guilabel> slider is located above the tabbed section at the top of the window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2780
+#: C/goscustdesk.xml:2688
 msgid "<guilabel>Choose a device for sound output </guilabel> list"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2785
+#: C/goscustdesk.xml:2693
 msgid "Choose the device that you want to hear sound output from."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2791
+#: C/goscustdesk.xml:2699
 msgid "<guilabel>Balance </guilabel> slider"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2796
+#: C/goscustdesk.xml:2704
 msgid "Use the <guilabel>Balance</guilabel> slider to control the left/right balance of an output device that has more than one channel (e.g. stereo or 5.1)."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscustdesk.xml:2804
+#: C/goscustdesk.xml:2712
 msgid "Note that the output volume can also be controlled with the speaker icon that is shown in the notification area of the panel."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:2808
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2716
 msgid "Application Sound Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2809
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2717
 msgid "Use the <guilabel>Applications</guilabel> tabbed section to control the volume of sound played by individual applications."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2811
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2719
 msgid "Each application that is currently playing sound is identified by its name and icon."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscustdesk.xml:2829
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2733
 msgid "System"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscustdesk.xml:2832
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2735
 msgid "Sessions Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#. (itstool) path: sect1/indexterm
-#: C/goscustdesk.xml:2837
-#: C/gosstartsession.xml:177
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2738
+#: C/gosstartsession.xml:178
 msgid "<primary>preference tools</primary> <secondary>Sessions</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2841
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2742
 msgid "<primary>sessions</primary> <secondary>preferences</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscustdesk.xml:2845
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2746
 msgid "<primary>startup applications</primary> <secondary>customizing</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2849
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2750
 msgid "The <application>Sessions</application> preference tool enables you to manage your sessions. You can set session preferences, and specify which applications to start when you start a session. You can configure sessions to save the state of applications in the MATE Desktop, and to restore the state when you start another session. You can also use this preference tool to manage multiple MATE sessions."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscustdesk.xml:2855
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2756
 msgid "You can customize the settings for sessions and startup applications in the following functional areas:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2859
+#: C/goscustdesk.xml:2760
 msgid "<guilabel>Session Options</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2864
+#: C/goscustdesk.xml:2765
 msgid "<guilabel>Startup Programs</guilabel>"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:2870
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2771
 msgid "Setting Session Preferences"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:2871
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2772
 msgid "<primary>sessions</primary> <secondary>setting options</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2875
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2776
 msgid "Use the <guilabel>Session Options</guilabel> tabbed section to manage multiple sessions, and to set preferences for the current session."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2877
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2778
 msgid "<xref linkend=\"goscustsession-TBL-11\"/> lists the session options that you can modify."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:2880
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2780
 msgid "Session Options"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2897
+#: C/goscustdesk.xml:2797
 msgid "<guilabel>Automatically remember running applications when logging out</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/indexterm
-#: C/goscustdesk.xml:2902
-#: C/goscustdesk.xml:2921
+#: C/goscustdesk.xml:2802
+#: C/goscustdesk.xml:2821
 msgid "<primary>startup applications</primary> <secondary>session-managed</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2906
+#: C/goscustdesk.xml:2806
 msgid "Select this option if you want the session manager to save the state of your session when logging out. The session manager saves the session-managed applications that are open, and the settings associated with the session-managed applications when you log out. The next time that you start a session, the applications start automatically, with the saved settings."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2916
+#: C/goscustdesk.xml:2816
 msgid "<guilabel>Remember currently running applications</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2925
+#: C/goscustdesk.xml:2825
 msgid "Select this option if you want the session manager to save the current state of your session. The session manager saves the session-managed applications that are open, and the settings associated with the session-managed applications. The next time that you start a session, the applications start automatically, with the saved settings."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscustdesk.xml:2938
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2838
 msgid "Configuring Startup Applications"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscustdesk.xml:2939
+#. (itstool) path: section/indexterm
+#: C/goscustdesk.xml:2839
 msgid "<primary>startup applications</primary> <secondary>non-session-managed</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2943
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2843
 msgid "Use the <guilabel>Startup Programs</guilabel> tabbed section of the <application>Sessions</application> preference tool to specify non-session-managed <firstterm>startup applications</firstterm>. Startup applications are applications that start automatically when you start a session. You specify the commands that run the non-session-managed applications in the <guilabel>Startup Programs</guilabel> tabbed section. The commands execute automatically when you log in."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2950
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2850
 msgid "You can also start session-managed applications automatically. For more information, see <xref linkend=\"goscustsession-16\"/>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscustdesk.xml:2952
+#. (itstool) path: section/para
+#: C/goscustdesk.xml:2852
 msgid "<xref linkend=\"goscustsession-TBL-19\"/> lists the startup applications preferences that you can modify."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscustdesk.xml:2955
+#. (itstool) path: info/title
+#: C/goscustdesk.xml:2854
 msgid "Startup Programs Preferences"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2972
+#: C/goscustdesk.xml:2871
 msgid "<guilabel> Additional startup programs</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscustdesk.xml:2977
+#: C/goscustdesk.xml:2876
 msgid "Use this table to manage non-session-managed startup applications as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2981
+#: C/goscustdesk.xml:2880
 msgid "To add a startup application, click on the <guibutton>Add</guibutton> button. The <guilabel>New Startup Program</guilabel> dialog is displayed. Enter the name of the application in the <guilabel>Name</guilabel> field. Then enter the command to start the application in the <guilabel>Command</guilabel> field. You can also specify a comment in the <guilabel>Comment</guilabel> field"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2984
+#: C/goscustdesk.xml:2883
 msgid "To edit a startup application, select the startup application, then click on the <guibutton>Edit</guibutton> button. The <guilabel>Edit Startup Program</guilabel> dialog is displayed. Use the dialog to modify the command and the startup order for the startup application."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscustdesk.xml:2990
+#: C/goscustdesk.xml:2889
 msgid "To delete a startup application, select the startup application, then click on the <guilabel>Remove</guilabel> button."
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/goseditmainmenu.xml:2
+#. (itstool) path: info/title
+#: C/goseditmainmenu.xml:7
 msgid "Using the Main Menubar"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/goseditmainmenu.xml:13
+#: C/goseditmainmenu.xml:18
 msgid "This chapter describes how to use the MATE Panel Menubar."
 msgstr ""
 
 #. (itstool) path: chapter/indexterm
-#: C/goseditmainmenu.xml:15
+#: C/goseditmainmenu.xml:20
 msgid "<primary>menus</primary> <secondary>introduction</secondary>"
 msgstr ""
 
 #. (itstool) path: chapter/indexterm
-#: C/goseditmainmenu.xml:19
+#: C/goseditmainmenu.xml:24
 msgid "<primary>menus</primary> <secondary>Menu Bar</secondary> <see>Menu Bar</see>"
 msgstr ""
 
 #. (itstool) path: chapter/indexterm
-#: C/goseditmainmenu.xml:24
+#: C/goseditmainmenu.xml:29
 msgid "<primary>Menu Bar</primary> <secondary>introduction</secondary>"
 msgstr ""
 
 #. (itstool) path: chapter/para
-#: C/goseditmainmenu.xml:29
+#: C/goseditmainmenu.xml:34
 msgid "The panel menubar is your main point of access to MATE. Use the <guimenu>Applications</guimenu> menu to launch applications, the <guimenu>Places</guimenu> to open locations on your computer or network, and the <guimenu>System</guimenu> to customize your system, get help with MATE, and log out of MATE or shut down your computer."
 msgstr ""
 
 #. (itstool) path: chapter/para
-#: C/goseditmainmenu.xml:30
+#: C/goseditmainmenu.xml:35
 msgid "The following sections describe these three menus."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/goseditmainmenu.xml:31
+#: C/goseditmainmenu.xml:36
 msgid "By default, the panel menubar is on the <xref linkend=\"top-panel\"/>. But like any other panel object, you can move the menubar to another panel, or have more than one instance of the menubar in your panels. For more on this, see <xref linkend=\"panel-menus\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/goseditmainmenu.xml:34
+#. (itstool) path: info/title
+#: C/goseditmainmenu.xml:38
 msgid "Applications Menu"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/goseditmainmenu.xml:37
+#: C/goseditmainmenu.xml:41
 msgid "<primary>menus</primary> <secondary>Applications menu</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:41
+#: C/goseditmainmenu.xml:45
 msgid "The <guimenu>Applications</guimenu> menu contains a hierarchy of submenus, from which you can start the applications that are installed on your system."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:42
+#: C/goseditmainmenu.xml:46
 msgid "Each submenu corresponds to a category. For example, in the <guimenu>Sound &amp; Video</guimenu> submenu, you will find applications for playing CDs and recording sound."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:43
+#: C/goseditmainmenu.xml:47
 msgid "To launch an application, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:45
+#: C/goseditmainmenu.xml:49
 msgid "Open the <guimenu>Applications</guimenu> menu by clicking on it."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:46
+#: C/goseditmainmenu.xml:50
 msgid "Move the mouse down the menu to the category the application you want is in. Each submenu opens as your mouse passes over the category."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:47
+#: C/goseditmainmenu.xml:51
 msgid "Click the menu item for the application."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:49
+#: C/goseditmainmenu.xml:53
 msgid "When you install a new application, it is automatically added to the <guimenu>Applications</guimenu> menu in a suitable category. For example, if you install an instant messenger application, a VoIP application, or an FTP client, you will find it in the <guimenu>Internet</guimenu> submenu."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/goseditmainmenu.xml:52
+#. (itstool) path: info/title
+#: C/goseditmainmenu.xml:56
 msgid "Places Menu"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/goseditmainmenu.xml:53
+#: C/goseditmainmenu.xml:57
 msgid "<primary>Places menu</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:56
+#: C/goseditmainmenu.xml:60
 msgid "The <guimenu>Places</guimenu> menu is a quick way to go to various locations on your computer and your local network. The <guimenu>Places</guimenu> menu allows you to open the following items:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:58
+#: C/goseditmainmenu.xml:62
 msgid "Your Home folder"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:59
+#: C/goseditmainmenu.xml:63
 msgid "The Desktop folder, which corresponds to the items displays in the desktop."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:60
+#: C/goseditmainmenu.xml:64
 msgid "The items in your Caja bookmarks. For more on this, see <xref linkend=\"caja-bookmarks\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:61
+#: C/goseditmainmenu.xml:65
 msgid "Your computer, which shows all your drives."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:62
+#: C/goseditmainmenu.xml:66
 msgid "The Caja CD/DVD Creator. For more on this, see <xref linkend=\"caja-cdwriter\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:63
+#: C/goseditmainmenu.xml:67
 msgid "The local network. For more on this, see <xref linkend=\"caja-accessnetwork\"/>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:66
+#: C/goseditmainmenu.xml:70
 msgid "The last three items on the menu perform actions rather than open locations."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:69
+#: C/goseditmainmenu.xml:73
 msgid "<guimenuitem>Connect to Server</guimenuitem> lets you choose a server on your network. For more on this, see <xref linkend=\"caja-server-connect\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:70
-msgid "<guimenuitem>Search for Files</guimenuitem> lets you search for files on your computer. For more on this, see the <ulink type=\"help\" url=\"help:mate-search-tool\">Search for Files Manual</ulink>."
+#: C/goseditmainmenu.xml:74
+msgid "<guimenuitem>Search for Files</guimenuitem> lets you search for files on your computer. For more on this, see the <link xlink:href=\"help:mate-search-tool\">Search for Files Manual</link>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:71
+#: C/goseditmainmenu.xml:75
 msgid "The <guimenuitem>Recent Documents</guimenuitem> submenu lists the documents you have recently opened. The last entry in the submenu clears the list."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/goseditmainmenu.xml:75
+#. (itstool) path: info/title
+#: C/goseditmainmenu.xml:79
 msgid "System Menu"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/goseditmainmenu.xml:76
+#: C/goseditmainmenu.xml:80
 msgid "<primary>System Menu</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:79
+#: C/goseditmainmenu.xml:83
 msgid "The <guimenu>System</guimenu> menu allows you to set your preferences for the MATE Desktop, get help with using MATE, and log out or shut down."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:81
+#: C/goseditmainmenu.xml:85
 msgid "The <guimenuitem>Control Center</guimenuitem> item contains preference tools to configure your computer. For more information on using these preference tools, see <xref linkend=\"prefs\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:82
+#: C/goseditmainmenu.xml:86
 msgid "The <guimenuitem>Help</guimenuitem> item launches the Help Browser."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:83
+#: C/goseditmainmenu.xml:87
 msgid "The <guimenuitem>About MATE</guimenuitem> item has a brief introduction to MATE, links to the MATE website, and credits."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:84
+#: C/goseditmainmenu.xml:88
 msgid "The <guimenuitem>Lock Screen</guimenuitem> command starts your screensaver, and requires your password to return to the desktop. For more on this, see <xref linkend=\"lock-screen\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:85
+#: C/goseditmainmenu.xml:89
 msgid "Choose <guimenuitem>Log Out</guimenuitem> to log out of MATE, or to switch user."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:86
+#: C/goseditmainmenu.xml:90
 msgid "Choose <guimenuitem>Shut Down</guimenuitem> to end your MATE session and turn off your computer, or restart it."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:89
+#: C/goseditmainmenu.xml:93
 msgid "For more on logging out and shutting down, see <xref linkend=\"shutdown\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/goseditmainmenu.xml:93
+#. (itstool) path: info/title
+#: C/goseditmainmenu.xml:97
 msgid "Customizing the Panel Menubar"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/goseditmainmenu.xml:96
+#: C/goseditmainmenu.xml:100
 msgid "<primary>menus</primary> <secondary>customizing</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:101
+#: C/goseditmainmenu.xml:105
 msgid "You can modify the contents of the following menus:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:104
+#: C/goseditmainmenu.xml:108
 msgid "<guimenu>Applications</guimenu> menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:107
+#: C/goseditmainmenu.xml:111
 msgid "<menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisubmenu></menuchoice> submenu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goseditmainmenu.xml:110
+#: C/goseditmainmenu.xml:114
 msgid "<menuchoice><guimenu>System</guimenu><guisubmenu>Administration</guisubmenu></menuchoice> submenu"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:114
+#: C/goseditmainmenu.xml:118
 msgid "To edit the items in these menus, right-click on the panel menubar, and choose <guimenuitem>Edit Menus</guimenuitem>. The <guilabel>Menu Layout</guilabel> window opens."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:115
+#: C/goseditmainmenu.xml:119
 msgid "The <guilabel>Menu Layout</guilabel> window lists the menus in the left pane. Click on the expand arrows to show or hide submenus. Choose a menu in the left pane to see its items listed in the right pane."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/goseditmainmenu.xml:116
+#: C/goseditmainmenu.xml:120
 msgid "To remove an item from a menu, deselect it in the list. The item can be added back to the menu by selecting it once again."
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/goscaja.xml:2
+#. (itstool) path: info/title
+#: C/goscaja.xml:7
 msgid "Working with Files"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/goscaja.xml:37
+#: C/goscaja.xml:42
 msgid "This chapter describes how to use the <application>Caja</application> file manager."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#. (itstool) path: section/title
-#: C/goscaja.xml:41
-#: C/gosoverview.xml:30
-#: C/gospanel.xml:15
+#. (itstool) path: info/title
+#: C/goscaja.xml:45
+#: C/gosoverview.xml:31
+#: C/gospanel.xml:19
 #: C/gostools.xml:265
-#: C/gosdconf.xml:15
+#: C/gosdconf.xml:19
 msgid "Introduction"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:42
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:46
 msgid "<primary>file manager</primary> <secondary>introduction</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:47
+#. (itstool) path: info/title
+#: C/goscaja.xml:51
 msgid "File Manager Functionality"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:48
+#. (itstool) path: section/para
+#: C/goscaja.xml:52
 msgid "The <application>Caja</application> file manager provides a simple and integrated way to manage your files and applications. You can use the file manager to do the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:52
+#: C/goscaja.xml:56
 msgid "Create folders and documents"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:53
+#: C/goscaja.xml:57
 msgid "Display your files and folders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:54
+#: C/goscaja.xml:58
 msgid "Search and manage your files"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:55
+#: C/goscaja.xml:59
 msgid "Run scripts and launch applications"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:56
+#: C/goscaja.xml:60
 msgid "Customize the appearance of files and folders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:57
+#: C/goscaja.xml:61
 msgid "Open special locations on your computer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:58
+#: C/goscaja.xml:62
 msgid "Write data to a CD or DVD"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:59
+#: C/goscaja.xml:63
 msgid "Install and remove fonts"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:61
+#. (itstool) path: section/para
+#: C/goscaja.xml:65
 msgid "The file manager lets you organize your files into folders. Folders can contain files and may also contain other folders. Using folders can help you find your files more easily."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:62
+#. (itstool) path: section/para
+#: C/goscaja.xml:66
 msgid "<application>Caja</application> also manages the desktop. The desktop lies behind all other visible items on your screen. The desktop is an active component of the way you use your computer."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:65
+#. (itstool) path: section/para
+#: C/goscaja.xml:69
 msgid "Every user has a Home Folder. The Home Folder contains all user's files. The desktop is another folder. The desktop contains special icons allowing easy access to the users Home Folder, Trash, and also removable media such as floppy disks, CDs and USB flash drives."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:66
+#. (itstool) path: section/para
+#: C/goscaja.xml:70
 msgid "<application>Caja</application> is always running while you are using MATE. To open a new <application>Caja</application> window, double-click on an appropriate icon on the desktop such as <guimenuitem>Home</guimenuitem> or <guimenuitem>Computer</guimenuitem>, or choose an item from <link linkend=\"places-menu\"><guimenuitem>Places</guimenuitem> menu</link> on the top panel."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:67
+#. (itstool) path: section/para
+#: C/goscaja.xml:71
 msgid "In MATE many things are files, such as word processor documents, spreadsheets, photos, movies, and music."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:71
+#. (itstool) path: info/title
+#: C/goscaja.xml:74
 msgid "File Manager Presentation"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:72
+#. (itstool) path: section/para
+#: C/goscaja.xml:76
 msgid "<application>Caja</application> provides two modes in which you can interact with your filesystem: spatial and browser mode. You may decide which method you prefer and set <application>Caja</application> to always use this by selecting (or deselecting) <guilabel>Always open in browser windows</guilabel> in the <guilabel>Behavior</guilabel> tab of the <xref linkend=\"caja-preferences\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:73
+#. (itstool) path: section/para
+#: C/goscaja.xml:77
 msgid "Browser mode is the default in MATE, but your distributor, vendor, or system administrator may have configured <application>Caja</application> to use spatial mode by default."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:75
+#. (itstool) path: info/title
+#: C/goscaja.xml:78
 msgid "Dconf-Editor showing the value of always-use-browser key for gsettings org.mate.caja.preferences schema"
 msgstr ""
 
@@ -5005,43 +4977,43 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:79
+#: C/goscaja.xml:82
 msgctxt "_"
 msgid "external ref='figures/caja_always_use_browser.png' md5='19e041314b3a9c8844180f7bf0ef6282'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:77
+#: C/goscaja.xml:80
 msgid "<imageobject> <imagedata fileref=\"figures/caja_always_use_browser.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Dconf-Editor showing the value of always-use-browser key for gsettings org.mate.caja.preferences schema.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:87
+#. (itstool) path: section/para
+#: C/goscaja.xml:90
 msgid "The following explains the difference between the two modes:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:90
+#: C/goscaja.xml:93
 msgid "Browser mode: browse your files and folders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:92
+#: C/goscaja.xml:95
 msgid "The file manager window represents a browser, which can display any location. Opening a folder updates the current file manager window to show the contents of the new folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:93
+#: C/goscaja.xml:96
 msgid "As well as the folder contents, the browser window displays a toolbar with common actions and locations, a location bar that shows the current location in the hierarchy of folders, and a sidebar that can hold different kinds of information."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:94
+#: C/goscaja.xml:97
 msgid "In Browser Mode, you typically have fewer file manager windows open at a time. For more information on using browser mode see <xref linkend=\"caja-browser-mode\"/>."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:96
+#. (itstool) path: info/title
+#: C/goscaja.xml:98
 msgid "<application>Caja</application> in browser mode"
 msgstr ""
 
@@ -5050,34 +5022,34 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:100
-#: C/goscaja.xml:373
+#: C/goscaja.xml:102
+#: C/goscaja.xml:370
 msgctxt "_"
 msgid "external ref='figures/caja_browser_mode.png' md5='44b92e32cdc342cd5624b1be5626386d'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:98
+#: C/goscaja.xml:100
 msgid "<imageobject> <imagedata fileref=\"figures/caja_browser_mode.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Caja in browser mode.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:111
+#: C/goscaja.xml:113
 msgid "Spatial mode: navigate your files and folders as objects"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:113
+#: C/goscaja.xml:115
 msgid "The file manager window represents a particular folder. Opening a folder opens the new window for that folder. Each time you open a particular folder, you will find its window displayed in the same place on the screen and the same size as the last time you viewed it (this is the reason for the name 'spatial mode')."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:114
+#: C/goscaja.xml:116
 msgid "Using spatial mode may lead to more open file manager windows on the screen. On the other hand, some users find that representing files and folders as though they were real physical objects with particular locations makes it easier to work with them. For more information on using spatial mode see <xref linkend=\"caja-spatial-mode\"/>"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:117
+#. (itstool) path: info/title
+#: C/goscaja.xml:118
 #: C/goscaja.xml:179
 msgid "Three Folders Opened in Spatial Mode"
 msgstr ""
@@ -5087,91 +5059,91 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:121
+#: C/goscaja.xml:122
 #: C/goscaja.xml:183
 msgctxt "_"
 msgid "external ref='figures/caja_spatial_mode.png' md5='f2f8e037d14274ac04e1df45664f2103'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:119
+#: C/goscaja.xml:120
 #: C/goscaja.xml:181
 msgid "<imageobject> <imagedata fileref=\"figures/caja_spatial_mode.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Three Folders Opened in Spatial Mode.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:130
+#: C/goscaja.xml:131
 msgid "Notice how, when in spatial mode, <application>Caja</application> indicates an open folder with a different icon."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:139
+#. (itstool) path: info/title
+#: C/goscaja.xml:140
 msgid "Spatial Mode"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:141
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:143
 msgid "<primary>file manager</primary> <secondary>navigating</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:145
+#. (itstool) path: section/para
+#: C/goscaja.xml:147
 msgid "The following section describes how to browse your system using the <application>Caja</application> file manager when configured in spatial mode. In spatial mode, each <application>Caja</application> window corresponds to a single folder. When you open a folder its window appears at the same place on the screen as the last time you looked at it. This is the default behavior in <application>Caja</application>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:146
-#: C/goscaja.xml:359
+#. (itstool) path: section/para
+#: C/goscaja.xml:148
+#: C/goscaja.xml:357
 msgid "For a comparison of browser mode and spatial mode, see <xref linkend=\"caja-presentation\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:148
+#. (itstool) path: info/title
+#: C/goscaja.xml:150
 msgid "Spatial Windows"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:149
+#. (itstool) path: section/para
+#: C/goscaja.xml:151
 msgid "A new spatial window opens each time you open a folder. To open a folder, do one of the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:152
+#: C/goscaja.xml:154
 msgid "Double-click the folder's icon on the desktop or an existing window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:153
+#: C/goscaja.xml:155
 msgid "Select the folder, and press <keycombo><keycap>Ctrl</keycap><keycap>O</keycap></keycombo>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:154
+#: C/goscaja.xml:156
 msgid "Select the folder, and press <keycombo><keycap>Alt</keycap><keycap>down arrow</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:155
+#: C/goscaja.xml:157
 msgid "Choose an item from the <link linkend=\"places-menu\"><guimenuitem>Places</guimenuitem> menu</link> on the top panel. Your Home Folder and folders you have bookmarked are listed here. For more on bookmarks, see <xref linkend=\"caja-bookmarks\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:158
+#. (itstool) path: section/para
+#: C/goscaja.xml:160
 msgid "To close the current folder while opening the new one, hold down <keycap>Shift</keycap> when double-clicking, or press <keycombo><keycap>Shift</keycap><keycap>Alt</keycap><keycap>down arrow</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:160
+#. (itstool) path: section/para
+#: C/goscaja.xml:162
 msgid "<xref linkend=\"goscaja-FIG-504\"/> shows a spatial mode window that displays the contents of the Computer folder."
 msgstr ""
 
 #. (itstool) path: title/indexterm
-#: C/goscaja.xml:163
+#: C/goscaja.xml:164
 msgid "<primary>file manager</primary><secondary>icon view</secondary><tertiary>illustration</tertiary>"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:163
+#. (itstool) path: info/title
+#: C/goscaja.xml:164
 msgid "Contents of a folder in a spatial mode.<_:indexterm-1/>"
 msgstr ""
 
@@ -5180,23 +5152,23 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:168
+#: C/goscaja.xml:169
 msgctxt "_"
 msgid "external ref='figures/caja_spatial_view.png' md5='08673c38f4b4327f94f298c73b0d270b'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:166
+#: C/goscaja.xml:167
 msgid "<imageobject> <imagedata fileref=\"figures/caja_spatial_view.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Displaying a folder in spatial mode.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:176
+#. (itstool) path: section/para
+#: C/goscaja.xml:177
 msgid "In spatial mode each open <application>Caja</application> windows shows only one location. Selecting a second location will open a second <application>Caja</application> window. Because each location remembers the previous position on screen in which it was opened it allows you to easily recognize folders when many of them are open at once."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:177
+#. (itstool) path: section/para
+#: C/goscaja.xml:178
 msgid "Some people consider spatial mode better, particularly for moving files or folders to different location, others find the number of open windows daunting. <xref linkend=\"goscaja-FIG-naut-spatial-many-open\"/> shows an example of spatial browsing with many open locations."
 msgstr ""
 
@@ -5205,521 +5177,529 @@ msgstr ""
 msgid "Because spatial mode will fill your screen with <application>Caja</application> windows, it is important to be able to reposition them effectively. By holding the <keycap>Alt</keycap> key and clicking anywhere within the bounds of a <application>Caja</application> window you may reposition it simply, instead of requiring that you reposition it by dragging its title bar."
 msgstr ""
 
-#. (itstool) path: sect2/title
+#. (itstool) path: info/title
 #: C/goscaja.xml:196
 msgid "Spatial Window Components"
 msgstr ""
 
-#. (itstool) path: sect2/para
+#. (itstool) path: section/para
 #: C/goscaja.xml:197
 msgid "<xref linkend=\"goscaja-TBL-85\"/> describes the components of file object windows."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscaja.xml:200
+#. (itstool) path: info/title
+#: C/goscaja.xml:199
 msgid "The Spatial Window Components"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:207
-#: C/goscaja.xml:396
+#: C/goscaja.xml:206
+#: C/goscaja.xml:392
 msgid "Component"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:217
-#: C/goscaja.xml:406
+#. (itstool) path: term/interface
+#: C/goscaja.xml:216
+#: C/goscaja.xml:402
+#: C/gostools.xml:320
 msgid "Menubar"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:220
-#: C/goscaja.xml:409
+#: C/goscaja.xml:219
+#: C/goscaja.xml:405
 msgid "Contains menus that you use to perform tasks in the file manager."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:221
-#: C/goscaja.xml:410
+#: C/goscaja.xml:220
+#: C/goscaja.xml:406
 msgid "You can also open a popup menu from file manager windows. To open this popup menu right-click in a file manager window. The items in this menu depend on where you right-click. For example, when you right-click on a file or folder, you can choose items related to the file or folder. When you right-click on the background of a view pane, you can choose items related to the display of items in the view pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:232
-#: C/goscaja.xml:533
+#: C/goscaja.xml:231
+#: C/goscaja.xml:529
 msgid "View pane"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:235
-#: C/goscaja.xml:536
+#: C/goscaja.xml:234
+#: C/goscaja.xml:532
 msgid "Shows the contents of the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:238
-#: C/goscaja.xml:539
-#: C/goscaja.xml:2485
+#: C/goscaja.xml:237
+#: C/goscaja.xml:535
+#: C/goscaja.xml:2450
 msgid "Folders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:241
-#: C/goscaja.xml:542
+#: C/goscaja.xml:240
+#: C/goscaja.xml:538
 msgid "FTP sites"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:244
-#: C/goscaja.xml:545
+#: C/goscaja.xml:243
+#: C/goscaja.xml:541
 msgid "Windows shares"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:247
-#: C/goscaja.xml:548
+#: C/goscaja.xml:246
+#: C/goscaja.xml:544
 msgid "WebDAV servers"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:250
-#: C/goscaja.xml:551
+#: C/goscaja.xml:249
+#: C/goscaja.xml:547
 msgid "Locations that correspond to special URIs"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:257
-#: C/goscaja.xml:558
+#: C/goscaja.xml:256
+#: C/goscaja.xml:554
 msgid "Statusbar"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:260
-#: C/goscaja.xml:561
+#: C/goscaja.xml:259
+#: C/goscaja.xml:557
 msgid "Displays status information."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:265
+#: C/goscaja.xml:264
 msgid "Parent folder selector"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:268
+#: C/goscaja.xml:267
 msgid "This drop-down list shows the hierarchy of the folder. Choose a folder from the list to open it."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/goscaja.xml:269
+#: C/goscaja.xml:268
 msgid "Hold down <keycap>Shift</keycap> while choosing from the list to close the current folder as you open the new one."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:277
+#. (itstool) path: info/title
+#: C/goscaja.xml:276
 msgid "Displaying Your Home Folder in a Spatial Window"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:278
-#: C/goscaja.xml:670
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:277
+#: C/goscaja.xml:663
 msgid "<primary>file manager</primary> <secondary>Home location</secondary> <see>Home location</see>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:283
-#: C/goscaja.xml:675
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:282
+#: C/goscaja.xml:668
 msgid "<primary>Home location</primary> <secondary>displaying</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:287
+#. (itstool) path: section/para
+#: C/goscaja.xml:286
 msgid "To display your Home Folder, perform one of the following actions:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:291
+#: C/goscaja.xml:290
 msgid "Double-click on the <guilabel>Home</guilabel> object on the desktop."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:295
+#: C/goscaja.xml:294
 msgid "From a folder window's menubar, choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Home Folder</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:297
+#: C/goscaja.xml:296
 msgid "From the top panel menubar, choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Home Folder</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:299
+#. (itstool) path: section/para
+#: C/goscaja.xml:298
 msgid "The spatial window displays the contents of your Home Folder."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:302
-#: C/goscaja.xml:726
+#. (itstool) path: info/title
+#: C/goscaja.xml:301
+#: C/goscaja.xml:719
 msgid "Displaying a Parent Folder"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:303
+#. (itstool) path: section/para
+#: C/goscaja.xml:302
 msgid "A parent folder is the folder that contains the current folder. To display the contents of your current folder's parent, do one of the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:306
+#: C/goscaja.xml:305
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Open Parent</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:309
+#: C/goscaja.xml:308
 msgid "Press <keycombo><keycap>Alt</keycap><keycap>up arrow</keycap></keycombo>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:311
+#: C/goscaja.xml:310
 msgid "Choose from the parent folder selector at the bottom left of the window."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:313
+#. (itstool) path: section/para
+#: C/goscaja.xml:312
 msgid "To close the current folder while opening the parent, hold down <keycap>Shift</keycap> while choosing from the parent folder selector, or press <keycombo><keycap>Shift</keycap><keycap>Alt</keycap><keycap>up arrow</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:316
+#. (itstool) path: info/title
+#: C/goscaja.xml:315
 msgid "Closing Folders"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:317
+#. (itstool) path: section/para
+#: C/goscaja.xml:316
 msgid "To close folders you may simply click on the close window button, this however may not be the most efficient way to close many windows. If you would like to view only the current folder, and not the folders you opened to reach the current folder, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Close Parent Folders</guimenuitem></menuchoice>. If want to close all folders on the screen, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Close All Folders</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:322
+#. (itstool) path: info/title
+#: C/goscaja.xml:321
 msgid "Displaying a Folder in a Browser Window"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:323
+#. (itstool) path: section/para
+#: C/goscaja.xml:322
 msgid "If you wish to display a single folder in browser mode, while otherwise continuing to work in spatial mode, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:326
+#: C/goscaja.xml:325
 msgid "Select a folder while in spatial mode."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:329
+#: C/goscaja.xml:328
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Browse Folder</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:334
+#. (itstool) path: info/title
+#: C/goscaja.xml:333
 msgid "Opening a Location"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:335
+#. (itstool) path: section/para
+#: C/goscaja.xml:334
 msgid "You can open a folder or other location in spatial mode by typing its name."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:336
+#. (itstool) path: section/para
+#: C/goscaja.xml:335
 msgid "Choose <menuchoice> <shortcut> <keycombo><keysym>L</keysym></keycombo> </shortcut> <guimenu>File</guimenu> <guimenuitem>Open Location</guimenuitem> </menuchoice>, and type the path or URI of the location you wish to open."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:350
+#. (itstool) path: info/title
+#: C/goscaja.xml:347
 msgid "Browser Mode"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:354
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:352
 msgid "<primary>file manager</primary> <secondary>windows</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:358
+#. (itstool) path: section/para
+#: C/goscaja.xml:356
 msgid "The following section describes how to browse your system using the <application>Caja</application> file manager when configured in browser mode. In browser mode, opening a folder updates the current file manager to show the contents of the new folder."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:361
+#. (itstool) path: info/title
+#: C/goscaja.xml:359
 msgid "The File Browser Window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:364
+#: C/goscaja.xml:362
 msgid "Choose <menuchoice><guimenu>Applications</guimenu><guimenuitem>System Tools</guimenuitem><guimenuitem>File Browser</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:365
+#: C/goscaja.xml:363
 msgid "While in spatial mode you may open a folder in browser mode by right clicking on that folder and choosing <guimenuitem>Browse Folder</guimenuitem>. A new file browser window will then open and display the contents of the selected folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:366
+#: C/goscaja.xml:364
 msgid "If <application>Caja</application> is set to always open browser windows, double clicking any folder will open a browser window, see <xref linkend=\"goscaja-56\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:362
+#. (itstool) path: section/para
+#: C/goscaja.xml:360
 msgid "You can access the file browser in the following ways: <_:itemizedlist-1/>"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:369
+#. (itstool) path: info/title
+#: C/goscaja.xml:366
 msgid "Contents of a Folder in a File Browser Window"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:371
+#: C/goscaja.xml:368
 msgid "<imageobject> <imagedata fileref=\"figures/caja_browser_mode.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase> A folder in a file browser window.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:382
+#: C/goscaja.xml:379
 msgid "In some distributions of the MATE Desktop, the <guibutton>Home</guibutton> toolbar button might have another designation, for example, <guibutton>Documents</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:385
+#. (itstool) path: info/title
+#: C/goscaja.xml:382
 msgid "The File Browser Window Components"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:386
+#. (itstool) path: section/para
+#: C/goscaja.xml:383
 msgid "<xref linkend=\"goscaja-TBL-83\"/> describes the components of a file browser window."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscaja.xml:389
+#. (itstool) path: info/title
+#: C/goscaja.xml:385
 msgid "File Browser Window Components"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:420
+#. (itstool) path: term/interface
+#. (itstool) path: para/interface
+#: C/goscaja.xml:416
+#: C/gostools.xml:379
+#: C/gostools.xml:637
+#: C/gostools.xml:661
+#: C/gostools.xml:685
 msgid "Toolbar"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:423
+#: C/goscaja.xml:419
 msgid "Contains buttons that you use to perform tasks in the file manager."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:426
+#: C/goscaja.xml:422
 msgid "<guibutton>Back</guibutton> Returns to the previously visited location. The adjacent drop down list also contains a list of the most recently visited locations to allow you to return to them faster."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:429
+#: C/goscaja.xml:425
 msgid "<guimenu>Forward</guimenu> Performs the opposite function to the <guibutton>Back</guibutton> toolbar item. If you have previously navigated back in time, then this button returns you to the present."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:432
+#: C/goscaja.xml:428
 msgid "<guibutton>Up</guibutton> Moves up one level to the parent of the current folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:435
+#: C/goscaja.xml:431
 msgid "<guibutton>Reload</guibutton> Refreshes the contents of the current folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:438
+#: C/goscaja.xml:434
 msgid "<guibutton>Home</guibutton> Opens your Home Folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:441
+#: C/goscaja.xml:437
 msgid "<guibutton>Computer</guibutton> Opens your Computer folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:444
+#: C/goscaja.xml:440
 msgid "<guibutton>Search</guibutton> Opens the search bar."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:451
+#: C/goscaja.xml:447
 msgid "Location bar"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:454
+#: C/goscaja.xml:450
 msgid "The location bar is a very powerful tool for navigating your computer. It can appear in three different ways depending on your selection. For more on using the location bar see <xref linkend=\"caja-location-bar\"/>. In all three configurations the location bar always contains the following items."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:457
+#: C/goscaja.xml:453
 msgid "<guimenu>Zoom</guimenu> buttons: Enable you to change the size of items in the view pane."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:461
+#: C/goscaja.xml:457
 msgid "<guilabel>View as</guilabel> drop-down list: Enables you to choose how to show items in your view pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:470
+#: C/goscaja.xml:466
 msgid "Side pane"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:473
+#: C/goscaja.xml:469
 msgid "Performs the following functions:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:476
+#: C/goscaja.xml:472
 msgid "Shows information about the current file or folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:479
+#: C/goscaja.xml:475
 msgid "Enables you to navigate through your files."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:482
+#: C/goscaja.xml:478
 msgid "To display the side pane, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice>. The side pane contains a drop-down list that enables you to choose what to show in the side pane. You can choose from the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:487
+#: C/goscaja.xml:483
 msgid "<guilabel>Places</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:490
+#: C/goscaja.xml:486
 msgid "Displays places of particular interest."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:493
+#: C/goscaja.xml:489
 msgid "<guilabel>Information</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:496
+#: C/goscaja.xml:492
 msgid "Displays the icon and information about the current folder. Buttons may appear in the side pane, these buttons enable you to perform actions on the current folder, other than the default action."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:500
+#: C/goscaja.xml:496
 msgid "<guilabel>Tree</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:503
+#: C/goscaja.xml:499
 msgid "Displays a hierarchical representation of your file system. You can use the <guilabel>Tree</guilabel> to navigate through your files."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:507
+#: C/goscaja.xml:503
 msgid "<guilabel>History</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:510
+#: C/goscaja.xml:506
 msgid "Contains a history list of files, folders, FTP sites, and URIs that you have recently visited."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:514
+#: C/goscaja.xml:510
 msgid "<guilabel>Notes</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:517
+#: C/goscaja.xml:513
 msgid "Enables you to add notes to your files and folders."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:520
+#: C/goscaja.xml:516
 msgid "<guilabel>Emblems</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:523
+#: C/goscaja.xml:519
 msgid "Contains emblems that you can add to a file or folder."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:526
+#: C/goscaja.xml:522
 msgid "To close the side pane, click on the <guibutton>X</guibutton> button at the top right of the side pane."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:570
+#. (itstool) path: info/title
+#: C/goscaja.xml:566
 msgid "Showing and Hiding File Browser Window Components"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:571
-#: C/goscaja.xml:598
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:567
+#: C/goscaja.xml:594
 msgid "<primary>file manager</primary> <secondary>window components, showing and hiding</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:576
+#. (itstool) path: section/para
+#: C/goscaja.xml:572
 msgid "To show or hide any of the components of the file browser described in <xref linkend=\"goscaja-TBL-83\"/> select any of the following items from the menu:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:579
+#: C/goscaja.xml:575
 msgid "To hide the side pane, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice>. To display the side pane again, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice> again. Alternatively you may press <keycap>F9</keycap> to toggle the visibility of the side pane."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:583
+#: C/goscaja.xml:579
 msgid "To hide the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Main Toolbar</guimenuitem></menuchoice>. To display the toolbar again, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Main Toolbar</guimenuitem></menuchoice> again."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:587
+#: C/goscaja.xml:583
 msgid "To hide the location bar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Location Bar</guimenuitem></menuchoice>. To display the location bar again, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Location Bar</guimenuitem></menuchoice> again."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:591
+#: C/goscaja.xml:587
 msgid "To hide the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice>. To display the statusbar again, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice> again."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:597
+#. (itstool) path: info/title
+#: C/goscaja.xml:593
 msgid "Using the Location Bar"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:603
+#. (itstool) path: section/para
+#: C/goscaja.xml:599
 msgid "The file browser's location bar can show either a location field, a button bar, or a search field. Each is useful in different situations."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:608
+#: C/goscaja.xml:604
 msgid "<guilabel>Button bar</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:609
+#: C/goscaja.xml:605
 msgid "By default the button bar is shown. This shows a row of buttons representing the current location's hierarchy, with a button for each containing folder. Click on the button to jump between folders in the hierarchy. You can return to the original folder, which is shown as the last button in the row."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:610
+#: C/goscaja.xml:606
 msgid "You can also drag buttons, for example to another location, in order to copy a folder."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:612
+#. (itstool) path: info/title
+#: C/goscaja.xml:607
 msgid "The button bar"
 msgstr ""
 
@@ -5728,43 +5708,43 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:616
+#: C/goscaja.xml:611
 msgctxt "_"
 msgid "external ref='figures/caja_button_bar.png' md5='447c19259a84de017f4431ea205bed03'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:614
+#: C/goscaja.xml:609
 msgid "<imageobject> <imagedata fileref=\"figures/caja_button_bar.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>The button bar.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:626
+#: C/goscaja.xml:621
 msgid "<guilabel>Text Location Bar</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:627
+#: C/goscaja.xml:622
 msgid "The text location bar shows the current location as a text path, for example: '/home/user/Documents'. The location field is particularly useful for jumping to a known folder very quickly."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:628
+#: C/goscaja.xml:623
 msgid "To go to a new location, type a new path or edit the current one, then press <keycap>Enter</keycap>. The path field automatically completes what you are typing when there is only one possibility. To accept the suggested completion, press <keycap>Tab</keycap>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:629
+#: C/goscaja.xml:624
 msgid "To always use the text location bar, click on the toggle button at the left of the location bar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:630
+#: C/goscaja.xml:625
 msgid "To quickly switch to the text location bar while using the button bar, press <keycombo><keycap>Ctrl</keycap><keycap>L</keycap></keycombo>, choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Location</guimenuitem></menuchoice>, or press <keycap>Leading Slash (/)</keycap> to type a path from the root directory. The location bar shows the location buttons again after you press <keycap>Enter</keycap> or cancel with <keycap>Escape</keycap>."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:632
+#. (itstool) path: info/title
+#: C/goscaja.xml:626
 msgid "The location bar"
 msgstr ""
 
@@ -5773,29 +5753,29 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:636
+#: C/goscaja.xml:630
 msgctxt "_"
 msgid "external ref='figures/caja_go_to_location.png' md5='f5731ef77db819a54be69cab8806529a'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:634
+#: C/goscaja.xml:628
 msgid "<imageobject> <imagedata fileref=\"figures/caja_go_to_location.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>The location bar.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:646
+#: C/goscaja.xml:640
 msgid "<guilabel>Search bar</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:647
+#: C/goscaja.xml:641
 msgid "By pressing <keycombo><keycap>Ctrl</keycap><keycap>F</keycap></keycombo> or selecting the <guibutton>Search</guibutton> toolbar button the search bar appears. For more information on searching see <xref linkend=\"caja-searching\"/>. The search bar is excellent for locating files of folders when you are not sure of their exact location."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:649
-#: C/goscaja.xml:989
+#. (itstool) path: info/title
+#: C/goscaja.xml:642
+#: C/goscaja.xml:980
 msgid "The search bar"
 msgstr ""
 
@@ -5804,459 +5784,459 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:653
-#: C/goscaja.xml:993
+#: C/goscaja.xml:646
+#: C/goscaja.xml:984
 msgctxt "_"
 msgid "external ref='figures/caja_search_bar.png' md5='60a9a159dee2d7ad5c035ed794845798'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:651
-#: C/goscaja.xml:991
+#: C/goscaja.xml:644
+#: C/goscaja.xml:982
 msgid "<imageobject> <imagedata fileref=\"figures/caja_search_bar.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>The search bar.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:665
+#. (itstool) path: info/title
+#: C/goscaja.xml:658
 msgid "Displaying Your Home Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:666
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:659
 msgid "<primary>file manager</primary> <secondary>Home folder</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:679
+#. (itstool) path: section/para
+#: C/goscaja.xml:672
 msgid "To quickly display your Home Folder, perform one of the following actions from a file browser window:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:683
+#: C/goscaja.xml:676
 msgid "Choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Home</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:686
+#: C/goscaja.xml:679
 msgid "Click on the <guibutton>Home</guibutton> toolbar button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:689
+#: C/goscaja.xml:682
 msgid "Click on the <guibutton>Home</guibutton> button in the Places side pane."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:692
+#. (itstool) path: section/para
+#: C/goscaja.xml:685
 msgid "The file browser window displays the contents of your Home Folder."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:695
+#. (itstool) path: info/title
+#: C/goscaja.xml:688
 msgid "Displaying a Folder"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:696
+#. (itstool) path: section/para
+#: C/goscaja.xml:689
 msgid "The contents of a folder can be displayed in either list or icon view by selecting the appropriate item in the location bar <guilabel>View as</guilabel> menu. For more information on the list and icon view see <xref linkend=\"goscaja-7\"/>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:699
+#: C/goscaja.xml:692
 msgid "Double-click on the folder in the view pane."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:702
+#: C/goscaja.xml:695
 msgid "Use the <guilabel>Tree</guilabel> in the side pane. For more information, see <xref linkend=\"goscaja-27\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:706
+#: C/goscaja.xml:699
 msgid "Click on the <guilabel>Location</guilabel> buttons in the location bar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:710
+#: C/goscaja.xml:703
 msgid "Press <keycombo><keycap>Ctrl</keycap><keycap>L</keycap></keycombo> to show the text <guilabel>Location</guilabel> field, type the path of the folder that you want to display, then press <keycap>Return</keycap>. The <guilabel>Location</guilabel> field includes an autocomplete feature. As you type a path, the file manager reads your file system. When you type enough characters to uniquely identify a directory, the file manager completes the name of the directory in the <guilabel>Location</guilabel> field."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:718
+#: C/goscaja.xml:711
 msgid "Use the <guibutton>Back</guibutton> toolbar button and the <guibutton>Forward</guibutton> toolbar button to browse through your navigation history."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:721
+#. (itstool) path: section/para
+#: C/goscaja.xml:714
 msgid "To change to the folder that is one level above the current folder, choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Up</guimenuitem></menuchoice>. Alternatively, click on the <guibutton>Up</guibutton> toolbar button."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:727
+#. (itstool) path: section/para
+#: C/goscaja.xml:720
 msgid "The parent folder of the current folder which you are browsing is the one which exists, in a hierarchical representation, one level above the current. To display the contents of parent folder, perform one of the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:731
+#: C/goscaja.xml:724
 msgid "Press the <guibutton>Up</guibutton> button on the toolbar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:734
+#: C/goscaja.xml:727
 msgid "Choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Open Parent</guimenuitem></menuchoice> from the menubar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:737
+#: C/goscaja.xml:730
 msgid "Press the <keycap>Backspace</keycap> key."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:742
+#. (itstool) path: info/title
+#: C/goscaja.xml:735
 msgid "Using the Tree From the Side Pane"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:743
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:736
 msgid "<primary>file manager</primary> <secondary>Tree, using </secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:747
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:740
 msgid "<primary>Tree, using</primary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:750
+#. (itstool) path: section/para
+#: C/goscaja.xml:743
 msgid "The <guilabel>Tree</guilabel> view is one of the most useful features of the side pane. It displays a hierarchical representation of your file system and provides a convenient way to browse and to navigate your file system. To display the <guilabel>Tree</guilabel> in the side pane, choose <guimenuitem>Tree</guimenuitem> from the drop-down list at the top of the side pane."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:752
+#. (itstool) path: section/para
+#: C/goscaja.xml:745
 msgid "In the <guilabel>Tree</guilabel>view, open folders are represented as downwards facing arrows."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:754
+#. (itstool) path: section/para
+#: C/goscaja.xml:747
 msgid "<xref linkend=\"goscaja-TBL-34\"/> describes tasks you can perform with the <guilabel>Tree</guilabel>, and how to do so."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscaja.xml:757
+#. (itstool) path: info/title
+#: C/goscaja.xml:749
 msgid "Tree Tasks"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:764
-#: C/goscaja.xml:1500
-#: C/goscaja.xml:1625
+#: C/goscaja.xml:756
+#: C/goscaja.xml:1480
+#: C/goscaja.xml:1601
 msgid "Task"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:774
+#: C/goscaja.xml:766
 msgid "Open the <guilabel>Tree</guilabel>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:777
+#: C/goscaja.xml:769
 msgid "Choose <guilabel>Tree</guilabel> from the drop-down list at the top of the side pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:783
+#: C/goscaja.xml:775
 msgid "Close the <guilabel>Tree</guilabel>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:786
+#: C/goscaja.xml:778
 msgid "Choose another item from the drop-down list at the top of the side pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:792
+#: C/goscaja.xml:784
 msgid "Expand a folder in the <guilabel>Tree</guilabel>."
 msgstr ""
 
 #. (itstool) path: entry/para
+#: C/goscaja.xml:787
 #: C/goscaja.xml:795
-#: C/goscaja.xml:803
 msgid "Click on the arrow next to the folder in the <guilabel>Tree</guilabel>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:800
+#: C/goscaja.xml:792
 msgid "Collapse a folder in the <guilabel> Tree</guilabel>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:808
+#: C/goscaja.xml:800
 msgid "Display the contents of a folder in the view pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:812
+#: C/goscaja.xml:804
 msgid "Select the folder in the <guilabel>Tree</guilabel>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:817
+#: C/goscaja.xml:809
 msgid "Open a file."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:820
+#: C/goscaja.xml:812
 msgid "Select the file in the <guilabel>Tree</guilabel>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:826
+#. (itstool) path: section/para
+#: C/goscaja.xml:818
 msgid "You can set your preferences so that the <guilabel>Tree</guilabel> does not display files. For more information, see <xref linkend=\"goscaja-438\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:830
+#. (itstool) path: info/title
+#: C/goscaja.xml:822
 msgid "Using Your Navigation History"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:831
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:823
 msgid "<primary>file manager</primary> <secondary>navigating history list</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:835
+#. (itstool) path: section/para
+#: C/goscaja.xml:827
 msgid "The file browser window maintains a history list of files, folders, FTP sites, and URI locations you have recently visited. You can use the history list to navigate to quickly return to these places. Your history list contains the last ten items that you viewed."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:839
+#. (itstool) path: section/para
+#: C/goscaja.xml:831
 msgid "To clear your history list choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Clear History</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:841
+#. (itstool) path: info/title
+#: C/goscaja.xml:833
 msgid "Navigating Your History List Using the Go Menu"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:842
+#. (itstool) path: section/para
+#: C/goscaja.xml:834
 msgid "To display a list of previously-viewed items, choose the <guimenu>Go</guimenu> menu. Your history list is displayed in the lower part of the <guimenu>Go</guimenu> menu. To open an item in your history list, simply click on the item."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:845
+#. (itstool) path: info/title
+#: C/goscaja.xml:837
 msgid "Navigating Your History List Using the Toolbar"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:846
+#. (itstool) path: section/para
+#: C/goscaja.xml:838
 msgid "To use the toolbar to navigate your history list, perform one of the following actions:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:850
+#: C/goscaja.xml:842
 msgid "To open the folder or URI in your history list, click on the <guibutton>Back</guibutton> toolbar button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:854
+#: C/goscaja.xml:846
 msgid "To open the folder or URI in your history list, click on the <guibutton>Forward</guibutton> toolbar button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:858
+#: C/goscaja.xml:850
 msgid "To display a list of previously-viewed items, click on the down arrow to the right of the <guibutton>Back</guibutton> toolbar button. To open an item from this list, click on the item."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:863
+#: C/goscaja.xml:855
 msgid "To display a list of items that you viewed after you viewed the current item, click on the down arrow to the right of the <guibutton>Forward</guibutton> toolbar button. To open an item from this list, click on the item."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:870
+#. (itstool) path: info/title
+#: C/goscaja.xml:862
 msgid "Navigating Your History List Using History in the Side Pane"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:871
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:863
 msgid "<primary>file manager</primary> <secondary>History</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:875
+#. (itstool) path: section/para
+#: C/goscaja.xml:867
 msgid "To display the <guilabel>History</guilabel> list in the side pane, choose <guilabel>History</guilabel> from the drop-down list at the top of the side pane. The <guilabel>History</guilabel> list in the side pane displays a list of your previously-viewed items."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:877
+#. (itstool) path: section/para
+#: C/goscaja.xml:869
 msgid "To display an item from your history list in the view pane, double-click on the item in the <guilabel>History</guilabel> list."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:886
+#. (itstool) path: info/title
+#: C/goscaja.xml:876
 msgid "Opening Files"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:889
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:880
 msgid "<primary>file manager</primary> <secondary>opening files</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:893
+#. (itstool) path: section/para
+#: C/goscaja.xml:884
 msgid "When you open a file, the file manager performs the default action for that file type."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:895
+#. (itstool) path: section/para
+#: C/goscaja.xml:886
 msgid "For example, opening a music file will play it with the default music playing application, opening a text file will allow you to read and edit it in a text editor, and opening an image file will display the image."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:896
+#. (itstool) path: section/para
+#: C/goscaja.xml:887
 msgid "The file manager checks the contents of a file to determine the type of a file. If the first lines do not determine the type of the file, then the file manager checks the <glossterm>file extension</glossterm>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:899
+#: C/goscaja.xml:890
 msgid "If you open an executable text file, that is, one that Caja considers can be run as a program, then you will be asked what you want to do: run it, or display it in a text editor. You can modify this behavior in the <link linkend=\"caja-preferences\">File Management preferences</link>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:901
+#. (itstool) path: info/title
+#: C/goscaja.xml:892
 msgid "Executing the Default Action"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:902
-#: C/goscaja.xml:1031
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:893
+#: C/goscaja.xml:1020
 msgid "<primary>file manager</primary> <secondary>executing default actions for files</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:907
+#. (itstool) path: section/para
+#: C/goscaja.xml:898
 msgid "To execute the default action for a file, double-click on the file. For example, the default action for plain text documents is to display the file in a text viewer. In this case, you can double-click on the file to display the file in a text viewer."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:911
+#. (itstool) path: section/para
+#: C/goscaja.xml:902
 msgid "You can set your file manager preferences so that you click once on a file to execute the default action. For more information, see <xref linkend=\"goscaja-56\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:915
+#. (itstool) path: info/title
+#: C/goscaja.xml:906
 msgid "Executing Non-Default Actions"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:916
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:907
 msgid "<primary>file manager</primary> <secondary>executing non-default actions for files</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:921
+#. (itstool) path: section/para
+#: C/goscaja.xml:912
 msgid "To execute actions other than the default action for a file, select the file that you want to perform an action on. In the <menuchoice><guimenu>File</guimenu></menuchoice> menu you will either have \"Open with\" choices, or an <menuchoice><guimenuitem>Open With</guimenuitem></menuchoice> submenu. Select the desired option from this list."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:927
+#. (itstool) path: info/title
+#: C/goscaja.xml:918
 msgid "Adding Actions"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:930
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:922
 msgid "<primary>file manager</primary> <secondary>adding actions</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:934
+#. (itstool) path: section/para
+#: C/goscaja.xml:926
 msgid "To add actions associated with a file type, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:938
+#: C/goscaja.xml:930
 msgid "In the view pane, select a file of the type to which you want to add an action."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:942
+#: C/goscaja.xml:934
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Open with Other Application</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:945
+#: C/goscaja.xml:937
 msgid "Either choose an application in the open with dialog or browse to the program with which you wish to open this type."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:949
+#. (itstool) path: section/para
+#: C/goscaja.xml:941
 msgid "The action you have chosen is now added to the list of actions for that particular file type. If there was no prior action associated with the type, the newly added action is the default."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:951
+#. (itstool) path: section/para
+#: C/goscaja.xml:943
 msgid "You may also add actions in the <guilabel>Open With</guilabel> tabbed section under <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:954
+#. (itstool) path: info/title
+#: C/goscaja.xml:946
 msgid "Modifying Actions"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:955
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:947
 msgid "<primary>file manager</primary> <secondary>modifying actions</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:959
+#. (itstool) path: section/para
+#: C/goscaja.xml:951
 msgid "To modify the actions associated with a file or file type, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:963
+#: C/goscaja.xml:955
 msgid "In the view pane, select a file of the type to which you want to modify the action."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:967
+#: C/goscaja.xml:959
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:970
+#: C/goscaja.xml:962
 msgid "Choose <guilabel>Open With</guilabel> tabbed section."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:973
+#: C/goscaja.xml:965
 msgid "Use <guibutton>Add</guibutton> or <guibutton>Remove</guibutton> buttons to tailor the list of actions. Select the default action with the option to the left of the list."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:982
+#. (itstool) path: info/title
+#: C/goscaja.xml:974
 msgid "Searching For Files"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:983
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:975
 msgid "<primary>file manager</primary> <secondary>searching files</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:987
+#. (itstool) path: section/para
+#: C/goscaja.xml:979
 msgid "The <application>Caja</application> file manager includes an easy and simple to use way search for your files and folders. To begin a search press <keycombo><keycap>Ctrl</keycap><keycap>F</keycap></keycombo> or select the <guibutton>Search</guibutton> toolbar button. The search bar should appear as in <xref linkend=\"goscaja-FIG-925\"/>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:1001
+#. (itstool) path: section/para
+#: C/goscaja.xml:992
 msgid "Enter characters present in the name or contents of the file or folder you wish to find and press <keycap>Enter</keycap>. The results of your search should appear in the view pane as illustrated in <xref linkend=\"goscaja-FIG-926\"/>"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:1003
+#. (itstool) path: info/title
+#: C/goscaja.xml:993
 msgid "The result of a search"
 msgstr ""
 
@@ -6265,23 +6245,23 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:1007
+#: C/goscaja.xml:997
 msgctxt "_"
 msgid "external ref='figures/caja_search_results.png' md5='cdb07b97b638c6157d40d57373fcc5d4'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1005
+#: C/goscaja.xml:995
 msgid "<imageobject> <imagedata fileref=\"figures/caja_search_results.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>The result of a search.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:1015
+#. (itstool) path: section/para
+#: C/goscaja.xml:1005
 msgid "If you are not happy with your search, you can refine it by adding addition conditions. This allows you to restrict the search to a specific file type or location. To add search conditions click the <guibutton>+</guibutton> icon. <xref linkend=\"goscaja-FIG-927\"/> shows a search which has been restricted to the users home directory and to only search for text files."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:1017
+#. (itstool) path: info/title
+#: C/goscaja.xml:1006
 msgid "Restricting a search"
 msgstr ""
 
@@ -6290,28 +6270,28 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:1021
+#: C/goscaja.xml:1010
 msgctxt "_"
 msgid "external ref='figures/caja_refine_search.png' md5='c3d58f408fd7ec2f6965a0f06e05c43e'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1019
+#: C/goscaja.xml:1008
 msgid "<imageobject> <imagedata fileref=\"figures/caja_refine_search.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Restricting a search.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1030
+#. (itstool) path: info/title
+#: C/goscaja.xml:1019
 msgid "Saving Searches"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1036
+#. (itstool) path: section/para
+#: C/goscaja.xml:1024
 msgid "Caja searches can also be saved for future use. Once saved, searches may be reopened later. <xref linkend=\"goscaja-FIG-935\"/> shows a user with three saved searches, browsing one of them."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:1038
+#. (itstool) path: info/title
+#: C/goscaja.xml:1025
 msgid "Browsing the results of a saved search"
 msgstr ""
 
@@ -6320,179 +6300,209 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:1042
+#: C/goscaja.xml:1030
 msgctxt "_"
 msgid "external ref='figures/caja_restore_saved_search.png' md5='1b7dbb7d82639abe4d9f8cc75bc2c80f'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1040
+#: C/goscaja.xml:1028
 msgid "<imageobject> <imagedata fileref=\"figures/caja_restore_saved_search.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Browsing the results of a saved search.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1050
+#. (itstool) path: section/para
+#: C/goscaja.xml:1038
 msgid "Saved searches behave exactly like regular folders, for example you can open, move or delete files from within a saved search."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:1056
+#. (itstool) path: info/title
+#: C/goscaja.xml:1043
 msgid "Managing Your Files and Folders"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:1057
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1044
 msgid "<primary>file manager</primary> <secondary>managing files and folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:1061
+#. (itstool) path: section/para
+#: C/goscaja.xml:1048
 msgid "This section describes how to work with your files and folders."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1065
+#. (itstool) path: info/title
+#: C/goscaja.xml:1051
 msgid "Directories and File Systems"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1066
+#. (itstool) path: section/para
+#: C/goscaja.xml:1052
 msgid "In Linux and other Unix-like operating systems, the filesystem is organised in a hierarchical, tree-like structure. The highest level of the filesystem is the <filename>/</filename> or <emphasis>root directory</emphasis>. These operating systems create a virtual file system, in which a filesystem object, such as a file or a directory, is represented by an inode. Each inode stores information about its parent and children, as well as its own attributes, among others, the owner, the permissions, the last change, access or modification of the filesystem object."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1068
+#. (itstool) path: section/para
+#: C/goscaja.xml:1054
 msgid "For example, <filename>/home/jebediah/cheeses.odt</filename> shows the correct full path to the <filename>cheeses.odt</filename> file that exists in the <filename>jebediah</filename> directory which is under the <filename>home</filename> directory, which in turn, is under the root (<filename>/</filename>) directory."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1070
+#. (itstool) path: section/para
+#: C/goscaja.xml:1056
 msgid "Underneath the root (<filename>/</filename>) directory, there is a set of important directories, or symbolic links to directories:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1074
+#: C/goscaja.xml:1060
 msgid "<filename>/bin</filename> - important <emphasis>bin</emphasis>ary applications"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1078
+#: C/goscaja.xml:1064
 msgid "<filename>/boot</filename> - files that are required to <emphasis>boot</emphasis> the computer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1082
+#: C/goscaja.xml:1068
 msgid "<filename>/dev</filename> - the <emphasis>dev</emphasis>ice files"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1086
+#: C/goscaja.xml:1072
 msgid "<filename>/etc</filename> - configuration files, startup scripts, <emphasis>etc</emphasis>..."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1090
+#: C/goscaja.xml:1076
 msgid "<filename>/home</filename> - local users' <emphasis>home</emphasis> directories"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1094
+#: C/goscaja.xml:1080
 msgid "<filename>/lib</filename> - system <emphasis>lib</emphasis>raries"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1098
+#: C/goscaja.xml:1084
 msgid "<filename>/lost+found</filename> - provides a <emphasis>lost+found</emphasis> system for files that exist under the root (<filename>/</filename>) directory"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1102
+#: C/goscaja.xml:1088
 msgid "<filename>/media</filename> - mounted (loaded) removable <emphasis>media</emphasis> such as CDs, digital cameras, etc..."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1106
+#: C/goscaja.xml:1092
 msgid "<filename>/mnt</filename> - <emphasis>m</emphasis>ou<emphasis>nt</emphasis>ed filesystems"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1110
+#: C/goscaja.xml:1096
 msgid "<filename>/opt</filename> - provides a location for <emphasis>opt</emphasis>ional applications to be installed"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1114
+#: C/goscaja.xml:1100
 msgid "<filename>/proc</filename> - special dynamic directory that maintains information about the state of the system, including currently running <emphasis>proc</emphasis>esses"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1118
+#: C/goscaja.xml:1104
 msgid "<filename>/root</filename> - <emphasis>root</emphasis> user home directory, pronounced 'slash-root'"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1122
+#: C/goscaja.xml:1108
 msgid "<filename>/sbin</filename> - important <emphasis>s</emphasis>ystem <emphasis>bin</emphasis>aries"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1126
+#: C/goscaja.xml:1112
 msgid "<filename>/srv</filename> - provides a location for data used by <emphasis>s</emphasis>e<emphasis>rv</emphasis>ers"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1129
+#: C/goscaja.xml:1115
 msgid "<filename>/sys</filename> - contains information about the <emphasis>sys</emphasis>tem"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1133
+#: C/goscaja.xml:1119
 msgid "<filename>/tmp</filename> - <emphasis>t</emphasis>e<emphasis>mp</emphasis>orary files"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1137
+#: C/goscaja.xml:1123
 msgid "<filename>/usr</filename> - applications and files that are mostly available for all <emphasis>us</emphasis>e<emphasis>r</emphasis>s to access"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1141
+#: C/goscaja.xml:1127
 msgid "<filename>/var</filename> - <emphasis>var</emphasis>iable files such as logs and databases"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:1145
-msgid "More detailed information on the UNIX-like filesystem hierarchy is available at Filesystem Hierarchy Standard 3.0 <ulink url=\"http://refspecs.linuxfoundation.org/fhs.shtml\">http://refspecs.linuxfoundation.org/fhs.shtml</ulink>."
+#: C/goscaja.xml:1131
+msgid "More detailed information on the UNIX-like filesystem hierarchy is available at Filesystem Hierarchy Standard 3.0 <link xlink:href=\"http://refspecs.linuxfoundation.org/fhs.shtml\">http://refspecs.linuxfoundation.org/fhs.shtml</link>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1149
+#. (itstool) path: info/title
+#: C/goscaja.xml:1134
 msgid "Using Views to Display Your Files and Folders"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1150
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1135
 msgid "<primary>viewer components</primary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1153
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1138
 msgid "<primary>file manager</primary> <secondary>views</secondary> <tertiary>introduction</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1158
+#. (itstool) path: section/para
+#: C/goscaja.xml:1143
 msgid "The file manager includes views that enable you to show the contents of your folders in different ways, icon view, and list view."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1162
+#: C/goscaja.xml:1147
 msgid "Icon view"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/goscaja.xml:1165
+#. (itstool) path: info/title
+#: C/goscaja.xml:1149
 msgid "The Home Folder displayed in an icon view"
+msgstr ""
+
+#. (itstool) path: imageobject/imagedata
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/goscaja.xml:1153
+msgctxt "_"
+msgid "external ref='figures/caja_spatial_icon_view.png' md5='c2dd3a38476c26a924c2673c6bb6de93'"
+msgstr ""
+
+#. (itstool) path: screenshot/mediaobject
+#: C/goscaja.xml:1151
+msgid "<imageobject> <imagedata fileref=\"figures/caja_spatial_icon_view.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Your Home Folder displayed in an icon view.</phrase> </textobject>"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/goscaja.xml:1148
+msgid "<xref linkend=\"goscaja-FIG-naut-icon-view\"/> Shows the items in the folder as icons. <_:figure-1/>"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/goscaja.xml:1163
+msgid "List view"
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/goscaja.xml:1165
+msgid "The Home Folder displayed in a list view"
 msgstr ""
 
 #. (itstool) path: imageobject/imagedata
@@ -6502,249 +6512,219 @@ msgstr ""
 #. whatever you like once you have updated your copy of the file.
 #: C/goscaja.xml:1169
 msgctxt "_"
-msgid "external ref='figures/caja_spatial_icon_view.png' md5='c2dd3a38476c26a924c2673c6bb6de93'"
-msgstr ""
-
-#. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1167
-msgid "<imageobject> <imagedata fileref=\"figures/caja_spatial_icon_view.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Your Home Folder displayed in an icon view.</phrase> </textobject>"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/goscaja.xml:1163
-msgid "<xref linkend=\"goscaja-FIG-naut-icon-view\"/> Shows the items in the folder as icons. <_:figure-1/>"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/goscaja.xml:1179
-msgid "List view"
-msgstr ""
-
-#. (itstool) path: figure/title
-#: C/goscaja.xml:1182
-msgid "The Home Folder displayed in a list view"
-msgstr ""
-
-#. (itstool) path: imageobject/imagedata
-#. This is a reference to an external file such as an image or video. When
-#. the file changes, the md5 hash will change to let you know you need to
-#. update your localized copy. The msgstr is not used at all. Set it to
-#. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:1186
-msgctxt "_"
 msgid "external ref='figures/caja_spatial_list_view.png' md5='99693c429ea6f6889793a85b0c8fb099'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1184
+#: C/goscaja.xml:1167
 msgid "<imageobject> <imagedata fileref=\"figures/caja_spatial_list_view.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Your Home Folder displayed in a list view.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1180
+#: C/goscaja.xml:1164
 msgid "<xref linkend=\"goscaja-FIG-naut-list-view\"/> Shows the items in the folder as a list. <_:figure-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1197
+#. (itstool) path: section/para
+#: C/goscaja.xml:1180
 msgid "You may use the <guilabel>View</guilabel> menu, or the <guilabel>View as</guilabel> drop-down list to choose between icon or list view. You can specify how you want to arrange or sort items in the folder and modify the size of the items in the view pane. The following sections describe how to work with icon view and list view."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1199
+#. (itstool) path: info/title
+#: C/goscaja.xml:1182
 msgid "To Arrange Your Files in Icon View"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:1200
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1183
 msgid "<primary>file manager</primary> <secondary>icon view</secondary> <tertiary>arranging files in</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1205
+#. (itstool) path: section/para
+#: C/goscaja.xml:1188
 msgid "When you display the contents of a folder in icon view, you can specify how to arrange the items in the folder. To specify how to arrange items in icon view, choose <menuchoice><guimenu>View</guimenu><guisubmenu>Arrange Items</guisubmenu></menuchoice>. The <guisubmenu>Arrange Items</guisubmenu> submenu contains the following sections:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1212
+#: C/goscaja.xml:1195
 msgid "At the top is an option that enables you to arrange your files manually."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1216
+#: C/goscaja.xml:1199
 msgid "The middle section contains options that enable you to sort your files automatically."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1220
+#: C/goscaja.xml:1203
 msgid "The bottom section contains options that enable you to modify how your files are arranged."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1224
+#. (itstool) path: section/para
+#: C/goscaja.xml:1207
 msgid "Choose the appropriate options from the submenu, as described in the following table:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1233
-#: C/goscaja.xml:3935
-#: C/goscaja.xml:4076
-#: C/gostools.xml:149
+#: C/goscaja.xml:1216
+#: C/goscaja.xml:3864
+#: C/goscaja.xml:4003
+#: C/gostools.xml:151
 msgid "Option"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1243
+#: C/goscaja.xml:1226
 msgid "<guilabel>Manually</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1248
+#: C/goscaja.xml:1231
 msgid "Select this option to arrange the items manually. To arrange the items manually, drag the items to the location you require within the view pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1255
+#: C/goscaja.xml:1238
 msgid "<guilabel>By Name</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1260
+#: C/goscaja.xml:1243
 msgid "Select this option to sort the items alphabetically by name. The order of the items is not case-sensitive. If the file manager is set to display hidden files, the hidden files are shown last."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1268
+#: C/goscaja.xml:1251
 msgid "<guilabel>By Size</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1273
+#: C/goscaja.xml:1256
 msgid "Select this option to sort the items by size, with the largest item first. When you sort items by size, the folders are sorted by the number of items in the folder. The folders are not sorted by the total size of the items in the folder."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1281
+#: C/goscaja.xml:1264
 msgid "<guilabel>By Type</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1286
+#: C/goscaja.xml:1269
 msgid "Select this option to sort the items alphabetically by object type. The items are sorted alphabetically by the description of their <firstterm>MIME type</firstterm>. The MIME type identifies the format of a file, and enables applications to read the file. For example, an email application can use the <literal>image/png</literal> MIME type to detect that a PNG file is attached to an email."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1296
+#: C/goscaja.xml:1279
 msgid "<guilabel>By Modification Date</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1302
+#: C/goscaja.xml:1284
 msgid "Select this option to sort the items by the date the items were last modified. The most recently modified item is first."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1308
+#: C/goscaja.xml:1290
 msgid "<guilabel>By Emblems</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1313
+#: C/goscaja.xml:1295
 msgid "Select this option to sort the items by any emblems that are added to the items. The items are sorted alphabetically by emblem name. Items that do not have emblems are last."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1320
+#: C/goscaja.xml:1302
 msgid "<guilabel>Compact Layout</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1325
+#: C/goscaja.xml:1307
 msgid "Select this option to arrange the items so that the items are closer to each other."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1331
+#: C/goscaja.xml:1313
 msgid "<guilabel>Reversed Order</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1336
+#: C/goscaja.xml:1318
 msgid "Select this option to reverse the order of the option by which you sort the items. For example, if you sort the items by name, select the <guilabel>Reversed Order</guilabel> option to sort the items in reverse alphabetical order."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1347
+#. (itstool) path: info/title
+#: C/goscaja.xml:1329
 msgid "To Arrange Your Files in List View"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:1348
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1330
 msgid "<primary>file manager</primary> <secondary>list view</secondary> <tertiary>arranging files in</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1353
+#. (itstool) path: section/para
+#: C/goscaja.xml:1335
 msgid "When you display the contents of a folder in list view, you can specify how to arrange the items in the folder. To specify how to arrange items in list view, click on the header of the column specifying the property by which you wish to arrange the items. To inverse the sorting order click on the same column header again."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1356
+#. (itstool) path: section/para
+#: C/goscaja.xml:1338
 msgid "To add or remove columns from the list view choose <menuchoice><guimenu>View</guimenu><guisubmenu>Visible Columns</guisubmenu></menuchoice>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1357
+#. (itstool) path: section/para
+#: C/goscaja.xml:1339
 msgid "The file manager remembers how you arrange the items in a particular folder. The next time that you display the folder, the items are arranged in the way that you selected. In other words, when you specify how to arrange the items in a folder, you customize the folder to display the items in that way. To return the arrangement settings of the folder to the default arrangement settings specified in your preferences, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Reset View to Defaults</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1365
+#. (itstool) path: info/title
+#: C/goscaja.xml:1347
 msgid "To Change the Size of Items in a View"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:1366
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1348
 msgid "<primary>file manager</primary> <secondary>zooming in and out</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1370
+#. (itstool) path: section/para
+#: C/goscaja.xml:1352
 msgid "You can change the size of items in a view. You can change the size if the view displays a file or a folder. You can change the size of items in a view in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1375
+#: C/goscaja.xml:1357
 msgid "To enlarge the size of items in a view, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Zoom In</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1378
+#: C/goscaja.xml:1360
 msgid "To reduce the size of items in a view, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Zoom Out</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1381
+#: C/goscaja.xml:1363
 msgid "To return items in a view to the normal size, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Normal Size</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1384
+#. (itstool) path: section/para
+#: C/goscaja.xml:1366
 msgid "You can also use the zoom buttons on the location bar in a browser window to change the size of items in a view. <xref linkend=\"goscaja-TBL-42\"/> describes how to use the zoom buttons."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscaja.xml:1388
+#. (itstool) path: info/title
+#: C/goscaja.xml:1369
 msgid "Zoom Buttons"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1396
+#: C/goscaja.xml:1377
 msgid "Button"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1399
+#: C/goscaja.xml:1380
 msgid "Button Name"
 msgstr ""
 
@@ -6753,23 +6733,23 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:1412
+#: C/goscaja.xml:1393
 msgctxt "_"
 msgid "external ref='figures/caja_zoom_out_button.png' md5='372c3f4288c029af11bac9c9012f7d8c'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1410
+#: C/goscaja.xml:1391
 msgid "<imageobject> <imagedata fileref=\"figures/caja_zoom_out_button.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Zoom Out button.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1421
+#: C/goscaja.xml:1402
 msgid "<guibutton>Zoom Out</guibutton> button"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1424
+#: C/goscaja.xml:1405
 msgid "Click on this button to reduce the size of items in a view."
 msgstr ""
 
@@ -6778,23 +6758,23 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:1432
+#: C/goscaja.xml:1413
 msgctxt "_"
 msgid "external ref='figures/caja_normal_size_button.png' md5='5bf2b3af293a950536ca593cd49b2f5e'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1430
+#: C/goscaja.xml:1411
 msgid "<imageobject> <imagedata fileref=\"figures/caja_normal_size_button.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Normal Size button.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1441
+#: C/goscaja.xml:1422
 msgid "<guibutton>Normal Size</guibutton> button"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1445
+#: C/goscaja.xml:1426
 msgid "Click on this button to return items in a view to normal size."
 msgstr ""
 
@@ -6803,1332 +6783,1331 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:1454
+#: C/goscaja.xml:1435
 msgctxt "_"
 msgid "external ref='figures/caja_zoom_in_button.png' md5='0369994f20b3221243b5b7550a5a9318'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1452
+#: C/goscaja.xml:1433
 msgid "<imageobject> <imagedata fileref=\"figures/caja_zoom_in_button.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Zoom In button.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1463
+#: C/goscaja.xml:1444
 msgid "<guibutton>Zoom In</guibutton> button"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1466
+#: C/goscaja.xml:1447
 msgid "Click on this button to enlarge the size of items in a view."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1472
+#. (itstool) path: section/para
+#: C/goscaja.xml:1453
 msgid "The file manager remembers the size of items in a particular folder. The next time that you display the folder, the items are displayed in the size that you selected. In other words, when you change the size of items in a folder, you customize the folder to display the items at that size. To return the size of the items to the default size specified in your preferences, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Reset View to Defaults</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1483
+#. (itstool) path: info/title
+#: C/goscaja.xml:1463
 msgid "Selecting Files and Folders"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1486
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1467
 msgid "<primary>file manager</primary> <secondary>selecting files and folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1490
+#. (itstool) path: section/para
+#: C/goscaja.xml:1471
 msgid "You can select files and folders in several ways in the file manager. Typically, this is achieved by clicking on the files using the mouse, as explained in <xref linkend=\"goscaja-TBL-10\"/>. In addition, <xref linkend=\"caja-select-pattern\"/> describes how to select a group of files matching a specific pattern."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscaja.xml:1493
-#: C/goscaja.xml:1557
+#. (itstool) path: info/title
+#: C/goscaja.xml:1473
+#: C/goscaja.xml:1534
 msgid "Selecting Items in the File Manager"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1510
+#: C/goscaja.xml:1490
 msgid "Select an item"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1513
+#: C/goscaja.xml:1493
 msgid "Click on the item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1518
+#: C/goscaja.xml:1498
 msgid "Select a group of contiguous items"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1522
+#: C/goscaja.xml:1501
 msgid "In icon view, drag around the files that you want to select."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1524
+#: C/goscaja.xml:1502
 msgid "In list view, click on the first item in the group. Press-and-hold <keycap>Shift</keycap>, then click on the last item in the group."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1531
+#: C/goscaja.xml:1509
 msgid "Select multiple items"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1534
+#: C/goscaja.xml:1512
 msgid "Press-and-hold <keycap>Ctrl</keycap>. Click on the items that you want to select."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1536
+#: C/goscaja.xml:1514
 msgid "Alternatively, press-and-hold <keycap>Ctrl</keycap>, then drag around the files that you want to select."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1541
+#: C/goscaja.xml:1519
 msgid "Select all items in a folder"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1544
+#: C/goscaja.xml:1522
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Select All Files</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1550
+#. (itstool) path: section/para
+#: C/goscaja.xml:1528
 msgid "To perform the default action on an item, double-click on the item. You can set your file manager preferences so that you click once on a file to execute the default action. For more information, see <xref linkend=\"goscaja-56\"/>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1554
+#. (itstool) path: info/title
+#: C/goscaja.xml:1532
 msgid "Selecting Files Matching a Specific Pattern"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1555
+#. (itstool) path: section/para
+#: C/goscaja.xml:1533
 msgid "<application>Caja</application> allows you to select all files matching a pattern based upon their filename and an optional number of wildcards. This can be useful if, for example, you wish to select all files which contain the phrase \"memo\" in their filename. <xref linkend=\"goscaja-TBL-select-pattern\"/> gives some examples of possible patterns and the resulting files they would match."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1564
+#: C/goscaja.xml:1541
 msgid "Pattern"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1567
+#: C/goscaja.xml:1544
 msgid "Files Matched"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1574
+#: C/goscaja.xml:1551
 msgid "note.*"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1577
+#: C/goscaja.xml:1554
 msgid "This pattern would match files called note, with any extension."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1582
+#: C/goscaja.xml:1559
 msgid "*.ogg"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1585
+#: C/goscaja.xml:1562
 msgid "This pattern would match all files with the .ogg extension"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1590
+#: C/goscaja.xml:1567
 msgid "*memo*"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1593
+#: C/goscaja.xml:1570
 msgid "This pattern would match all files or folders whose name contains the word memo."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1599
+#. (itstool) path: section/para
+#: C/goscaja.xml:1576
 msgid "To perform the Select Pattern command Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Select Patterns</guimenuitem></menuchoice> from the menu. After entering the desired pattern you are left with those files or folders which matched the pattern selected. You may then do with the selected files or folders what you choose."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#. (itstool) path: table/title
-#: C/goscaja.xml:1604
-#: C/goscaja.xml:1617
+#. (itstool) path: info/title
+#: C/goscaja.xml:1580
+#: C/goscaja.xml:1593
 msgid "Drag-and-Drop in the File Manager"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1607
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1584
 msgid "<primary>file manager</primary> <secondary>drag-and-drop</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1611
+#. (itstool) path: section/para
+#: C/goscaja.xml:1588
 msgid "You can use drag-and-drop to perform several tasks in the file manager. When you drag-and-drop, the mouse pointer provides feedback about the task that you perform. <xref linkend=\"goscaja-TBL-11\"/> describes the tasks that you can perform with drag-and-drop. The table also shows the mouse pointers that appear when you drag-and-drop."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1631
+#: C/goscaja.xml:1607
 msgid "Mouse Pointer"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1638
+#: C/goscaja.xml:1614
 msgid "Move an item"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1641
+#: C/goscaja.xml:1617
 msgid "Drag the item to the new location."
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1645
+#: C/goscaja.xml:1621
 msgid "<imageobject> <imagedata fileref=\"figures/move_pointer.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Move pointer.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1658
+#: C/goscaja.xml:1634
 msgid "Copy an item"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1661
+#: C/goscaja.xml:1637
 msgid "Grab the item, then press-and-hold <keycap>Ctrl</keycap>. Drag the item to the location where you want the copy to reside."
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1665
+#: C/goscaja.xml:1641
 msgid "<imageobject> <imagedata fileref=\"figures/copy_pointer.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Copy pointer.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1678
+#: C/goscaja.xml:1654
 msgid "Create a symbolic link to an item"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1682
+#: C/goscaja.xml:1657
 msgid "Grab the item, then press-and-hold <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap></keycombo>. Drag the item to the location where you want the symbolic link to reside."
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1688
+#: C/goscaja.xml:1663
 msgid "<imageobject> <imagedata fileref=\"figures/link_pointer.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Symbolic link pointer.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1701
+#: C/goscaja.xml:1676
 msgid "Ask what to do with the item you drag"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:1705
+#: C/goscaja.xml:1679
 msgid "Grab the item, then press-and-hold <keycap>Alt</keycap>. You may also use the middle mouse button to perform the same operation. Drag the item to the location where you want the item to reside. Release the mouse button. A popup menu appears. Choose one of the following items from the popup menu:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1710
+#: C/goscaja.xml:1684
 msgid "<guimenuitem>Move here</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1713
+#: C/goscaja.xml:1687
 msgid "Moves the item to the location."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1716
+#: C/goscaja.xml:1690
 msgid "<guimenuitem>Copy here</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1719
+#: C/goscaja.xml:1693
 msgid "Copies the item to the location."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1722
+#: C/goscaja.xml:1696
 msgid "<guimenuitem>Link here</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1725
+#: C/goscaja.xml:1699
 msgid "Creates a symbolic link to the item at the location."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1728
+#: C/goscaja.xml:1702
 msgid "<guimenuitem>Set as Background</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1731
+#: C/goscaja.xml:1705
 msgid "If the item is an image, sets the image to be the background. You can use this command to set the background of the desktop, the side pane or the view pane."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1735
+#: C/goscaja.xml:1709
 msgid "<guimenuitem>Cancel</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1738
+#: C/goscaja.xml:1712
 msgid "Cancels the drag-and-drop operation."
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:1744
+#: C/goscaja.xml:1718
 msgid "<imageobject> <imagedata fileref=\"figures/ask_pointer.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Ask pointer.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1761
+#. (itstool) path: info/title
+#: C/goscaja.xml:1734
 msgid "Moving a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1762
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1735
 msgid "<primary>file manager</primary> <secondary>moving files and folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1766
+#. (itstool) path: section/para
+#: C/goscaja.xml:1739
 msgid "You can move a file or folder by dragging it with the mouse, or with the cut and paste commands. The following sections describe these two methods."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1768
-#: C/goscaja.xml:1811
+#. (itstool) path: info/title
+#: C/goscaja.xml:1741
+#: C/goscaja.xml:1784
 msgid "Drag to the New Location"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1769
+#. (itstool) path: section/para
+#: C/goscaja.xml:1742
 msgid "To drag a file or folder to a new location, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1772
-#: C/goscaja.xml:1815
+#: C/goscaja.xml:1745
+#: C/goscaja.xml:1788
 msgid "Open two file manager windows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1774
-#: C/goscaja.xml:1817
+#: C/goscaja.xml:1747
+#: C/goscaja.xml:1790
 msgid "The window containing the item you want to move."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1775
-#: C/goscaja.xml:1818
+#: C/goscaja.xml:1748
+#: C/goscaja.xml:1791
 msgid "The window you want to move it to, or the window containing the folder you want to move it to."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1779
+#: C/goscaja.xml:1752
 msgid "Drag the file or folder that you want to move to the new location. If the new location is a window, drop it anywhere in the window. If the new location is a folder icon, drop the item you are dragging on the folder."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1782
+#. (itstool) path: section/para
+#: C/goscaja.xml:1755
 msgid "To move the file or folder to a folder that is one level below the current location, do not open a new window. Instead, drag the file or folder to the new location in the same window."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/goscaja.xml:1785
-#: C/goscaja.xml:1829
-#: C/goscaja.xml:2041
+#: C/goscaja.xml:1758
+#: C/goscaja.xml:1802
+#: C/goscaja.xml:2014
 msgid "For more on dragging items, see <xref linkend=\"caja-dragndrop\"/>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1788
+#. (itstool) path: info/title
+#: C/goscaja.xml:1761
 msgid "Cut and Paste to the New Location"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1789
+#. (itstool) path: section/para
+#: C/goscaja.xml:1762
 msgid "You can cut a file or folder and paste the file or folder into another folder, as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1793
+#: C/goscaja.xml:1766
 msgid "Select the file or folder that you want to move, then choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Cut</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1796
+#: C/goscaja.xml:1769
 msgid "Open the folder to which you want to move the file or folder, then choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste </guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1804
+#. (itstool) path: info/title
+#: C/goscaja.xml:1777
 msgid "Copying a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1805
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1778
 msgid "<primary>file manager</primary> <secondary>copying files and folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1809
+#. (itstool) path: section/para
+#: C/goscaja.xml:1782
 msgid "You can copy a file or folder by dragging it with the mouse, or with the copy and paste commands. The following sections describe these two methods."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1812
+#. (itstool) path: section/para
+#: C/goscaja.xml:1785
 msgid "To copy a file or folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1822
+#: C/goscaja.xml:1795
 msgid "Drag the file or folder that you want to move to the new location. Press-and-hold <keycap>Ctrl</keycap> either before or during the drag. If the new location is a window, drop it anywhere in the window. If the new location is a folder icon, drop the item you are dragging on the folder."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1825
+#. (itstool) path: section/para
+#: C/goscaja.xml:1798
 msgid "To copy the file or folder to a folder that is one level below the current location, do not open a new window. Instead, grab the file or folder, then press-and-hold <keycap>Ctrl</keycap>. Drag the file or folder to the new location in the same window."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1832
+#. (itstool) path: info/title
+#: C/goscaja.xml:1805
 msgid "Copy and Paste to the New Location"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1833
+#. (itstool) path: section/para
+#: C/goscaja.xml:1807
 msgid "You can copy a file or folder and paste the file or folder into another folder, as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1837
+#: C/goscaja.xml:1811
 msgid "Select the file or folder that you want to copy, then choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Copy</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1840
+#: C/goscaja.xml:1814
 msgid "Open the folder to which you want to copy the file or folder, then choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste </guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1848
+#. (itstool) path: info/title
+#: C/goscaja.xml:1822
 msgid "Duplicating a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1849
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1823
 msgid "<primary>file manager</primary> <secondary>duplicating files and folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1854
+#. (itstool) path: section/para
+#: C/goscaja.xml:1828
 msgid "To create a copy of a file or folder in the current folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1858
+#: C/goscaja.xml:1832
 msgid "Select the file or folder that you want to duplicate."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1861
+#: C/goscaja.xml:1835
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Duplicate</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1862
+#: C/goscaja.xml:1836
 msgid "A copy of the file or folder appears in the current folder."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1867
+#. (itstool) path: info/title
+#: C/goscaja.xml:1841
 msgid "Creating a Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1868
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1842
 msgid "<primary>file manager</primary> <secondary>creating folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1872
+#. (itstool) path: section/para
+#: C/goscaja.xml:1846
 msgid "To create a folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1875
+#: C/goscaja.xml:1849
 msgid "Open the folder where you want to create the new folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1878
+#: C/goscaja.xml:1852
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Create Folder</guimenuitem></menuchoice>. Alternatively, right-click on the background of the window, then choose <guimenuitem>Create Folder</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1880
+#: C/goscaja.xml:1854
 msgid "An <guilabel>untitled</guilabel> folder is added to the location. The name of the folder is selected."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1884
+#: C/goscaja.xml:1858
 msgid "Type a name for the folder, then press <keycap>Return</keycap>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1889
+#. (itstool) path: info/title
+#: C/goscaja.xml:1863
 msgid "Templates and Documents"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1890
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1864
 msgid "<primary>file manager</primary> <secondary>creating documents</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1894
+#. (itstool) path: section/para
+#: C/goscaja.xml:1868
 msgid "You can create templates from documents that you frequently create. For example, if you often create invoices, you can create an empty invoice document and save the document as <literal>invoice.doc</literal> in the <literal>$HOME/Templates</literal> folder."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1898
+#. (itstool) path: section/para
+#: C/goscaja.xml:1872
 msgid "You can also access the templates folder from a file browser window. Choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Templates</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1900
+#. (itstool) path: section/para
+#: C/goscaja.xml:1874
 msgid "The template name is displayed as a submenu item in the <guilabel>Create Document</guilabel> menu."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1902
+#. (itstool) path: section/para
+#: C/goscaja.xml:1876
 msgid "You can also create subfolders in the template folder. Subfolders display as submenus in the menu."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1904
+#. (itstool) path: section/para
+#: C/goscaja.xml:1878
 msgid "You can also share templates. Create a symbolic link from the template folder to the folder containing the shared templates."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:1907
+#. (itstool) path: info/title
+#: C/goscaja.xml:1881
 msgid "To Create a Document"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1908
+#. (itstool) path: section/para
+#: C/goscaja.xml:1882
 msgid "If you have document templates, you can choose to create a document from one of the installed templates."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:1910
+#. (itstool) path: section/para
+#: C/goscaja.xml:1884
 msgid "To create a document perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1913
+#: C/goscaja.xml:1887
 msgid "Select the folder where you want to create the new document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1916
+#: C/goscaja.xml:1890
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Create Document</guimenuitem></menuchoice>. Alternatively, right-click on the background of the view pane, then choose <guimenuitem>Create Document</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1918
+#: C/goscaja.xml:1892
 msgid "The names of any available templates are displayed as submenu items from the <guilabel>Create Document</guilabel> menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1922
+#: C/goscaja.xml:1896
 msgid "Double-click on the template name for the document that you want to create."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1926
+#: C/goscaja.xml:1900
 msgid "Rename the document before saving to the appropriate folder."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1932
+#. (itstool) path: info/title
+#: C/goscaja.xml:1906
 msgid "Renaming a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1933
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1907
 msgid "<primary>file manager</primary> <secondary>renaming folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1937
+#. (itstool) path: section/para
+#: C/goscaja.xml:1911
 msgid "To rename a file or folder perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1940
+#: C/goscaja.xml:1914
 msgid "Select the file or folder that you want to rename."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1943
+#: C/goscaja.xml:1917
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Rename</guimenuitem></menuchoice>. Alternatively, right-click on the file or folder, then choose <guimenuitem>Rename</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1945
+#: C/goscaja.xml:1919
 msgid "The name of the file or folder is selected."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1948
+#: C/goscaja.xml:1922
 msgid "Type a new name for the file or folder, then press <keycap>Return</keycap>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1953
+#. (itstool) path: info/title
+#: C/goscaja.xml:1927
 msgid "Moving a File or Folder to Trash"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1954
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1928
 msgid "<primary>file manager</primary> <secondary>Trash</secondary> <see>Trash</see>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1959
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1933
 msgid "<primary>Trash</primary> <secondary>moving files or folders to</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1964
+#. (itstool) path: section/para
+#: C/goscaja.xml:1937
 msgid "To move a file or folder to <guilabel>Trash</guilabel> perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1968
+#: C/goscaja.xml:1941
 msgid "Select the file or folder that you want to move to <guilabel>Trash</guilabel>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1971
+#: C/goscaja.xml:1944
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Move to Trash</guimenuitem></menuchoice>. Alternatively, right-click on the file or folder, then choose <guimenuitem>Move to Trash</guimenuitem>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1975
+#. (itstool) path: section/para
+#: C/goscaja.xml:1948
 msgid "Alternatively, you can drag the file or folder to the <guilabel>Trash</guilabel> object on the desktop."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:1977
+#: C/goscaja.xml:1950
 msgid "When you move a file or folder from a removable media to <guilabel>Trash</guilabel>, the file or folder is stored in a <guilabel>Trash</guilabel> location on the removable media. To remove the file or folder permanently from the removable media, you must empty <guilabel>Trash</guilabel>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:1983
+#. (itstool) path: info/title
+#: C/goscaja.xml:1956
 msgid "Deleting a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:1984
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1957
 msgid "<primary>file manager</primary> <secondary>deleting files or folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1988
+#. (itstool) path: section/para
+#: C/goscaja.xml:1961
 msgid "When you delete a file or folder, the file or folder is not moved to <guilabel>Trash</guilabel>, but is deleted from your file system immediately. The <guimenuitem>Delete</guimenuitem> menu item is only available if you select the <guilabel>Include a Delete command that bypasses Trash</guilabel> option in the <guilabel>File Management Preferences</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:1994
+#. (itstool) path: section/para
+#: C/goscaja.xml:1967
 msgid "To delete a file or folder perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:1997
+#: C/goscaja.xml:1970
 msgid "Select the file or folder that you want to delete."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2000
+#: C/goscaja.xml:1973
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Delete</guimenuitem></menuchoice>. Alternatively, right-click on the file or folder, then choose <guimenuitem>Delete</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:2007
+#: C/goscaja.xml:1980
 msgid "This shortcut is independent from the <guilabel>Include a Delete command that bypasses Trash</guilabel> option."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2004
+#. (itstool) path: section/para
+#: C/goscaja.xml:1977
 msgid "Alternatively, select the file or folder you want to delete, and press <keycombo><keycap>Shift</keycap><keycap>Del</keycap></keycombo>. <_:note-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2014
+#. (itstool) path: info/title
+#: C/goscaja.xml:1986
 msgid "Creating a Symbolic Link to a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2017
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1990
 msgid "<primary>file manager</primary> <secondary>creating symbolic link</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2021
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:1994
 msgid "<primary>symbolic link</primary> <secondary>to file or folder, creating</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2025
+#. (itstool) path: section/para
+#: C/goscaja.xml:1998
 msgid "A symbolic link is a special type of file that points to another file or folder. When you perform an action on a symbolic link, the action is performed on the file or folder to which the symbolic link points. However, when you delete a symbolic link, you delete the link file, not the file to which the symbolic link points."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2030
+#. (itstool) path: section/para
+#: C/goscaja.xml:2003
 msgid "To create a symbolic link to a file or folder, select the file or folder to which you want to create a link. Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Make Link</guimenuitem></menuchoice>. A link to the file or folder is added to the current folder."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2033
+#. (itstool) path: section/para
+#: C/goscaja.xml:2006
 msgid "Alternatively, grab the item to which you want to create a link, then press-and-hold <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap></keycombo>. Drag the item to the location where you want to place the link."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2036
+#. (itstool) path: section/para
+#: C/goscaja.xml:2009
 msgid "By default, the file manager adds an emblem to symbolic links."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:2038
+#: C/goscaja.xml:2011
 msgid "The permissions of a symbolic link are determined by the file or folder to which a symbolic link points."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2044
+#. (itstool) path: info/title
+#: C/goscaja.xml:2017
 msgid "Viewing the Properties of a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2045
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2018
 msgid "<primary>file manager</primary> <secondary>viewing properties</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2049
+#. (itstool) path: section/para
+#: C/goscaja.xml:2022
 msgid "To view the properties of a file or folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2053
+#: C/goscaja.xml:2025
 msgid "Select the file or folder whose properties you want to view."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2056
+#: C/goscaja.xml:2028
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. A properties dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2059
+#: C/goscaja.xml:2031
 msgid "Use the properties dialog to view the properties of the file or folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2063
-#: C/goscaja.xml:2771
-#: C/goscaja.xml:2808
+#: C/goscaja.xml:2034
+#: C/goscaja.xml:2727
+#: C/goscaja.xml:2762
 msgid "Click <guibutton>Close</guibutton> to close the properties dialog."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2068
+#. (itstool) path: section/para
+#: C/goscaja.xml:2038
 msgid "The following table lists the properties that you can view or set for files and folders, the exact information shown depends on the object type:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2076
+#: C/goscaja.xml:2046
 msgid "Property"
 msgstr ""
 
 #. (itstool) path: entry/para
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2086
-#: C/gospanel.xml:836
+#: C/goscaja.xml:2056
+#: C/gospanel.xml:823
 msgid "Name"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2089
+#: C/goscaja.xml:2059
 msgid "The name of the file or folder. You can change the name here and the file or folder will be renamed when you click on <guibutton>Close</guibutton>."
 msgstr ""
 
 #. (itstool) path: entry/para
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2094
-#: C/gospanel.xml:811
+#: C/goscaja.xml:2064
+#: C/gospanel.xml:798
 msgid "Type"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2097
+#: C/goscaja.xml:2067
 msgid "The type of object, file or folder for example."
 msgstr ""
 
 #. (itstool) path: entry/para
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2102
-#: C/gospanel.xml:825
-#: C/gospanel.xml:848
+#: C/goscaja.xml:2072
+#: C/gospanel.xml:812
+#: C/gospanel.xml:835
 msgid "Location"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2105
+#: C/goscaja.xml:2075
 msgid "The system path for the object. This represents where the object is situated on your computer, relative to the system root."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2110
+#: C/goscaja.xml:2080
 msgid "Volume"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2113
+#: C/goscaja.xml:2083
 msgid "The volume on which a folder resides. This is the physical location of the folder, on which media it resides, for example which hard disk or CD-ROM drive."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2118
+#: C/goscaja.xml:2088
 msgid "Free space"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2121
+#: C/goscaja.xml:2091
 msgid "The amount of free space on the media upon which a folder resides. This represents the maximum amount of data you can copy to this folder."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2126
+#: C/goscaja.xml:2096
 msgid "MIME Type"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2129
+#: C/goscaja.xml:2099
 msgid "The official naming of the type of file."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2134
+#: C/goscaja.xml:2104
 msgid "Modified"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2137
+#: C/goscaja.xml:2107
 msgid "The date and time at which the object was last changed."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2142
+#: C/goscaja.xml:2112
 msgid "Accessed"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2145
+#: C/goscaja.xml:2115
 msgid "The date and time at which the object was last viewed."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2154
+#. (itstool) path: info/title
+#: C/goscaja.xml:2123
 msgid "File Permissions"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2155
+#. (itstool) path: section/para
+#: C/goscaja.xml:2124
 msgid "Permissions are settings assigned to each file and folder that determine what type of access users can have to the file or folder. For example, you can determine whether other users can read and edit a file that belongs to you, or only have access to read it but not make changes to it."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2157
+#. (itstool) path: section/para
+#: C/goscaja.xml:2126
 msgid "Each file belongs to a particular user, and is associated with a group that the owner belongs to. The super user \"root\" has the ability to access any file on the system."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2158
+#. (itstool) path: section/para
+#: C/goscaja.xml:2127
 msgid "You can set permissions for three categories of users:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2160
+#: C/goscaja.xml:2129
 msgid "Owner"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2162
+#: C/goscaja.xml:2131
 msgid "The user that created the file or folder."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2165
+#: C/goscaja.xml:2134
 msgid "Group"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2167
+#: C/goscaja.xml:2136
 msgid "A group of users to which the owner belongs."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2170
+#: C/goscaja.xml:2139
 msgid "Others"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2172
+#: C/goscaja.xml:2141
 msgid "All other users not already included."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2176
+#. (itstool) path: section/para
+#: C/goscaja.xml:2145
 msgid "For each category of user, different permissions can be set. These behave differently for files and folders, as follows:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2179
+#: C/goscaja.xml:2148
 msgid "read"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2181
+#: C/goscaja.xml:2150
 msgid "Files can be opened"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2182
+#: C/goscaja.xml:2151
 msgid "Directory contents can be displayed"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2185
+#: C/goscaja.xml:2154
 msgid "write"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2187
+#: C/goscaja.xml:2156
 msgid "Files can be edited or deleted"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2188
+#: C/goscaja.xml:2157
 msgid "Directory contents can be modified"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2191
+#: C/goscaja.xml:2160
 msgid "execute"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2193
+#: C/goscaja.xml:2162
 msgid "Executable files can be run as a program"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2194
+#: C/goscaja.xml:2163
 msgid "Directories can be entered"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2199
+#. (itstool) path: section/para
+#: C/goscaja.xml:2168
 msgid "For more on changing the permissions for a file or folder, see <xref linkend=\"caja-permissions\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2203
+#. (itstool) path: info/title
+#: C/goscaja.xml:2171
 msgid "Changing Permissions"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2208
+#. (itstool) path: info/title
+#: C/goscaja.xml:2175
 msgid "Changing Permissions for a File"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:2210
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2176
 msgid "<primary>file manager</primary> <secondary>changing permissions</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:2214
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2180
 msgid "<primary>permissions</primary> <secondary>changing file</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2218
+#. (itstool) path: section/para
+#: C/goscaja.xml:2184
 msgid "To change the permissions of a file, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2221
+#: C/goscaja.xml:2187
 msgid "Select the file that you want to change."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2224
-#: C/goscaja.xml:2759
+#: C/goscaja.xml:2190
+#: C/goscaja.xml:2715
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. The <xref linkend=\"caja-properties\"/> for the item is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2227
-#: C/goscaja.xml:2270
+#: C/goscaja.xml:2193
+#: C/goscaja.xml:2236
 msgid "Click on the <guilabel>Permissions</guilabel> tab."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2230
+#: C/goscaja.xml:2196
 msgid "To change the file's group, choose from the groups the user belongs to in the drop-down selector."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2233
+#: C/goscaja.xml:2199
 msgid "For each of the owner, the group, and all other users, choose from these permissions for the file:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2235
-#: C/goscaja.xml:2278
+#: C/goscaja.xml:2201
+#: C/goscaja.xml:2244
 msgid "None"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2237
+#: C/goscaja.xml:2203
 msgid "No access to the file is possible. (You can't set this for the owner.)"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2240
+#: C/goscaja.xml:2206
 msgid "Read-only"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2242
+#: C/goscaja.xml:2208
 msgid "The users can open a file to see its contents, but not make any changes."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2245
+#: C/goscaja.xml:2211
 msgid "Read and write"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2247
+#: C/goscaja.xml:2213
 msgid "Normal access to a file is possible: it can be opened and saved."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2253
+#: C/goscaja.xml:2219
 msgid "To allow a file to be run as a program, select <guilabel>Execute</guilabel>"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2259
+#. (itstool) path: info/title
+#: C/goscaja.xml:2224
 msgid "Changing Permissions for a Folder"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2261
+#. (itstool) path: section/para
+#: C/goscaja.xml:2227
 msgid "To change the permissions of a folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2264
+#: C/goscaja.xml:2230
 msgid "Select the folder that you want to change."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2267
-#: C/goscaja.xml:2339
+#: C/goscaja.xml:2233
+#: C/goscaja.xml:2304
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. The <link linkend=\"caja-properties\">properties window</link> for the item is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2273
+#: C/goscaja.xml:2239
 msgid "To change the folder's group, choose from the groups the user belongs to in the drop-down selector."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2276
+#: C/goscaja.xml:2242
 msgid "For each of the owner, the group, and all other users, choose from these folder access permissions:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2280
+#: C/goscaja.xml:2246
 msgid "No access to the folder is possible. (You can't set this for the owner.)"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2283
+#: C/goscaja.xml:2249
 msgid "List files only"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2285
+#: C/goscaja.xml:2251
 msgid "The users can see the items in the folder, but not open any of them."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2288
+#: C/goscaja.xml:2254
 msgid "Access files"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2290
+#: C/goscaja.xml:2256
 msgid "Items in the folder can be opened and modified, provided their own permissions allow it."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:2293
+#: C/goscaja.xml:2259
 msgid "Create and delete files"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2295
+#: C/goscaja.xml:2261
 msgid "The user can create new files and delete files in the folder, in addition to being able to access existing files."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2302
+#. (itstool) path: section/para
+#: C/goscaja.xml:2268
 msgid "To set permissions for all the items contained in a folder, set the <guilabel>File Access</guilabel> and <guilabel>Execute</guilabel> properties and click on <guibutton>Apply permissions to enclosed files</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2308
+#. (itstool) path: info/title
+#: C/goscaja.xml:2273
 msgid "Adding Notes to Files and Folders"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2309
+#. (itstool) path: section/para
+#: C/goscaja.xml:2274
 msgid "You can add notes to files or folders. You can add notes to files or folders in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2313
+#: C/goscaja.xml:2278
 msgid "From the properties dialog"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2316
+#: C/goscaja.xml:2281
 msgid "From <guilabel>Notes</guilabel> in the side pane"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2320
+#. (itstool) path: info/title
+#: C/goscaja.xml:2285
 msgid "To Add a Note Using the Properties Dialog"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:2323
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2288
 msgid "<primary>notes</primary> <secondary>adding to files and folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:2327
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2292
 msgid "<primary>file manager</primary> <secondary>notes</secondary> <tertiary>adding</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2332
-#: C/goscaja.xml:2353
+#. (itstool) path: section/para
+#: C/goscaja.xml:2297
+#: C/goscaja.xml:2318
 msgid "To add a note to a file or folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2336
+#: C/goscaja.xml:2301
 msgid "Select the file or folder to which you want to add a note."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2342
+#: C/goscaja.xml:2307
 msgid "Click on the <guilabel>Notes</guilabel> tab. In the <guilabel>Notes</guilabel> tabbed section, type the note."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2345
+#: C/goscaja.xml:2310
 msgid "Click <guibutton>Close</guibutton> to close the properties dialog. A note emblem is added to the file or folder."
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:2349
+#: C/goscaja.xml:2314
 msgid "<primary>notes</primary><secondary>deleting</secondary>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:2349
+#: C/goscaja.xml:2314
 msgid "<primary>file manager</primary><secondary>notes</secondary><tertiary>deleting</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2349
+#. (itstool) path: section/para
+#: C/goscaja.xml:2314
 msgid "<_:indexterm-1/><_:indexterm-2/>To delete a note, delete the note text from the <guilabel>Notes</guilabel> tabbed section."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2352
+#. (itstool) path: info/title
+#: C/goscaja.xml:2316
 msgid "To Add a Note Using Notes in the Side Pane"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2356
+#: C/goscaja.xml:2321
 msgid "Open the file or folder to which you want to add a note in the view pane."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2360
+#: C/goscaja.xml:2325
 msgid "Choose <guilabel>Notes</guilabel> from the drop-down list at the top of the side pane. To display the side pane, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2364
+#: C/goscaja.xml:2329
 msgid "Type the note in the side pane. A note emblem is added to the file or folder in the view pane, and a note icon is added to the side pane. You can click on this icon to display the note."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2369
+#. (itstool) path: section/para
+#: C/goscaja.xml:2334
 msgid "To delete a note, delete the note text from <guilabel>Notes</guilabel> in the side pane."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2374
+#. (itstool) path: info/title
+#: C/goscaja.xml:2339
 msgid "Using Bookmarks For Your Favorite Locations"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2377
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2343
 msgid "<primary>file manager</primary> <secondary>bookmarks</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2381
+#. (itstool) path: section/para
+#: C/goscaja.xml:2347
 msgid "You can keep a list of <firstterm>bookmarks</firstterm> in <application>Caja</application>: folders and other locations that you frequently need to open."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2382
+#. (itstool) path: section/para
+#: C/goscaja.xml:2348
 msgid "Your bookmarks are listed in the following places:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2384
+#: C/goscaja.xml:2350
 msgid "The <guimenu>Places</guimenu> menu on the top panel."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2385
+#: C/goscaja.xml:2351
 msgid "The <guimenu>Places</guimenu> menu in a folder window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2386
+#: C/goscaja.xml:2352
 msgid "The <guimenu>Bookmarks</guimenu> menu in a <application>Caja</application> browser window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2387
+#: C/goscaja.xml:2353
 msgid "The side pane in the <xref linkend=\"filechooser-open\"/>. This allows you to quickly open a file that is in one of your bookmarked locations."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2388
+#: C/goscaja.xml:2354
 msgid "The list of commonly used locations in the <xref linkend=\"filechooser-save\"/>. This allows you to quickly save a file to a location you have in your bookmarks."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2391
+#. (itstool) path: section/para
+#: C/goscaja.xml:2357
 msgid "To open an item that is in your bookmarks, choose the item from a menu."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2394
+#. (itstool) path: info/title
+#: C/goscaja.xml:2359
 msgid "Adding a Bookmark"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2395
+#. (itstool) path: section/para
+#: C/goscaja.xml:2360
 msgid "To add a bookmark, open the folder or location that you want to bookmark, then choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Add Bookmark</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2396
+#. (itstool) path: section/para
+#: C/goscaja.xml:2361
 msgid "If you are using a <application>Caja</application> browser window, choose <menuchoice><guimenu>Bookmarks</guimenu><guimenuitem>Add Bookmark</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2399
+#. (itstool) path: info/title
+#: C/goscaja.xml:2364
 msgid "To Edit a Bookmark"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2400
+#. (itstool) path: section/para
+#: C/goscaja.xml:2365
 msgid "To edit your bookmarks perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2403
+#: C/goscaja.xml:2368
 msgid "Choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Edit Bookmarks</guimenuitem></menuchoice>, or in a browser window, <menuchoice><guimenu>Bookmarks</guimenu><guimenuitem>Edit Bookmarks</guimenuitem></menuchoice>. An <guilabel>Edit Bookmarks</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2407
+#: C/goscaja.xml:2372
 msgid "Select the bookmark on the left side of the <guilabel>Edit Bookmarks</guilabel> dialog. Edit the details for the bookmark on the right side of the <guilabel>Edit Bookmarks</guilabel> dialog, as follows:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2427
-#: C/goscaja.xml:3801
+#: C/goscaja.xml:2392
+#: C/goscaja.xml:3737
 msgid "<guilabel>Name</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2432
+#: C/goscaja.xml:2397
 msgid "Use this text box to specify the name that identifies the bookmark in the menus."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2438
+#: C/goscaja.xml:2403
 msgid "<guilabel>Location</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2443
+#: C/goscaja.xml:2408
 msgid "Use this field to specify the location of the bookmark."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2444
+#: C/goscaja.xml:2409
 msgid "Folders on your system use the <uri>file:///</uri> URI."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2452
+#: C/goscaja.xml:2417
 msgid "To delete a bookmark, select the bookmark on the left side of the dialog. Click <guilabel>Delete</guilabel>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2459
+#. (itstool) path: info/title
+#: C/goscaja.xml:2424
 msgid "Using Trash"
 msgstr ""
 
@@ -8137,303 +8116,303 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:2465
+#: C/goscaja.xml:2430
 msgctxt "_"
 msgid "external ref='figures/caja_trash_launcher.png' md5='42951c298a8bc2e3cd779e636e64efcd'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:2463
+#: C/goscaja.xml:2428
 msgid "<imageobject> <imagedata fileref=\"figures/caja_trash_launcher.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Trash icon, empty.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2472
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2437
 msgid "<primary>Trash</primary> <secondary>introduction</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2476
+#. (itstool) path: section/para
+#: C/goscaja.xml:2441
 msgid "Trash is a special folder that holds files that you no longer want to keep. Files in the Trash are not deleted permanently until you empty the trash. This two-stage process is in case you change your mind, or accidentally remove the wrong file."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2479
+#. (itstool) path: section/para
+#: C/goscaja.xml:2444
 msgid "You can move the following items to <guilabel>Trash</guilabel>:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2482
+#: C/goscaja.xml:2447
 msgid "Files"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2488
+#: C/goscaja.xml:2453
 msgid "Desktop objects"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2491
+#. (itstool) path: section/para
+#: C/goscaja.xml:2456
 msgid "If you need to retrieve a file from <guilabel>Trash</guilabel>, you can display <guilabel>Trash</guilabel> and move the file out of <guilabel>Trash</guilabel>. When you empty <guilabel>Trash</guilabel>, you delete the contents of <guilabel>Trash</guilabel> permanently."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2495
+#. (itstool) path: info/title
+#: C/goscaja.xml:2460
 msgid "To Display Trash"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:2496
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2461
 msgid "<primary>Trash</primary> <secondary>displaying</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2500
+#. (itstool) path: section/para
+#: C/goscaja.xml:2465
 msgid "You can display the contents of <guilabel>Trash</guilabel> in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2504
-#: C/goscaja.xml:2529
+#: C/goscaja.xml:2469
+#: C/goscaja.xml:2494
 msgid "From a file browser window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2505
+#: C/goscaja.xml:2470
 msgid "Choose <menuchoice><guimenu>Go</guimenu><guimenuitem>Trash</guimenuitem></menuchoice>. The contents of <guilabel>Trash</guilabel> are displayed in the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2509
+#: C/goscaja.xml:2474
 msgid "From a spatial window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2510
+#: C/goscaja.xml:2475
 msgid "Choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Trash</guimenuitem></menuchoice>. The contents of <guilabel>Trash</guilabel> are displayed in the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2514
-#: C/goscaja.xml:2534
+#: C/goscaja.xml:2479
+#: C/goscaja.xml:2499
 msgid "From the desktop"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2515
+#: C/goscaja.xml:2480
 msgid "Double-click on the <guilabel>Trash</guilabel> object on the desktop."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2520
+#. (itstool) path: info/title
+#: C/goscaja.xml:2484
 msgid "To Empty Trash"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:2521
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2486
 msgid "<primary>Trash</primary> <secondary>emptying</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2525
+#. (itstool) path: section/para
+#: C/goscaja.xml:2490
 msgid "You can empty the contents of <guilabel>Trash</guilabel> in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2530
+#: C/goscaja.xml:2495
 msgid "Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Empty Trash</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2535
+#: C/goscaja.xml:2500
 msgid "Right-click on the <guilabel>Trash</guilabel> object, then choose <guimenuitem>Empty Trash</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: caution/para
-#: C/goscaja.xml:2539
+#: C/goscaja.xml:2504
 msgid "When you empty trash, you destroy all files in the trash. Be sure that the trash only contains files you no longer need."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2546
+#. (itstool) path: info/title
+#: C/goscaja.xml:2511
 msgid "Hidden Files"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2547
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2512
 msgid "<primary>hidden</primary> <secondary>files</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2551
+#. (itstool) path: section/para
+#: C/goscaja.xml:2516
 msgid "By default, <application>Caja</application> does not display certain system and backup files in folders. This prevents accidental modification or deletion of them, which can impair the operation of your computer, and also reduces clutter in locations such as your Home Folder. Caja does not display:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2553
+#: C/goscaja.xml:2518
 msgid "Hidden files, whose filename begins with a period (.),"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2554
+#: C/goscaja.xml:2519
 msgid "Backup files, whose filename ends with a tilde (~)"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2555
+#: C/goscaja.xml:2520
 msgid "Files that are listed in a particular folder's <filename>.hidden</filename> file."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2558
+#. (itstool) path: section/para
+#: C/goscaja.xml:2523
 msgid "You may hide or show hidden files in a particular folder by selecting <menuchoice><guimenu>View</guimenu><guimenuitem>Show Hidden Files</guimenuitem></menuchoice>, or by pressing <keycombo><keycap>Ctrl</keycap><keycap>H</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2560
+#. (itstool) path: section/para
+#: C/goscaja.xml:2525
 msgid "To set <application>Caja</application> to always show hidden files, see <xref linkend=\"caja-preferences\"/>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:2563
+#. (itstool) path: info/title
+#: C/goscaja.xml:2527
 msgid "Hiding a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect3/indexterm
-#: C/goscaja.xml:2564
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2528
 msgid "<primary>create</primary> <secondary>hidden</secondary>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2568
+#. (itstool) path: section/para
+#: C/goscaja.xml:2532
 msgid "To hide a file or folder in <application>Caja</application>, either rename the file so its name begins with the period (.) character, or create a text file named <filename>.hidden</filename> in the same folder, and add its name to it, as in the example below:"
 msgstr ""
 
-#. (itstool) path: sect3/programlisting
-#: C/goscaja.xml:2569
+#. (itstool) path: section/programlisting
+#: C/goscaja.xml:2533
 #, no-wrap
 msgid ""
 "filename\n"
 "foldername"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:2571
+#. (itstool) path: section/para
+#: C/goscaja.xml:2535
 msgid "You may need to refresh the relevant <application>Caja</application> window to see the change: press <keycombo><keycap>Ctrl</keycap><keycap>R</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:2578
+#. (itstool) path: info/title
+#: C/goscaja.xml:2541
 msgid "Item Properties"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:2581
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2545
 msgid "<primary>file manager</primary> <secondary>properties</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:2585
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2549
 msgid "<primary>file manager</primary> <secondary>file properties</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:2589
+#. (itstool) path: section/para
+#: C/goscaja.xml:2553
 msgid "The <guilabel>Item Properties</guilabel> window shows more information about any file, folder, or other item in the file manager. With this window, you can also do the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2592
+#: C/goscaja.xml:2556
 msgid "Change the icon for an item: see <xref linkend=\"caja-icon\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2593
+#: C/goscaja.xml:2557
 msgid "Add or remove emblems for an item: see <xref linkend=\"caja-emblems\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2594
+#: C/goscaja.xml:2558
 msgid "Change the UNIX file permissions for an item: see <xref linkend=\"caja-permissions\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2595
+#: C/goscaja.xml:2559
 msgid "Choose which application is used to open an item, and others of the same type."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2596
+#: C/goscaja.xml:2560
 msgid "Add notes to an item: see <xref linkend=\"caja-notes\"/>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:2598
+#. (itstool) path: section/para
+#: C/goscaja.xml:2562
 msgid "To open the item properties window, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2600
+#: C/goscaja.xml:2564
 msgid "Select the item whose properties you want to examine or change. If you select more than one item, the properties window will show the properties that are in common to all items."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2602
+#: C/goscaja.xml:2566
 msgid "Do one of the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2604
+#: C/goscaja.xml:2568
 msgid "Choose <menuchoice> <guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2606
+#: C/goscaja.xml:2570
 msgid "Right-click on the selected item and choose <guimenuitem>Properties</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2607
+#: C/goscaja.xml:2571
 msgid "Press <keycombo><keycap>Alt</keycap><keycap>Return</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:2620
+#. (itstool) path: info/title
+#: C/goscaja.xml:2578
 msgid "Modifying the Appearance of Files and Folders"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:2621
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2579
 msgid "<primary>file manager</primary> <secondary>modifying appearance of files and folders</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:2626
+#. (itstool) path: section/para
+#: C/goscaja.xml:2583
 msgid "The <application>Caja</application> file manager enables you to modify the appearance of your files and folders in several ways. You may customize the way files or folders look by attaching emblems or backgrounds to them. You can also change format in which <application>Caja</application> displays these items to you. The following sections describe how to do so."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2628
+#. (itstool) path: info/title
+#: C/goscaja.xml:2585
 msgid "Icons and Emblems"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2629
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2586
 msgid "<primary>file manager</primary> <secondary>icons</secondary> <tertiary>introduction</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2634
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2591
 msgid "<primary>file manager</primary> <secondary>emblems</secondary> <see>emblems</see>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2639
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2596
 msgid "<primary>emblems</primary> <secondary>introduction</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2643
+#. (itstool) path: section/para
+#: C/goscaja.xml:2600
 msgid "The file manager displays your files and folders as icons. Depending on the type of the file the icon may be a image representative of the file type, a small thumbnail or preview showing the files contents. You can also add emblems to your file and folder icons. Such emblems appear in addition to the file icon and provide another means to manage your files. For example you can mark a file as important by adding an <guilabel>Important</guilabel> emblem to it, creating the following visual effect:"
 msgstr ""
 
@@ -8442,62 +8421,62 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:2647
+#: C/goscaja.xml:2604
 msgctxt "_"
 msgid "external ref='figures/caja_emblem.png' md5='4dfffab4440360f5b2a307b42fa50691'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:2645
+#: C/goscaja.xml:2602
 msgid "<imageobject> <imagedata fileref=\"figures/caja_emblem.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>File icon with Important emblem.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2655
+#. (itstool) path: section/para
+#: C/goscaja.xml:2612
 msgid "Notice how the file on the left is distinguished from the file on the right by the addition of the <guilabel>Important (!)</guilabel> emblem to its icon. See <xref linkend=\"caja-emblems\"/> for more on adding emblems."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2656
+#. (itstool) path: section/para
+#: C/goscaja.xml:2613
 msgid "The file manager automatically applies emblems for the following types of files:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2659
+#: C/goscaja.xml:2616
 msgid "Symbolic links"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:2662
+#: C/goscaja.xml:2619
 msgid "<primary>permissions</primary><secondary>and emblems</secondary>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2662
+#: C/goscaja.xml:2619
 msgid "Items for which you have the following permissions:<_:indexterm-1/>"
 msgstr ""
 
 #. (itstool) path: listitem/para
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2665
-#: C/goscaja.xml:2738
+#: C/goscaja.xml:2622
+#: C/goscaja.xml:2694
 msgid "No read permission"
 msgstr ""
 
 #. (itstool) path: listitem/para
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2668
-#: C/goscaja.xml:2721
+#: C/goscaja.xml:2625
+#: C/goscaja.xml:2677
 msgid "No write permission"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2673
+#. (itstool) path: section/para
+#: C/goscaja.xml:2630
 msgid "The following table shows the default emblems:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2681
+#: C/goscaja.xml:2638
 msgid "Default Emblem"
 msgstr ""
 
@@ -8506,23 +8485,23 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:2694
+#: C/goscaja.xml:2651
 msgctxt "_"
 msgid "external ref='figures/caja_link_emblem.png' md5='7fefb663977d2a003bc86b8eb61e9100'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:2692
+#: C/goscaja.xml:2649
 msgid "<imageobject> <imagedata fileref=\"figures/caja_link_emblem.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Symbolic link emblem.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:2703
+#: C/goscaja.xml:2660
 msgid "<primary>symbolic links</primary><secondary>and emblems</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:2703
+#: C/goscaja.xml:2660
 msgid "<_:indexterm-1/>Symbolic link"
 msgstr ""
 
@@ -8531,13 +8510,13 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:2712
+#: C/goscaja.xml:2668
 msgctxt "_"
 msgid "external ref='figures/caja_nowrite_emblem.png' md5='06a5b7050d82e38d2f54048a1f698092'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:2710
+#: C/goscaja.xml:2666
 msgid "<imageobject> <imagedata fileref=\"figures/caja_nowrite_emblem.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>No write permission emblem.</phrase> </textobject>"
 msgstr ""
 
@@ -8546,1737 +8525,1735 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/goscaja.xml:2729
+#: C/goscaja.xml:2685
 msgctxt "_"
 msgid "external ref='figures/caja_noread_emblem.png' md5='e54419d1a042a072d0a56effcc13278a'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/goscaja.xml:2727
+#: C/goscaja.xml:2683
 msgid "<imageobject> <imagedata fileref=\"figures/caja_noread_emblem.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>No read permission emblem.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2746
+#. (itstool) path: info/title
+#: C/goscaja.xml:2701
 msgid "Changing the Icon for a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2747
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2703
 msgid "<primary>file manager</primary> <secondary>icons</secondary> <tertiary>changing</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2752
+#. (itstool) path: section/para
+#: C/goscaja.xml:2708
 msgid "To change the icon that represents an individual file or folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2756
+#: C/goscaja.xml:2712
 msgid "Select the file or folder that you want to change."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2762
+#: C/goscaja.xml:2718
 msgid "On the <guilabel>Basic</guilabel> tabbed section, click on the current <guibutton>Icon</guibutton>. A <guilabel>Select custom icon</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2767
+#: C/goscaja.xml:2723
 msgid "Use the <guilabel>Select custom icon</guilabel> dialog to choose the icon to represent the file or folder."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2775
+#. (itstool) path: section/para
+#: C/goscaja.xml:2730
 msgid "To restore an icon from a custom icon to the default icon, Select the file or folder that you want to change, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. click on the <guibutton>Icon</guibutton> button, in the <guilabel>Select custom icon</guilabel> dialog click <guibutton>Revert</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2781
+#. (itstool) path: info/title
+#: C/goscaja.xml:2736
 msgid "Adding an Emblem to a File or Folder"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2784
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2739
 msgid "<primary>emblems</primary> <secondary>adding to file</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2788
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2743
 msgid "<primary>emblems</primary> <secondary>adding to folder</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2792
+#. (itstool) path: section/para
+#: C/goscaja.xml:2747
 msgid "To add an emblem to an item perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2796
+#: C/goscaja.xml:2750
 msgid "Select the item to which you want to add an emblem."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2799
+#: C/goscaja.xml:2753
 msgid "Right-click on the item, then choose <guimenuitem>Properties</guimenuitem>. The <link linkend=\"caja-properties\">properties window</link> for the item is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2802
+#: C/goscaja.xml:2756
 msgid "Click on the <guilabel>Emblems</guilabel> tab to display the <guilabel>Emblems</guilabel> tabbed section."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2805
+#: C/goscaja.xml:2759
 msgid "Select the emblem to add to the item."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2812
+#. (itstool) path: section/para
+#: C/goscaja.xml:2765
 msgid "In browser windows you may also add emblems to items by dragging them from the emblem side pane."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2815
+#. (itstool) path: info/title
+#: C/goscaja.xml:2768
 msgid "Creating a New Emblem"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2816
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2770
 msgid "<primary>emblems</primary> <secondary>adding new</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2820
+#. (itstool) path: section/para
+#: C/goscaja.xml:2774
 msgid "To Create a new emblem, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2823
+#: C/goscaja.xml:2777
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Backgrounds and Emblems</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2826
+#: C/goscaja.xml:2780
 msgid "Click on the <guibutton>Emblem</guibutton> button, then click on the <guibutton>Add a New Emblem</guibutton> button. A <guilabel>Create a New Emblem</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2831
+#: C/goscaja.xml:2785
 msgid "Type a name for the emblem in the <guilabel>Keyword</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2835
+#: C/goscaja.xml:2788
 msgid "Click on the <guilabel>Image</guilabel> button. A dialog is displayed, click <guibutton>Browse</guibutton>. When you choose an emblem, click <guibutton>OK</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2840
+#: C/goscaja.xml:2793
 msgid "Click <guibutton>OK</guibutton> on the <guilabel>Create a New Emblem</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2846
+#. (itstool) path: info/title
+#: C/goscaja.xml:2799
 msgid "Changing Backgrounds"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2851
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2804
 msgid "<primary>file manager</primary> <secondary>changing backgrounds</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2855
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2808
 msgid "<primary>backgrounds</primary> <secondary>changing screen component</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2859
+#. (itstool) path: section/para
+#: C/goscaja.xml:2812
 msgid "The file manager includes background patterns and emblems that you can use to change the appearance of your folders. Background patterns and emblems can also be used on the desktop, on folders and certain side panes in the file browser, and on panels."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2863
+#. (itstool) path: section/para
+#: C/goscaja.xml:2816
 msgid "To change the background of a window, pane, or panel, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2867
+#: C/goscaja.xml:2820
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Backgrounds and Emblems</guimenuitem></menuchoice> in any file manager window. The <guilabel>Backgrounds and Emblems</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2871
+#: C/goscaja.xml:2824
 msgid "Click the <guibutton>Patterns</guibutton> button or the <guibutton>Colors</guibutton> button to see a list of background patterns or background colors you can use."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2875
+#: C/goscaja.xml:2828
 msgid "To change the background, drag a pattern or color to the desired window, pane, or panel. To reset the background, drag the <guilabel>Reset</guilabel> entry to the desired window, pane, or panel."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2881
+#. (itstool) path: section/para
+#: C/goscaja.xml:2834
 msgid "You can set the background of all folders in the file manager by dragging a pattern or color with your right or middle mouse button. When you release the drag, you will see a popup menu with the option to set the pattern or color as the background for all folders."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2885
+#. (itstool) path: section/para
+#: C/goscaja.xml:2838
 msgid "You can add a new pattern to the list by clicking the <guibutton>Add a New Pattern</guibutton> button when the patterns are selected. Locate an image file in the file chooser dialog and click <guibutton>Open</guibutton>. The image file will appear in the list of patterns you can use."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2889
+#. (itstool) path: section/para
+#: C/goscaja.xml:2842
 msgid "You can add a new color to the list by clicking the <guibutton>Add a New Color</guibutton> button when the colors are selected. Select a color in the color chooser dialog and click <guibutton>OK</guibutton>. The color will appear in the list of colors you can use."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:2897
+#. (itstool) path: info/title
+#: C/goscaja.xml:2849
 msgid "Using Removable Media"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:2900
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2853
 msgid "<primary>removable media</primary> <secondary>introduction</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:2904
+#. (itstool) path: section/para
+#: C/goscaja.xml:2857
 msgid "The file manager can initiate various actions when removable media appear, such as mounting it, opening a file manager window showing its contents, or running a suitable application that can handle it (for example a music player for an audio CD). See <xref linkend=\"goscaja-61\"/> for how to configure these actions for different media formats."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2912
+#. (itstool) path: info/title
+#: C/goscaja.xml:2865
 msgid "To Mount Media"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2913
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2866
 msgid "<primary>removable media</primary> <secondary>mounting</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2917
+#. (itstool) path: section/para
+#: C/goscaja.xml:2870
 msgid "To <firstterm>mount</firstterm> media is to make the file system of the media available for access. When you mount media, the file system of the media is attached as a subdirectory to your file system."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2920
+#. (itstool) path: section/para
+#: C/goscaja.xml:2873
 msgid "To mount media, insert the media in the appropriate device. An icon that represents the media is added to the desktop. The icon is added only if your system is configured to mount the device automatically when media is detected."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2924
+#. (itstool) path: section/para
+#: C/goscaja.xml:2877
 msgid "If your system is not configured to mount the device automatically, you must mount the device manually. Double-click on the <guilabel>Computer</guilabel> icon from the desktop. A <guilabel>Computer </guilabel> dialog is displayed. Double-click on the icon that represents the media. For example, to mount a floppy diskette, double-click on the <guilabel>Floppy</guilabel> icon. An icon that represents the media is added to the desktop."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:2930
+#: C/goscaja.xml:2883
 msgid "You cannot change the name of a removable media icon."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2934
+#. (itstool) path: info/title
+#: C/goscaja.xml:2887
 msgid "To Display Media Contents"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2935
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2888
 msgid "<primary>removable media</primary> <secondary>displaying media contents</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2939
+#. (itstool) path: section/para
+#: C/goscaja.xml:2892
 msgid "You can display media contents in any of the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2943
+#: C/goscaja.xml:2895
 msgid "Double-click on the icon that represents the media on the desktop."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2947
+#: C/goscaja.xml:2898
 msgid "Right-click on the icon that represents the media on the desktop, then choose <guimenuitem>Open</guimenuitem>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2951
+#. (itstool) path: section/para
+#: C/goscaja.xml:2902
 msgid "A file manager window displays the contents of the media. To reload the display, click on the <guibutton>Reload</guibutton> button."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2955
+#. (itstool) path: info/title
+#: C/goscaja.xml:2906
 msgid "To Display Media Properties"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2956
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2907
 msgid "<primary>removable media</primary> <secondary>displaying media properties</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2960
+#. (itstool) path: section/para
+#: C/goscaja.xml:2911
 msgid "To display the properties of removable media, right-click on the icon that represents the media on the desktop, then choose <guimenuitem>Properties</guimenuitem>. A dialog displays the properties of the media."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2962
+#. (itstool) path: section/para
+#: C/goscaja.xml:2913
 msgid "To close the properties dialog, click <guibutton>Close</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:2965
+#. (itstool) path: info/title
+#: C/goscaja.xml:2916
 msgid "To Eject Media"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:2966
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2917
 msgid "<primary>removable media</primary> <secondary>ejecting</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2970
+#. (itstool) path: section/para
+#: C/goscaja.xml:2921
 msgid "To eject media, right-click on the media icon on the desktop, then choose <guimenuitem>Eject</guimenuitem>. If the drive for the media is a motorized drive, the media is ejected from the drive. If the drive for the media is not motorized, wait until the desktop icon for the media disappears, then eject the media manually."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:2975
+#. (itstool) path: section/para
+#: C/goscaja.xml:2926
 msgid "You cannot eject media from a motorized drive when the media is mounted. To eject media, first unmount the media. For example, to remove a USB flash drive, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2979
+#: C/goscaja.xml:2930
 msgid "Close all file manager windows, <application>Terminal</application> windows, and any other windows that access the USB drive."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2983
+#: C/goscaja.xml:2934
 msgid "Right-click on the icon that represents the drive on the desktop, then choose <guimenuitem>Eject</guimenuitem>. The desktop icon for the drive disappears."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:2988
+#: C/goscaja.xml:2939
 msgid "Remove the USB flash drive."
 msgstr ""
 
 #. (itstool) path: caution/para
-#: C/goscaja.xml:2992
+#: C/goscaja.xml:2943
 msgid "You must unmount removable media before ejecting. Do not remove a USB flash drive before you unmount the flash drive. If you do not unmount the media first you might lose data."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:2997
+#. (itstool) path: info/title
+#: C/goscaja.xml:2948
 msgid "Writing CDs or DVDs"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:3000
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2952
 msgid "<primary>file manager</primary> <secondary>writing CDs</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:3004
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2956
 msgid "<primary>CDs, writing</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:3007
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2959
 msgid "<primary>writing CDs</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:3010
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:2962
 msgid "<primary>burning CDs</primary> <see>writing CDs</see>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:3014
+#. (itstool) path: section/para
+#: C/goscaja.xml:2966
 msgid "Writing to a CD or DVD may be useful for backing up your important documents. To do this, your computer must have a CD or DVD writer."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/goscaja.xml:3016
+#: C/goscaja.xml:2968
 msgid "A simple way to check what sort of CD or DVD drive your computer has is to choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Computer</guimenuitem></menuchoice> from the top panel menubar. If the icon for your CD drive has terms like \"CD-RW\" or \"DVD(+-)R\" in its label, then your computer is able to write discs."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:3018
+#. (itstool) path: section/para
+#: C/goscaja.xml:2970
 msgid "You can start choosing files to burn to a disc at any time. The file manager provides a special folder for files and folders that you wish to write to a CD or DVD. From there you can easily write all the content (which you place in this special folder) to a CD or DVD."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3022
+#. (itstool) path: info/title
+#: C/goscaja.xml:2973
 msgid "Creating Data Discs"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3023
+#. (itstool) path: section/para
+#: C/goscaja.xml:2975
 msgid "To write a CD or DVD, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3026
+#: C/goscaja.xml:2978
 msgid "Open <menuchoice><guimenu>Applications</guimenu><guimenu>System Tools</guimenu><guimenuitem>CD/DVD Creator</guimenuitem></menuchoice>. The file manager opens the CD/DVD Creator folder."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:3027
+#: C/goscaja.xml:2979
 msgid "In a File Browser window, the <guimenuitem>CD/DVD Creator</guimenuitem> item is available in the <guimenu>Go</guimenu> menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3030
+#: C/goscaja.xml:2982
 msgid "Drag the files and folders that you want to write to CD or DVD to the CD/DVD Creator folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3034
+#: C/goscaja.xml:2986
 msgid "Insert a writable CD or DVD into the CD/DVD writer device on your system."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3037
+#: C/goscaja.xml:2989
 msgid "Press the <guibutton>Write to Disc</guibutton> button, or choose <menuchoice><guimenu>File</guimenu><guimenuitem>Write to CD/DVD</guimenuitem></menuchoice>. A <guilabel>Write to Disc</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3040
+#: C/goscaja.xml:2992
 msgid "Use the <guilabel>Write to Disc</guilabel> dialog to specify how you want to write the CD, as follows:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3059
+#: C/goscaja.xml:3011
 msgid "<guilabel>Write disc to</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3064
+#: C/goscaja.xml:3016
 msgid "Select the device to which you want to write the CD from the drop-down list. To create an CD image file, select the <guilabel>File image</guilabel> option. A CD image file is a normal file that contains all the data in the same format as a CD, that you can write to a CD later."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3070
+#: C/goscaja.xml:3022
 msgid "<guilabel>Disc name</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3075
+#: C/goscaja.xml:3027
 msgid "Type a name for the CD in the text box."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3080
+#: C/goscaja.xml:3032
 msgid "<guilabel>Data size</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3085
+#: C/goscaja.xml:3037
 msgid "Shows the size of the data to be written to disc. The blank disk must be at least this size."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3091
+#: C/goscaja.xml:3043
 msgid "<guilabel>Write speed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3096
+#: C/goscaja.xml:3048
 msgid "Select the speed at which you want to write the CD from the drop-down list."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3105
+#: C/goscaja.xml:3057
 msgid "Click on the <guibutton>Write</guibutton> button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3106
+#: C/goscaja.xml:3058
 msgid "If you selected the <guilabel>File image</guilabel> option from the <guilabel>Target to write to</guilabel> drop-down list, a <guilabel>Choose a filename for the disc image</guilabel> dialog is displayed. Use the dialog to specify the location where you want to save the disc image file. By default, disc image files have a <filename>.iso</filename> file extension."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3110
+#: C/goscaja.xml:3062
 msgid "A <guilabel>Writing disc</guilabel> dialog is displayed. This process takes some time. When the disc is written or when the disc image file is created, a message to indicate that the process is complete is displayed in the dialog."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/goscaja.xml:3115
+#: C/goscaja.xml:3067
 msgid "You can set the CD/DVD Creator folder to open automatically when you insert a blank disc. See <xref linkend=\"goscaja-61\"/>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:3116
+#: C/goscaja.xml:3068
 msgid "The filesystem written to the CD will be readable with long filenames on all recent operating systems. Both the Joliet and the Rock Ridge CD-ROM filesystem extensions are used."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3119
+#. (itstool) path: info/title
+#: C/goscaja.xml:3071
 msgid "Copying CDs or DVDs"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3120
+#. (itstool) path: section/para
+#: C/goscaja.xml:3072
 msgid "You can create a copy of a CD or DVD, either to another disc or to an image file stored on your computer. To create a copy, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3122
+#: C/goscaja.xml:3074
 msgid "Insert the disc you want to copy."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3123
+#: C/goscaja.xml:3075
 msgid "Choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Computer</guimenuitem></menuchoice> from the top panel menubar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3124
+#: C/goscaja.xml:3076
 msgid "Right-click on the CD icon, and choose <guimenuitem>Copy Disc</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3125
+#: C/goscaja.xml:3077
 msgid "The <guilabel>Write to Disc</guilabel> dialog is displayed."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3127
+#. (itstool) path: section/para
+#: C/goscaja.xml:3079
 msgid "If you have only one drive with write capabilities, the process will first create a disc image file on your computer. It will then eject the original disk, and ask you to change it for a blank disk on which to write the copy."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/goscaja.xml:3128
+#: C/goscaja.xml:3080
 msgid "If you want to create more than one copy, choose the Image File option on the <guilabel>Write to Disc</guilabel> and then write the disc image: see <xref linkend=\"caja-cdwriter-writeimage\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3132
+#. (itstool) path: info/title
+#: C/goscaja.xml:3083
 msgid "Creating a Disc from an Image File"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3133
+#. (itstool) path: section/para
+#: C/goscaja.xml:3084
 msgid "You can write a disc image to a CD or DVD. For example, you may have downloaded a disc image from the internet, or previously created one yourself. Disc images usually have a <filename>.iso</filename> file extension and are sometimes called iso files."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3134
+#. (itstool) path: section/para
+#: C/goscaja.xml:3085
 msgid "To write a disc image, right-click on the disc image file, then choose <guimenuitem>Write to Disc</guimenuitem> from the popup menu."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:3139
+#. (itstool) path: info/title
+#: C/goscaja.xml:3089
 msgid "Navigating Remote Servers"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:3140
+#. (itstool) path: section/para
+#: C/goscaja.xml:3090
 msgid "The <application>Caja</application> file manager provides an integrated access point to your files, applications, FTP sites, Windows shares, WebDav servers and SSH servers."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3143
+#. (itstool) path: info/title
+#: C/goscaja.xml:3093
 msgid "To Access a remote server"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3149
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3100
 msgid "<primary>FTP sites</primary> <secondary>accessing</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3153
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3104
 msgid "<primary>file manager</primary> <secondary>FTP sites</secondary> <see>FTP sites</see>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3158
+#. (itstool) path: section/para
+#: C/goscaja.xml:3109
 msgid "You can use the file manager to access a remote server, be it an FTP site, a Windows share, a WebDav server or an SSH server."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3160
+#. (itstool) path: section/para
+#: C/goscaja.xml:3111
 msgid "To access a remote server, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Connect to Server</guimenuitem></menuchoice>. You may also access this dialog from the menubar by choosing <menuchoice><guimenu>Places</guimenu><guimenuitem>Connect to Server</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3162
+#. (itstool) path: section/para
+#: C/goscaja.xml:3113
 msgid "To connect to a remote server, start by choosing the service type, then enter the server address."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3163
+#. (itstool) path: section/para
+#: C/goscaja.xml:3114
 msgid "If required by your server, you may provide the following optional information :"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3181
+#: C/goscaja.xml:3132
 msgid "<guilabel>Port</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3186
+#: C/goscaja.xml:3137
 msgid "Port to connect to on the server. This should only be used if it is necessary to change the default port, you would normally leave this blank."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3192
+#: C/goscaja.xml:3143
 msgid "<guilabel>Folder</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3197
+#: C/goscaja.xml:3148
 msgid "Folder to open upon connecting to server."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3202
+#: C/goscaja.xml:3153
 msgid "<guilabel>User Name</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3207
+#: C/goscaja.xml:3158
 msgid "The user name of the account used to connect to the server. This should be supplied with the connection information if needed. The user name information is not appropriate for a public FTP connection."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3214
+#: C/goscaja.xml:3165
 msgid "<guilabel>Name to use for connection</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3219
+#: C/goscaja.xml:3170
 msgid "The designation of the connection as it will appear in the file manager."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3224
+#: C/goscaja.xml:3175
 msgid "<guilabel>Share</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3229
+#: C/goscaja.xml:3180
 msgid "Name of desired windows share. This is only applicable to Windows shares."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3234
+#: C/goscaja.xml:3185
 msgid "<guilabel>Domain name</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3239
+#: C/goscaja.xml:3190
 msgid "Windows domain. This is only applicable to Windows shares."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3245
+#. (itstool) path: section/para
+#: C/goscaja.xml:3196
 msgid "If the server information is provided in the form of a URI, or you require a specialized connection, choose <menuchoice><guimenuitem>Custom Location</guimenuitem></menuchoice> as the service type."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3246
+#. (itstool) path: section/para
+#: C/goscaja.xml:3197
 msgid "Once you have filled in the information, click on the <guibutton>Connect</guibutton> button. When the connection succeeds, the contents of the site are displayed and you may drag and drop files to and from the remote server."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3250
+#. (itstool) path: info/title
+#: C/goscaja.xml:3201
 msgid "To Access Network Places"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3256
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3208
 msgid "<primary>network places</primary> <secondary>accessing</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3260
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3212
 msgid "<primary>file manager</primary> <secondary>network places</secondary> <see>network places</see>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3265
+#. (itstool) path: section/para
+#: C/goscaja.xml:3217
 msgid "If your system is configured to access places on a network, you can use the file manager to access the network places."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3268
+#. (itstool) path: section/para
+#: C/goscaja.xml:3220
 msgid "To access network places, open the file manager and choose <menuchoice><guimenu>Places</guimenu><guimenuitem>Network Servers</guimenuitem></menuchoice>. A window opens that displays the network places that you can access. Double-click on the network that you want to access."
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:3270
+#: C/goscaja.xml:3222
 msgid "<primary>NFS servers</primary><see>Unix network</see>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3270
+#. (itstool) path: section/para
+#: C/goscaja.xml:3222
 msgid "<_:indexterm-1/>To access UNIX shares, double-click on the <guilabel>Unix Network (NFS) </guilabel> object. A list of the UNIX shares available to you is displayed in the file manager window."
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:3274
+#: C/goscaja.xml:3226
 msgid "<primary>Samba servers</primary><see>Windows network</see>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3274
+#. (itstool) path: section/para
+#: C/goscaja.xml:3226
 msgid "<_:indexterm-1/>To access Windows shares, double-click on the <guilabel>Windows Network (SMB) </guilabel> object. A list of the Windows shares available to you is displayed in the file manager window."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3280
+#. (itstool) path: info/title
+#: C/goscaja.xml:3232
 msgid "Accessing Special URI Locations"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3281
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3233
 msgid "<primary>special URI locations</primary> <secondary>accessing</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3285
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3237
 msgid "<primary>file manager</primary> <secondary>special URI locations</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3290
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3241
 msgid "<primary>URI, special</primary> <see>special URI locations</see>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3294
+#. (itstool) path: section/para
+#: C/goscaja.xml:3245
 msgid "Caja has certain special URI locations that enable you to access particular functions from the file manager."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3295
+#. (itstool) path: section/para
+#: C/goscaja.xml:3246
 msgid "These are intended for advanced users: in most cases, an easier method of accessing the function or location exists."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3296
+#. (itstool) path: section/para
+#: C/goscaja.xml:3247
 msgid "<xref linkend=\"goscaja-TBL-479\"/> lists the special URI locations that you can use with the file manager."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/goscaja.xml:3299
+#. (itstool) path: info/title
+#: C/goscaja.xml:3249
 msgid "Special URI Locations"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3306
+#: C/goscaja.xml:3256
 msgid "URI Location"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3316
+#: C/goscaja.xml:3266
 msgid "<command>burn:///</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3321
+#: C/goscaja.xml:3271
 msgid "This is a special location where you can copy files and folders that you want to write to a CD. From here you can write the contents of the location to a CD easily. See also <xref linkend=\"caja-cdwriter\"/>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3327
+#: C/goscaja.xml:3277
 msgid "<command>network:///</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3332
+#: C/goscaja.xml:3282
 msgid "Displays network locations to which you can connect, if your system is configured to access locations on a network. To access a network location, double-click on the network location. You can also use this URI to add network locations to your system. See also <xref linkend=\"caja-accessnetwork\"/>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:3348
+#. (itstool) path: info/title
+#: C/goscaja.xml:3295
 msgid "Caja Preferences"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:3355
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3303
 msgid "<primary>file manager</primary> <secondary>customizing</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:3359
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3307
 msgid "<primary>file manager</primary> <secondary>preferences</secondary> <tertiary>introduction</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:3364
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3312
 msgid "<primary>preferences, file manager</primary> <see>file manager preferences</see>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:3369
+#. (itstool) path: section/para
+#: C/goscaja.xml:3316
 msgid "Use the <guilabel>File Management Preferences</guilabel> dialog to customize the file manager to suit your requirements and preferences."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:3371
+#. (itstool) path: section/para
+#: C/goscaja.xml:3318
 msgid "To display the <guilabel>File Management Preferences</guilabel> dialog, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. You can also access this dialog directly from the top panel Menubar by choosing <menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisubmenu><guimenuitem>File Management</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:3373
+#. (itstool) path: section/para
+#: C/goscaja.xml:3320
 msgid "You can set preferences in the following categories:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3376
+#: C/goscaja.xml:3323
 msgid "The default settings for views."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3379
+#: C/goscaja.xml:3326
 msgid "The behavior of files and folders, executable text files, and Trash."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3383
+#: C/goscaja.xml:3329
 msgid "The information that is displayed in icon captions and the date format."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3386
+#: C/goscaja.xml:3332
 msgid "The columns that appear in the list view and their order."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3389
+#: C/goscaja.xml:3335
 msgid "Preview options to improve the performance of the file manager."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3392
+#: C/goscaja.xml:3338
 msgid "How removable media and connected devices are handled."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#. (itstool) path: table/title
-#: C/goscaja.xml:3396
-#: C/goscaja.xml:3411
+#. (itstool) path: info/title
+#: C/goscaja.xml:3342
+#: C/goscaja.xml:3356
 msgid "Views Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3397
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3343
 msgid "<primary>file manager</primary> <secondary>preferences</secondary> <tertiary>views</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3402
+#. (itstool) path: section/para
+#: C/goscaja.xml:3348
 msgid "You can specify a default view, and select sort options and display options. You can also specify default settings for icon views and list views."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3405
+#. (itstool) path: section/para
+#: C/goscaja.xml:3351
 msgid "To specify your default view settings, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. Click on the <guilabel>Views</guilabel> tab to display the <guilabel>Views</guilabel> tabbed section."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3408
+#. (itstool) path: section/para
+#: C/goscaja.xml:3354
 msgid "<xref linkend=\"goscaja-TBL-30\"/> lists the views preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3428
+#: C/goscaja.xml:3373
 msgid "<guilabel>View new folders using</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3433
+#: C/goscaja.xml:3378
 msgid "Select the default view for folders. When you open a folder, the folder is displayed in the view that you select. This can be the icon view, the list view, or the compact view, which is a variant of the icon view that is organized in columns rather than rows.."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3439
+#: C/goscaja.xml:3384
 msgid "<guilabel>Arrange items</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3444
+#: C/goscaja.xml:3389
 msgid "Select the characteristic by which you want to sort the items in folders that are displayed in this view."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3450
+#: C/goscaja.xml:3395
 msgid "<guilabel>Sort folders before files</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3455
+#: C/goscaja.xml:3400
 msgid "Select this option to list folders before files when you sort a folder."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3461
+#: C/goscaja.xml:3406
 msgid "<guilabel>Show hidden and backup files</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3467
+#: C/goscaja.xml:3411
 msgid "Select this option to display files that are normally not shown in folders. For more on hidden files, see <xref linkend=\"caja-hidden-files\"/>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3472
+#: C/goscaja.xml:3416
 msgid "<guilabel>Default zoom level</guilabel> in the Icon View, Compact View, or List View sections"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3477
+#: C/goscaja.xml:3421
 msgid "Select the default zoom level for folders that are displayed in this view. The zoom level specifies the size of items in a view."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3483
+#: C/goscaja.xml:3427
 msgid "<guilabel>Use compact layout</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3488
+#: C/goscaja.xml:3432
 msgid "Select this option to arrange the items in icon view so that the items in the folder are closer to each other."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3495
+#: C/goscaja.xml:3439
 msgid "<guilabel>Text beside icons</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3500
+#: C/goscaja.xml:3444
 msgid "Select this option to place the icon captions for items beside the icon rather than under the icon."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3506
+#: C/goscaja.xml:3450
 msgid "<guilabel>All columns have the same width</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3511
+#: C/goscaja.xml:3455
 msgid "Select this option to make all columns in a compact view have the same width."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3516
+#: C/goscaja.xml:3460
 msgid "<guilabel>Show only folders</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3521
+#: C/goscaja.xml:3465
 msgid "Select this option to display only folders in the <guilabel>Tree</guilabel> in the side pane."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3529
+#. (itstool) path: info/title
+#: C/goscaja.xml:3473
 msgid "Behavior Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3530
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3474
 msgid "<primary>file manager</primary> <secondary>preferences</secondary> <tertiary>behavior</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3535
+#. (itstool) path: section/para
+#: C/goscaja.xml:3479
 msgid "To set your preferences for files and folders, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. Click on the <guilabel>Behavior</guilabel> tab to display the <guilabel>Behavior</guilabel> tabbed section. You can set the following preferences:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3541
+#: C/goscaja.xml:3485
 msgid "<guilabel>Single click to open items</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3543
+#: C/goscaja.xml:3487
 msgid "Select this option to perform the default action for an item when you click on the item. When this option is selected, and you point to an item, the title of the item is underlined."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3549
+#: C/goscaja.xml:3493
 msgid "<guilabel>Double click to open items</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3551
+#: C/goscaja.xml:3495
 msgid "Select this option to perform the default action for an item when you double-click on the item."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3556
+#: C/goscaja.xml:3500
 msgid "<guilabel>Always open in browser windows</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3558
+#: C/goscaja.xml:3502
 msgid "Select this option to use <application>Caja</application> in browser mode rather than spatial mode. Selecting this lets you browse your files and folders in the same window, otherwise you will navigate your files and folders as objects."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3563
+#: C/goscaja.xml:3507
 msgid "<guilabel>Run executable text files when they are opened</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3565
+#: C/goscaja.xml:3509
 msgid "Select this option to run an text executable file when you choose the file. An executable text file is a text file that can execute, that is, a shell script."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3571
+#: C/goscaja.xml:3515
 msgid "<guilabel>View executable text files when they are opened</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3573
+#: C/goscaja.xml:3517
 msgid "Select this option to display the contents of an executable text file when you choose the executable text file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3578
+#: C/goscaja.xml:3522
 msgid "<guilabel>Ask each time</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3580
+#: C/goscaja.xml:3524
 msgid "Select this option to display a dialog when you choose an executable text file. The dialog asks whether you want to execute the file or display the file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3586
+#: C/goscaja.xml:3530
 msgid "<guilabel>Ask before emptying the Trash or deleting files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3588
+#: C/goscaja.xml:3532
 msgid "Select this option to display a confirmation message before <guilabel>Trash</guilabel> is emptied, or files are deleted. Leave this selected unless you have good reason not to."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/goscaja.xml:3592
+#: C/goscaja.xml:3536
 msgid "<guilabel>Include a Delete command that bypasses Trash</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3594
+#: C/goscaja.xml:3538
 msgid "Select this option to add a <guimenuitem>Delete</guimenuitem> menu item to the following menus:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3598
+#: C/goscaja.xml:3542
 msgid "The <guimenu>Edit</guimenu> menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3601
+#: C/goscaja.xml:3545
 msgid "The popup menu that is displayed when you right-click on a file, folder, or desktop object."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:3605
+#: C/goscaja.xml:3549
 msgid "When you select an item then choose the <guimenuitem>Delete</guimenuitem> menu item, the item is deleted from your file system immediately. There is no way to recover a deleted file. Do not select this unless you have good reason to."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3612
+#. (itstool) path: info/title
+#: C/goscaja.xml:3556
 msgid "Display Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3613
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3557
 msgid "<primary>file manager</primary> <secondary>icons</secondary> <tertiary>caption preferences</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3618
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3562
 msgid "<primary>file manager</primary> <secondary>preferences</secondary> <tertiary>icon captions</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3623
+#. (itstool) path: section/para
+#: C/goscaja.xml:3567
 msgid "An icon caption displays the name of a file or folder in an icon view. The icon caption also includes three additional items of information on the file or folder. The additional information is displayed after the file name. Normally only one item of information is visible, but when you zoom in on an icon, more of the information is displayed. You can modify what additional information is displayed in icon captions."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3629
+#. (itstool) path: section/para
+#: C/goscaja.xml:3573
 msgid "To set your preferences for icon captions, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. Click on the <guilabel>Display</guilabel> tab to display the <guilabel>Display</guilabel> tabbed section."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3631
+#. (itstool) path: section/para
+#: C/goscaja.xml:3575
 msgid "Select the items of information that you want to display in the icon caption from the three drop-down lists. Select the first item from the first drop-down list, select the second item from the second drop-down list, and so on. The following table describes the items of information that you can select:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3643
-#: C/goscaja.xml:3791
+#: C/goscaja.xml:3587
+#: C/goscaja.xml:3727
 msgid "Information"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3653
-#: C/goscaja.xml:3812
-#: C/gospanel.xml:188
-#: C/gospanel.xml:1435
+#: C/goscaja.xml:3597
+#: C/goscaja.xml:3747
+#: C/gospanel.xml:189
+#: C/gospanel.xml:1420
 msgid "<guilabel>Size</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3658
-#: C/goscaja.xml:3817
+#: C/goscaja.xml:3602
+#: C/goscaja.xml:3752
 msgid "Choose this option to display the size of the item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3664
-#: C/goscaja.xml:3823
+#: C/goscaja.xml:3607
+#: C/goscaja.xml:3757
 msgid "<guilabel>Type</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3669
+#: C/goscaja.xml:3612
 msgid "Choose this option to display the description of the MIME type of the item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3675
-#: C/goscaja.xml:3835
+#: C/goscaja.xml:3617
+#: C/goscaja.xml:3769
 msgid "<guilabel>Date Modified</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3680
-#: C/goscaja.xml:3840
+#: C/goscaja.xml:3622
+#: C/goscaja.xml:3774
 msgid "Choose this option to display the last modification date of the item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3686
-#: C/goscaja.xml:3846
+#: C/goscaja.xml:3627
+#: C/goscaja.xml:3779
 msgid "<guilabel>Date Accessed</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3691
-#: C/goscaja.xml:3851
+#: C/goscaja.xml:3632
+#: C/goscaja.xml:3784
 msgid "Choose this option to display the date that the item was last accessed."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3697
-#: C/goscaja.xml:3890
+#: C/goscaja.xml:3637
+#: C/goscaja.xml:3820
 msgid "<guilabel>Owner</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3702
-#: C/goscaja.xml:3895
+#: C/goscaja.xml:3642
+#: C/goscaja.xml:3825
 msgid "Choose this option to display the owner of the item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3708
-#: C/goscaja.xml:3857
+#: C/goscaja.xml:3647
+#: C/goscaja.xml:3789
 msgid "<guilabel>Group</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3713
-#: C/goscaja.xml:3862
+#: C/goscaja.xml:3652
+#: C/goscaja.xml:3794
 msgid "Choose this option to display the group to which the item belongs."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3719
-#: C/goscaja.xml:3901
+#: C/goscaja.xml:3657
+#: C/goscaja.xml:3830
 msgid "<guilabel>Permissions</guilabel>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:3724
-#: C/goscaja.xml:3906
+#: C/goscaja.xml:3662
+#: C/goscaja.xml:3835
 msgid "<primary>permissions</primary><secondary>displaying as characters</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3724
-#: C/goscaja.xml:3906
+#: C/goscaja.xml:3662
+#: C/goscaja.xml:3835
 msgid "<_:indexterm-1/>Choose this option to display the permissions of the item as three sets of three characters, for example <computeroutput>-rwxrw-r--</computeroutput>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3731
-#: C/goscaja.xml:3879
+#: C/goscaja.xml:3669
+#: C/goscaja.xml:3809
 msgid "<guilabel>Octal Permissions</guilabel>"
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/goscaja.xml:3736
-#: C/goscaja.xml:3884
+#: C/goscaja.xml:3674
+#: C/goscaja.xml:3814
 msgid "<primary>permissions</primary><secondary>displaying in octal notation</secondary>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3736
-#: C/goscaja.xml:3884
+#: C/goscaja.xml:3674
+#: C/goscaja.xml:3814
 msgid "<_:indexterm-1/>Choose this option to display the permissions of the item in octal notation, for example <computeroutput>764</computeroutput>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3742
+#: C/goscaja.xml:3680
 msgid "<guilabel>MIME Type</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3747
-#: C/goscaja.xml:3873
+#: C/goscaja.xml:3685
+#: C/goscaja.xml:3804
 msgid "Choose this option to display the MIME type of the item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3753
+#: C/goscaja.xml:3690
 msgid "<guilabel>None</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3758
+#: C/goscaja.xml:3695
 msgid "Choose this option to display no information for the item."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3765
+#. (itstool) path: section/para
+#: C/goscaja.xml:3701
 msgid "The date <guilabel>Format</guilabel> option lets you choose how the date is displayed throughout Caja."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:3770
+#. (itstool) path: info/title
+#: C/goscaja.xml:3706
 msgid "List Columns Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3771
+#. (itstool) path: section/para
+#: C/goscaja.xml:3707
 msgid "You can specify what information is displayed in list view in file manager windows. You can specify which columns are displayed in list view, and the order in which the columns are displayed."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3774
+#. (itstool) path: section/para
+#: C/goscaja.xml:3710
 msgid "To set your preferences for list columns, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. Click on the <guilabel>List Columns</guilabel> tab to display the <guilabel>List Columns</guilabel> tabbed section."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3776
+#. (itstool) path: section/para
+#: C/goscaja.xml:3712
 msgid "To specify a column to display in list view, select the option that corresponds to the column, then click on the <guibutton>Show</guibutton> button. To remove a column from the list view, select the option that corresponds to the column, then click on the <guibutton>Hide</guibutton> button."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3780
+#. (itstool) path: section/para
+#: C/goscaja.xml:3716
 msgid "Use the <guibutton>Move Up</guibutton> and <guibutton>Move Down</guibutton> buttons to specify the position of columns in list view."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3782
+#. (itstool) path: section/para
+#: C/goscaja.xml:3718
 msgid "To use the default columns and column positions, click on the <guibutton>Use Default</guibutton> button."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3783
+#. (itstool) path: section/para
+#: C/goscaja.xml:3719
 msgid "The following table describes the columns that you can display:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3806
+#: C/goscaja.xml:3742
 msgid "Choose this option to display the name of the item."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3828
+#: C/goscaja.xml:3762
 msgid "Choose this option to display the description of the MIME type of the item from the <application>File Types and Programs</application> preference tool."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3868
+#: C/goscaja.xml:3799
 msgid "<guilabel>MIME type</guilabel>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#. (itstool) path: table/title
-#: C/goscaja.xml:3916
-#: C/goscaja.xml:3982
-#: C/goscaja.xml:4137
+#. (itstool) path: info/title
+#: C/goscaja.xml:3845
+#: C/goscaja.xml:3910
+#: C/goscaja.xml:4062
 msgid "Preview Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/goscaja.xml:3917
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:3846
 msgid "<primary>file manager</primary> <secondary>preferences</secondary> <tertiary>preview</tertiary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3922
+#. (itstool) path: section/para
+#: C/goscaja.xml:3851
 msgid "The file manager include some file preview features. The preview features can affect the speed with which the file manager responds to your requests. You can modify the behavior of some of these features to improve the speed of the file manager. For each preview preference, you can select one of the options described in the following table:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3945
+#: C/goscaja.xml:3874
 msgid "<guilabel>Always</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3950
+#: C/goscaja.xml:3879
 msgid "Performs the action for both local files, and files on other file systems."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3956
+#: C/goscaja.xml:3885
 msgid "<guilabel>Local Files Only</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3961
+#: C/goscaja.xml:3890
 msgid "Performs the action for local files only."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3966
+#: C/goscaja.xml:3895
 msgid "<guilabel>Never</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3971
+#: C/goscaja.xml:3900
 msgid "Never performs the action."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3977
+#. (itstool) path: section/para
+#: C/goscaja.xml:3906
 msgid "To set your preview preferences, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. Click on the <guilabel>Preview</guilabel> tab dialog to display the <guilabel>Preview</guilabel> tabbed section."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:3979
+#. (itstool) path: section/para
+#: C/goscaja.xml:3908
 msgid "<xref linkend=\"goscaja-TBL-41\"/> lists the preview preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:3999
+#: C/goscaja.xml:3927
 msgid "<guilabel>Show text in icons</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4004
+#: C/goscaja.xml:3932
 msgid "Select an option to specify when to preview the content of text files in the icon that represents the file."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4010
+#: C/goscaja.xml:3938
 msgid "<guilabel>Show thumbnails</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4015
+#: C/goscaja.xml:3943
 msgid "Select an option to specify when to show thumbnails of image files. The file manager stores the thumbnail files for each folder in a <filename>.thumbnails</filename> directory in the user's Home Folder."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4023
+#: C/goscaja.xml:3951
 msgid "<guilabel>Only for files smaller than</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4028
+#: C/goscaja.xml:3956
 msgid "Specify the maximum file size for files for which the file manager creates a thumbnail."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4034
+#: C/goscaja.xml:3962
 msgid "<guilabel>Preview sound files</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4040
+#: C/goscaja.xml:3967
 msgid "Select an option to specify when to preview sound files."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4045
+#: C/goscaja.xml:3972
 msgid "<guilabel>Count number of items</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4050
+#: C/goscaja.xml:3977
 msgid "Select an option to specify when to show the number of items in folders. When in icon view, you might need to increase your zoom level to see the number of items in each folder."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:4060
+#. (itstool) path: info/title
+#: C/goscaja.xml:3987
 msgid "Media Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4061
+#. (itstool) path: section/para
+#: C/goscaja.xml:3988
 msgid "You can configure how <application>Caja</application> handles removable media and devices that are connected to the computer, such as music players or cameras. For each media format or device type, <application>Caja</application> offers to run one of the applications that are known to support this format, as well as the following options:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4086
+#: C/goscaja.xml:4013
 msgid "<guilabel>Ask what to do</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4091
+#: C/goscaja.xml:4018
 msgid "Make <application>Caja</application> ask for the desired action when the media or device appears."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4097
+#: C/goscaja.xml:4024
 msgid "<guilabel>Do Nothing</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4102
+#: C/goscaja.xml:4029
 msgid "Do nothing."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4107
+#: C/goscaja.xml:4034
 msgid "<guilabel>Open Folder</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4112
+#: C/goscaja.xml:4039
 msgid "Treat the media or device like an ordinary folder and open it in a <application>Caja</application> window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4118
+#: C/goscaja.xml:4045
 msgid "<guilabel>Open with other Application</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4123
+#: C/goscaja.xml:4050
 msgid "Select an application to run with the <application>Caja</application> application chooser dialog. Note that applications known to handle the media or device can be chosen directly from the drop-down list."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4132
+#. (itstool) path: section/para
+#: C/goscaja.xml:4059
 msgid "The most common media formats can be configured in the <guilabel>Media Handling</guilabel> section: audio CDs, video DVDs, music players, cameras, and software cds."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4133
+#. (itstool) path: section/para
+#: C/goscaja.xml:4060
 msgid "To configure the handling for other media formats, first select the format in the <guilabel>Type</guilabel> drop-down list, then select the desired handling for this format in the <guilabel>Action</guilabel> drop-down list."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4134
+#. (itstool) path: section/para
+#: C/goscaja.xml:4061
 msgid "<xref linkend=\"goscaja-TBL-43\"/> lists other media handling preferences that you can modify."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4154
+#: C/goscaja.xml:4079
 msgid "<guilabel>Never prompt or start programs on media insertion</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4159
+#: C/goscaja.xml:4084
 msgid "Select this option to prevent <application>Caja</application> from showing dialogs or running programs when media or devices appear. When this option is selected, the preferences for the handling of specific media formats are ignored."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4166
+#: C/goscaja.xml:4091
 msgid "<guilabel>Browse media when inserted</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4171
+#: C/goscaja.xml:4096
 msgid "When this option is selected, <application>Caja</application> will automatically open a folder when media is inserted. This only applies for media formats for which the handling has not been explicitly configured."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/goscaja.xml:4186
+#. (itstool) path: info/title
+#: C/goscaja.xml:4110
 msgid "Extending Caja"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:4187
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:4111
 msgid "<primary>file manager</primary> <secondary>running scripts</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/goscaja.xml:4191
+#. (itstool) path: section/indexterm
+#: C/goscaja.xml:4115
 msgid "<primary>scripts, running from file manager</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/goscaja.xml:4194
+#. (itstool) path: section/para
+#: C/goscaja.xml:4118
 msgid "Caja can be extended in two main ways. Through <application>Caja</application> extensions, and through scripts. This section explains the difference between the two and how to install."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:4196
+#. (itstool) path: info/title
+#: C/goscaja.xml:4120
 msgid "Caja Scripts"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4197
+#. (itstool) path: section/para
+#: C/goscaja.xml:4121
 msgid "Caja can run scripts. Scripts are typically simpler in operation than full <application>Caja</application> extensions and can be written in any scripted language capable of being executed on your computer. To run a script choose <menuchoice><guimenu>File</guimenu><guimenuitem>Scripts</guimenuitem></menuchoice>, then choose the script that you want to run from the submenu."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4198
+#. (itstool) path: section/para
+#: C/goscaja.xml:4122
 msgid "To run a script on a particular file, select the file in the view pane. Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Scripts</guimenuitem></menuchoice>, then choose the script that you want to run on the file from the submenu. You can also select multiple files to run your scripts on."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4201
+#. (itstool) path: section/para
+#: C/goscaja.xml:4125
 msgid "You may also access scripts from the context menu."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:4203
+#: C/goscaja.xml:4127
 msgid "If you do not have any scripts installed, the script menu will not appear."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:4206
+#. (itstool) path: info/title
+#: C/goscaja.xml:4130
 msgid "Installing File Manager Scripts"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:4207
+#. (itstool) path: section/para
+#: C/goscaja.xml:4131
 msgid "The file manager includes a special folder where you can store your scripts. All executable files in this folder will appear in the Scripts menu. The script folder is located at $HOME/.config/caja/scripts."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:4210
+#. (itstool) path: section/para
+#: C/goscaja.xml:4134
 msgid "To install a script, simply copy the script to the script folder and give it the user executable permission."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:4211
+#. (itstool) path: section/para
+#: C/goscaja.xml:4135
 msgid "To view the contents of your scripts folder, if you already have scripts installed, choose <menuchoice><guimenu>File</guimenu><guisubmenu>Scripts</guisubmenu><guimenuitem>Open Scripts Folder</guimenuitem></menuchoice>. You will have to navigate to the scripts folder with the file manager if you do not yet have any scripts. You may need to show hidden files for this, use <menuchoice><guimenu>View</guimenu><guimenuitem>Show Hidden Files</guimenuitem></menuchoice>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:4213
-msgid "A good source to download <application>Caja</application> scripts is from the <ulink url=\"http://g-scripts.sourceforge.net\"><citetitle>G-Scripts website</citetitle></ulink>."
+#. (itstool) path: section/para
+#: C/goscaja.xml:4137
+msgid "A good source to download <application>Caja</application> scripts is from the <link xlink:href=\"http://g-scripts.sourceforge.net\"><citetitle>G-Scripts website</citetitle></link>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/goscaja.xml:4216
+#. (itstool) path: info/title
+#: C/goscaja.xml:4140
 msgid "Writing File Manager Scripts"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:4217
+#. (itstool) path: section/para
+#: C/goscaja.xml:4141
 msgid "When executed from a local folder, scripts will be passed the selected file names. When executed from a remote folder (e.g. a folder showing web or ftp content), scripts will be passed no parameters."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/goscaja.xml:4219
+#. (itstool) path: section/para
+#: C/goscaja.xml:4143
 msgid "The following table shows variables passed to the script :"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4227
+#: C/goscaja.xml:4151
 msgid "Environment variable"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4237
+#: C/goscaja.xml:4161
 msgid "<guilabel>CAJA_SCRIPT_SELECTED_FILE_PATHS</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4242
+#: C/goscaja.xml:4166
 msgid "newline-delimited paths for selected files (only if local)"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4247
+#: C/goscaja.xml:4171
 msgid "<guilabel>CAJA_SCRIPT_SELECTED_URIS</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4252
+#: C/goscaja.xml:4176
 msgid "newline-delimited URIs for selected files"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4257
+#: C/goscaja.xml:4181
 msgid "<guilabel>CAJA_SCRIPT_CURRENT_URI</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4262
+#: C/goscaja.xml:4186
 msgid "URI for current location"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4267
+#: C/goscaja.xml:4191
 msgid "<guilabel>CAJA_SCRIPT_WINDOW_GEOMETRY</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/goscaja.xml:4272
+#: C/goscaja.xml:4196
 msgid "position and size of current window"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/goscaja.xml:4281
+#. (itstool) path: info/title
+#: C/goscaja.xml:4205
 msgid "Caja Extensions"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4282
+#. (itstool) path: section/para
+#: C/goscaja.xml:4206
 msgid "<application>Caja</application> extensions are far more powerful than <application>Caja</application> scripts, allowing more freedom where and how they extend <application>Caja</application>. <application>Caja</application> extensions are typically installed by your system administrator."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:4286
+#: C/goscaja.xml:4210
 msgid "caja-actions"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:4287
+#: C/goscaja.xml:4211
 msgid "This extension allows you to easily assign actions based on file type"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:4290
+#: C/goscaja.xml:4214
 msgid "caja-send-to"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:4291
+#: C/goscaja.xml:4215
 msgid "This extension provides a simple way to send a file or folder to another using email, instant messaging, or Bluetooth."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:4294
+#: C/goscaja.xml:4218
 msgid "caja-open-terminal."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/goscaja.xml:4295
+#: C/goscaja.xml:4219
 msgid "This extension provides an easy way to open a terminal at the selected starting location."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/goscaja.xml:4283
+#. (itstool) path: section/para
+#: C/goscaja.xml:4207
 msgid "Some popular <application>Caja</application> extensions include: <_:orderedlist-1/>"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/goscaja.xml:4300
+#: C/goscaja.xml:4224
 msgid "If you are looking for the <guilabel>Open Terminal</guilabel> command which used to exist in the <application>Caja</application> right click menu by default then you should install the <application>caja-open-terminal</application> extension."
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/gosoverview.xml:3
+#. (itstool) path: info/title
+#: C/gosoverview.xml:6
 msgid "Desktop Overview"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/gosoverview.xml:20
+#: C/gosoverview.xml:22
 msgid "This chapter introduces you to some of the very basic components of the desktop. These components include <glossterm>Windows</glossterm>, <glossterm>Workspaces</glossterm>, and <glossterm>Applications</glossterm>. Almost all the work (or play) that you do in MATE will involve these very basic components."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosoverview.xml:23
+#: C/gosoverview.xml:25
 msgid "This chapter describes the default configuration of MATE. Your vendor or system administrator may have configured your desktop to look different from what is described here."
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosoverview.xml:35
+#: C/gosoverview.xml:36
 msgid "<primary>MATE Desktop components, introducing</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:39
+#: C/gosoverview.xml:40
 msgid "When you start a desktop session for the first time, you should see a default startup screen, with panels, windows, and various icons."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:43
+#: C/gosoverview.xml:44
 msgid "The major components of the MATE Desktop are as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:48
+#: C/gosoverview.xml:49
 msgid "The desktop itself is behind all the other components on the desktop. You can place objects on the desktop to access your files and directories quickly, or to start applications that you use often. See <xref linkend=\"overview-desktop\"/> for more information."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:54
+#: C/gosoverview.xml:55
 msgid "Panels"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:55
+#: C/gosoverview.xml:56
 msgid "The <firstterm>panels</firstterm> are the two bars that run along the top and bottom of the screen. By default, the top panel shows you the MATE main menu bar, the date and time, and a set of application launcher icons, and the bottom panel shows you the list of open windows and the workspace switcher."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:56
+#: C/gosoverview.xml:57
 msgid "Panels can be customized to contain a variety of tools, such as other menus and launchers, and small utility applications, called <firstterm>panel applets</firstterm>. For example, you can configure your panel to display the current weather for your location. For more information on panels, see <xref linkend=\"panels\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#. (itstool) path: section/title
-#: C/gosoverview.xml:63
-#: C/gosoverview.xml:138
+#. (itstool) path: info/title
+#: C/gosoverview.xml:64
+#: C/gosoverview.xml:137
 msgid "Windows"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:64
+#: C/gosoverview.xml:65
 msgid "Most applications run inside of one or more windows. You can display multiple windows on your desktop at the same time. Windows can be resized and moved around to accommodate your workflow. Each window has a <firstterm>titlebar</firstterm> at the top with buttons which allow you to minimize, maximize, and close the window. For more information on working with windows, see <xref linkend=\"overview-windows\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#. (itstool) path: section/title
-#: C/gosoverview.xml:74
-#: C/gosoverview.xml:332
+#. (itstool) path: info/title
+#: C/gosoverview.xml:75
+#: C/gosoverview.xml:326
 msgid "Workspaces"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:75
+#: C/gosoverview.xml:76
 msgid "You can subdivide your desktop into separate <firstterm>workspaces</firstterm>. Each workspace can contain several windows, allowing you to group related tasks together. For more information on working with workspaces, see <xref linkend=\"overview-workspaces\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:83
+#: C/gosoverview.xml:84
 msgid "File Manager"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:84
+#: C/gosoverview.xml:85
 msgid "The <application>Caja</application> file manager provides access to your files, folders, and applications. You can manage the contents of folders in the file manager and open the files in the appropriate applications. See <xref linkend=\"caja\"/> for more information."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:92
+#: C/gosoverview.xml:93
 msgid "Control Center"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:93
+#: C/gosoverview.xml:94
 msgid "You can customize your computer using the <application>Control Center</application>, which can be found in the <guimenu>System</guimenu> menu on the top panel menubar. Each preference tool in the Control Center allows you to change a particular part of the behavior of your computer. See <xref linkend=\"prefs\"/> for more information on the Control Center."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:103
+#: C/gosoverview.xml:104
 msgid "Your vendor or system administrator can make configuration changes to suit your needs, so your desktop might not match exactly what is described in this manual. Nevertheless, this manual provides a useful introduction to using the various components of your desktop."
 msgstr ""
 
-#. (itstool) path: section/title
+#. (itstool) path: info/title
 #: C/gosoverview.xml:110
 msgid "The Desktop"
 msgstr ""
@@ -10291,19 +10268,34 @@ msgstr ""
 msgid "The desktop also has several special objects on it:"
 msgstr ""
 
+#. (itstool) path: para/interface
+#: C/gosoverview.xml:116
+msgid "Computer"
+msgstr ""
+
 #. (itstool) path: listitem/para
 #: C/gosoverview.xml:116
-msgid "The <interface>Computer</interface> icon gives you access to CDs, removable media such as floppy disks, and also the entire filesystem (also known as the root filesystem). By default, you do not have the security permissions to read other users' files or edit system files, but you may need to do so something such as configure a web server on the computer."
+msgid "The <_:interface-1/> icon gives you access to CDs, removable media such as floppy disks, and also the entire filesystem (also known as the root filesystem). By default, you do not have the security permissions to read other users' files or edit system files, but you may need to do so something such as configure a web server on the computer."
+msgstr ""
+
+#. (itstool) path: para/interface
+#: C/gosoverview.xml:117
+msgid "<replaceable>username</replaceable>'s Home"
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/gosoverview.xml:117
-msgid "Your Home Folder, labeled <interface><replaceable>username</replaceable>'s Home</interface>, where all of your personal files are kept. You can also open this folder from the <guimenu>Places</guimenu> menu."
+msgid "Your Home Folder, labeled <_:interface-1/>, where all of your personal files are kept. You can also open this folder from the <guimenu>Places</guimenu> menu."
+msgstr ""
+
+#. (itstool) path: para/interface
+#: C/gosoverview.xml:118
+msgid "Trash"
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/gosoverview.xml:118
-msgid "The <interface>Trash</interface> is a special folder in which to place files and folders you no longer need. For more on this, see <xref linkend=\"caja-trash\"/>."
+msgid "The <_:interface-1/> is a special folder in which to place files and folders you no longer need. For more on this, see <xref linkend=\"caja-trash\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
@@ -10342,102 +10334,102 @@ msgid "The files and folders you put on the desktop are stored in a special fold
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosoverview.xml:143
+#: C/gosoverview.xml:142
 msgid "<primary>windows</primary> <secondary>overview</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:148
+#: C/gosoverview.xml:147
 msgid "A <firstterm>window</firstterm> is a rectangular area of the screen, usually with a border all around and a title bar at the top. You can think of a window as a screen within the screen. Each window displays an application, allowing you to have more than one application visible, and work on more than one task at a time. You can also think of windows as pieces of paper on your desktop: they can overlap, or be side by side, for example."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:150
+#: C/gosoverview.xml:149
 msgid "You can control a window's position of the screen, as well as its size. You can control which windows overlap other windows, so the one you want to work with is completely visible. For more about moving and resizing windows, see <xref linkend=\"windows-manipulating\"/>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:152
+#: C/gosoverview.xml:151
 msgid "Each window is not necessarily a different application. An application usually has one main window, and may open additional windows at the request of the user."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:154
+#: C/gosoverview.xml:153
 msgid "The rest of this section describes the different types of windows and how you can interact with them."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:158
+#. (itstool) path: info/title
+#: C/gosoverview.xml:156
 msgid "Types of Windows"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:163
+#: C/gosoverview.xml:160
 msgid "There are two main types of window:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:167
+#: C/gosoverview.xml:164
 msgid "Application windows"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:169
+#: C/gosoverview.xml:166
 msgid "Application windows allow all minimize, maximize and close operations through the buttons on the titlebar. When opening an application you will usually see a window of this type appear."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:176
+#: C/gosoverview.xml:173
 msgid "Dialog windows"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:178
+#: C/gosoverview.xml:175
 msgid "Dialog windows appear at the request of an application window. A dialog window may alert you to a problem, ask for confirmation of an action, or request input from you."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:180
+#: C/gosoverview.xml:177
 msgid "For example, if you tell an application to save a document, a dialog will ask you where you want to save the new file. If you tell an application to quit while it is still busy, it may ask you to confirm that you want it to abandon work in progress."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:182
+#: C/gosoverview.xml:179
 msgid "Some dialogs do not allow you to interact with the main application window until you have closed them: these are called <firstterm>modal</firstterm> dialogs. Others can be left open while you work with the main application window: these are called <firstterm>transient</firstterm> dialogs."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosoverview.xml:184
+#: C/gosoverview.xml:181
 msgid "You can select the text in a dialog with the mouse. This allows you to copy it to the clipboard (by right-clicking the text and selecting <guilabel>Copy</guilabel>), and paste it into another application. This is useful if you wish to quote the text you see in a dialog when requesting support on the Internet."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:192
+#. (itstool) path: info/title
+#: C/gosoverview.xml:187
 msgid "Manipulating Windows"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:197
+#: C/gosoverview.xml:192
 msgid "You can change the size and position of windows on the screen. This allows you to see more than one application and do different tasks at the same time. For example, you might want to read text on a web page while writing with a word processor, or to change to another application to do a different task or check its progress."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:199
+#: C/gosoverview.xml:194
 msgid "You can <firstterm>minimize</firstterm> a window if you are not currently interested in seeing it. This hides it from view. You can <firstterm>maximize</firstterm> a window to fill the whole screen so you can give it your full attention."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:201
-msgid "<anchor id=\"gosoverview-FIG-33\"/>Most of these actions are carried out by using the mouse on different parts of the window's frame (see <xref linkend=\"mouse-actions\"/> for a recap of using the mouse). The top edge of the window frame, called the <firstterm>titlebar</firstterm> because it also displays the title of the window, contains several buttons that change the way the window is displayed."
+#: C/gosoverview.xml:196
+msgid "<anchor xml:id=\"gosoverview-FIG-33\"/>Most of these actions are carried out by using the mouse on different parts of the window's frame (see <xref linkend=\"mouse-actions\"/> for a recap of using the mouse). The top edge of the window frame, called the <firstterm>titlebar</firstterm> because it also displays the title of the window, contains several buttons that change the way the window is displayed."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:202
+#: C/gosoverview.xml:197
 msgid "<xref linkend=\"fig-titlebar-anno-window\"/> shows the titlebar for a typical application window. From left to right, this contains the Window Menu button, the window title, the minimize button, the maximize button, and the close button."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gosoverview.xml:205
+#. (itstool) path: info/title
+#: C/gosoverview.xml:199
 msgid "Titlebar for a Typical Application Window"
 msgstr ""
 
@@ -10446,198 +10438,198 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosoverview.xml:209
+#: C/gosoverview.xml:204
 msgctxt "_"
 msgid "external ref='figures/titlebar_window.png' md5='b3624c3e2eeb934a16ff5689c8163f44'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gosoverview.xml:207
+#: C/gosoverview.xml:202
 msgid "<imageobject> <imagedata fileref=\"figures/titlebar_window.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Titlebar of application window frame.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:218
+#: C/gosoverview.xml:213
 msgid "All actions can also be carried out from the Window Menu. To open this, click on the Window Menu button at the left-hand edge of the titlebar. Common actions can also be carried out with keyboard shortcuts: see <xref linkend=\"shortcuts-window\"/> for a simple list of these. The following lists the actions you can carry out on a window, with the mouse or the keyboard:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:222
+#: C/gosoverview.xml:217
 msgid "Move the window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:224
+#: C/gosoverview.xml:219
 msgid "Drag the titlebar to move the window. You can click on any part of the titlebar except the buttons at either end to begin the drag action. The window will move on the screen as you drag the mouse. On less powerful computers, the movement of the window may be represented by moving an outline of its frame."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:226
+#: C/gosoverview.xml:221
 msgid "You can also choose Move from the Window Menu, or press <keycombo> <keycap>Alt</keycap><keycap>F7</keycap></keycombo>, and then either move the mouse or press the keyboard arrow keys to move the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:229
+#: C/gosoverview.xml:224
 msgid "You can also press-and-hold <keycap>Alt</keycap> and drag any part of the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:231
+#: C/gosoverview.xml:226
 msgid "As you move the window, some parts of the screen will give slight resistance to movement. This is to help you align windows more easily to the edges of the desktop, the panels, and the edges of other windows."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:233
+#: C/gosoverview.xml:228
 msgid "You can also press-and-hold <keycap>Shift</keycap> while you move the window to cause it to only move between the corners of the desktop and other windows."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosoverview.xml:235
+#: C/gosoverview.xml:230
 msgid "If the <keycap>Num Lock</keycap> key is off, you can use the arrows on the numeric keypad, as well as the <keycap>7</keycap>, <keycap>9</keycap>, <keycap>1</keycap>, and <keycap>3</keycap> keys to move diagonally."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:239
+#: C/gosoverview.xml:234
 msgid "Resize the window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:241
+#: C/gosoverview.xml:236
 msgid "Drag one of the borders to expand or contract the window on that side. Drag a corner to change two sides at once. The <link linkend=\"mouse-pointers\">resize pointer</link> appears when your mouse is in the correct position to begin the drag action."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:243
+#: C/gosoverview.xml:238
 msgid "You can also choose Resize from the Window Menu, or press <keycombo> <keycap>Alt</keycap><keycap>F8</keycap></keycombo>. The resize pointer appears. Move the mouse in the direction of the edge you want to resize, or press one of the keyboard arrows keys. The pointer changes to indicate the chosen edge. Now you can use the mouse or the arrow keys to move this edge of the window. Click the mouse or press <keycap>Return</keycap> to accept the change. Press <keycap>Escape</keycap> to cancel the resize action and return the window to its original size and shape."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:248
+#: C/gosoverview.xml:243
 msgid "Minimize the window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:250
+#: C/gosoverview.xml:245
 msgid "Click on the Minimize button in the titlebar, the leftmost of the group of three on the right. This removes the window from view. The window can be restored to its previous position and size on the screen from the <firstterm>window list</firstterm> on the <link linkend=\"gospanel-3\">bottom edge panel</link> or the <firstterm>window selector</firstterm> in the top panel."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:252
+#: C/gosoverview.xml:247
 msgid "You can also choose Minimize from the Window Menu, or press <keycombo> <keycap>Alt</keycap><keycap>F9</keycap> </keycombo>."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosoverview.xml:257
+#: C/gosoverview.xml:252
 msgid "A minimized window is shown in the window list and the window selector with [ ] around its title."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:263
+#: C/gosoverview.xml:258
 msgid "Maximize the window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:265
+#: C/gosoverview.xml:260
 msgid "Click on the Maximize button in the titlebar, the middle of the group of three on the right. This expands the window so it fills the screen (the panels remain visible)."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:266
+#: C/gosoverview.xml:261
 msgid "You can also choose Maximize from the Window Menu, or press <keycombo> <keycap>Alt</keycap><keycap>F10</keycap></keycombo>, or double-click any part of the titlebar except the buttons at either end."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosoverview.xml:270
+#: C/gosoverview.xml:265
 msgid "If you prefer, you can assign the double-click action to <firstterm>roll up</firstterm> the window: see <xref linkend=\"prefs-windows\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:275
+#: C/gosoverview.xml:270
 msgid "Unmaximize the window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:277
+#: C/gosoverview.xml:272
 msgid "When a window is maximized, click again on the Maximize button to restore it to its previous position and size on the screen."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:279
+#: C/gosoverview.xml:274
 msgid "You can also choose Unmaximize from the Window Menu, press <keycombo> <keycap>Alt</keycap><keycap>F5</keycap></keycombo>, or double-click any part of the titlebar except the buttons at either end."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosoverview.xml:284
+#: C/gosoverview.xml:279
 msgid "Close the window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:286
+#: C/gosoverview.xml:281
 msgid "Click the Close button, the rightmost of the group of three on the right. Closing the window may also close the application itself. The application will ask you to confirm closing a window that contains unsaved work."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:296
+#. (itstool) path: info/title
+#: C/gosoverview.xml:290
 msgid "Giving Focus to a Window"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:299
+#: C/gosoverview.xml:293
 msgid "To work with an application, you need to give the <firstterm>focus</firstterm> to its window. When a window has focus, any actions such as mouse clicks, typing text, or keyboard shortcuts, are directed to the application in that window. Only one window can have focus at a time. The window that has focus will appear on top of other windows, so nothing covers any part of it. It may also have a different appearance from other windows, depending on your choice of <xref linkend=\"prefs-theme\"/>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:300
+#: C/gosoverview.xml:294
 msgid "You can give the focus to a window in any of the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:303
+#: C/gosoverview.xml:297
 msgid "With the mouse, click on any part of the window, if the window is visible."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:308
+#: C/gosoverview.xml:302
 msgid "On the bottom panel, click on the <guibutton>window list button</guibutton> that represents the window in the <application>Window List</application>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:313
+#: C/gosoverview.xml:307
 msgid "On the top panel, click the <guibutton>window list icon</guibutton> and choose the window you want to switch to from the list. The <guibutton>window list icon</guibutton> is at the extreme right of the panel, and its icon matches that of the current window's <guibutton>Window Menu button</guibutton>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosoverview.xml:316
+#: C/gosoverview.xml:310
 msgid "If the window you choose is on a different workspace, you will be switched to that workspace. For more on workspaces, see <xref linkend=\"overview-workspaces\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:321
+#: C/gosoverview.xml:315
 msgid "With the keyboard, hold the <keycap>Alt</keycap> key and press the <keycap>Tab</keycap> key. A pop-up window appears with a list of icons representing each window. While still holding <keycap>Alt</keycap>, press <keycap>Tab</keycap> to move the selection along the list: a black rectangle frames the selected icon and the position of the window it corresponds to is highlighted with a black border. When the window you want to see is selected, release the <keycap>Alt</keycap> key. Using <keycombo><keycap>Shift</keycap><keycap>Tab</keycap></keycombo> instead of just <keycap>Tab</keycap> cycles through the icons in reverse order."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosoverview.xml:324
+#: C/gosoverview.xml:318
 msgid "You can customize the shortcut used to perform this action with the <link linkend=\"prefs-keyboard-shortcuts\">Keyboard Shortcuts preference tool</link>."
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosoverview.xml:337
+#: C/gosoverview.xml:330
 msgid "<primary>workspaces</primary> <secondary>overview</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:341
+#: C/gosoverview.xml:334
 msgid "Workspaces allow you to manage which windows are on your screen. You can imagine workspaces as being virtual screens, which you can switch between at any time. Every workspace contains the same desktop, the same panels, and the same menus. However, you can run different applications, and open different windows in each workspace. The applications in each workspace will remain there when you switch to other workspaces."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:343
+#: C/gosoverview.xml:336
 msgid "By default, four workspaces are available. You can switch between them with the <application>Workspace Switcher</application> applet at the right of the <link linkend=\"bottom-panel\">bottom panel</link>. This shows a representation of your workspaces, by default a row of four rectangles. Click on one to switch to that workspace. In <xref linkend=\"gosoverview-FIG-42\"/>, <application>Workspace Switcher</application> contains four workspaces. The first three workspaces contain open windows. The last workspace does not contain currently open windows. The currently active workspace is highlighted."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gosoverview.xml:346
+#. (itstool) path: info/title
+#: C/gosoverview.xml:338
 msgid "Workspaces Displayed in Workspace Switcher"
 msgstr ""
 
@@ -10646,765 +10638,765 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosoverview.xml:350
+#: C/gosoverview.xml:342
 msgctxt "_"
 msgid "external ref='figures/workspace_switcher_applet.png' md5='00b75c538008ce6d01801ae2eb907af9'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gosoverview.xml:348
+#: C/gosoverview.xml:340
 msgid "<imageobject> <imagedata fileref=\"figures/workspace_switcher_applet.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Workspace Switcher. The context describes the graphic.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:359
+#: C/gosoverview.xml:351
 msgid "Each workspace can have any number of applications open in it. The number of workspaces can be customized: see <xref linkend=\"workspace-add\"/>."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosoverview.xml:361
+#: C/gosoverview.xml:353
 msgid "Workspaces enable you to organize the MATE Desktop when you run many applications at the same time. One way to use workspaces is to allocate a specific function to each workspace: one for email, one for web browsing, one for graphic design, etc. However, everyone has their own preference and you are in no way restricted to only using workspaces like this."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:365
+#. (itstool) path: info/title
+#: C/gosoverview.xml:356
 msgid "Switching Between Workspaces"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosoverview.xml:366
+#: C/gosoverview.xml:357
 msgid "<primary>workspaces</primary> <secondary>switching between</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:370
+#: C/gosoverview.xml:361
 msgid "You can switch between workspaces in any of the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:373
+#: C/gosoverview.xml:364
 msgid "In the <application>Workspace Switcher</application> applet in the bottom panel, click on the workspace where you want to work."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:376
+#: C/gosoverview.xml:367
 msgid "Move the mouse pointer over the <application>Workspace Switcher</application> applet in the bottom panel, and scroll the mouse wheel."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:379
+#: C/gosoverview.xml:370
 msgid "Press <keycombo><keycap>Ctrl</keycap><keycap>Alt</keycap><keycap>right arrow</keycap></keycombo> to switch to the workspace on the right of the current workspace."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:383
+#: C/gosoverview.xml:374
 msgid "Press <keycombo><keycap>Ctrl</keycap><keycap>Alt</keycap><keycap>left arrow</keycap></keycombo> to switch to the workspace on the left of the current workspace."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosoverview.xml:387
+#: C/gosoverview.xml:378
 msgid "The arrow shortcut keys work according to how your workspaces are set out in the <application>Workspace Switcher</application> applet. If you change your panel so workspaces are displayed vertically instead of horizontally, use <keycombo><keycap>Ctrl</keycap><keycap>Alt</keycap><keycap>up arrow</keycap></keycombo> and <keycombo><keycap>Ctrl</keycap><keycap>Alt</keycap><keycap>down arrow</keycap></keycombo> to switch workspaces."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:390
+#. (itstool) path: info/title
+#: C/gosoverview.xml:380
 msgid "Adding Workspaces"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosoverview.xml:393
+#: C/gosoverview.xml:384
 msgid "<primary>workspaces</primary> <secondary>specifying number of</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:397
+#: C/gosoverview.xml:388
 msgid "To add workspaces to the MATE Desktop, right-click on the <application>Workspace Switcher</application> applet, then choose <guimenuitem>Preferences</guimenuitem>. The <guilabel>Workspace Switcher Preferences</guilabel> dialog is displayed. Use the <guilabel>Number of workspaces</guilabel> spin box to specify the number of workspaces that you require."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:404
+#. (itstool) path: info/title
+#: C/gosoverview.xml:394
 msgid "Applications"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gosoverview.xml:407
+#: C/gosoverview.xml:398
 msgid "<primary>applications</primary> <secondary>overview</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:412
+#: C/gosoverview.xml:403
 msgid "An <firstterm>application</firstterm> is a type of computer program that allows you to perform a particular task. You might use applications to create text documents such as letters or reports; to work with spreadsheets; to listen to your favorite music; to navigate the Internet; or to create, edit, or view images and videos. For each of these tasks, you would use a different application."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:414
+#: C/gosoverview.xml:405
 msgid "To launch an application, open the <guimenu>Applications</guimenu> menu and choose the application you want from the submenus. For more on this, see <xref linkend=\"applications-menu\"/>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:416
+#: C/gosoverview.xml:407
 msgid "The applications that are part of MATE include the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:419
-msgid "<ulink type=\"help\" url=\"help:pluma\"><application>Pluma Text Editor</application></ulink> can read, create, or modify any kind of simple text without any formatting."
+#: C/gosoverview.xml:410
+msgid "<link xlink:href=\"help:pluma\" type=\"help\"><application>Pluma Text Editor</application></link> can read, create, or modify any kind of simple text without any formatting."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:420
-msgid "<ulink type=\"help\" url=\"help:mate-dictionary\"><application>Dictionary</application></ulink> allows you to look up definitions of a word."
+#: C/gosoverview.xml:411
+msgid "<link xlink:href=\"help:mate-dictionary\" type=\"help\"><application>Dictionary</application></link> allows you to look up definitions of a word."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:421
-msgid "<ulink type=\"help\" url=\"help:eom\"><application>Image Viewer</application></ulink> can display single image files, as well as large image collections."
+#: C/gosoverview.xml:412
+msgid "<link xlink:href=\"help:eom\" type=\"help\"><application>Image Viewer</application></link> can display single image files, as well as large image collections."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:422
-msgid "<ulink type=\"help\" url=\"help:gucharmap\"><application>Character Map</application></ulink> lets you choose letters and symbols from the <firstterm>Unicode</firstterm> character set and paste them into any application. If you are writing in several languages, not all the characters you need will be on your keyboard."
+#: C/gosoverview.xml:413
+msgid "<link xlink:href=\"help:gucharmap\" type=\"help\"><application>Character Map</application></link> lets you choose letters and symbols from the <firstterm>Unicode</firstterm> character set and paste them into any application. If you are writing in several languages, not all the characters you need will be on your keyboard."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:423
+#: C/gosoverview.xml:414
 msgid "<link linkend=\"caja\"><application>Caja File Manager</application></link> displays your folders and their contents. Use this to copy, move and classify your files, and to access CDs, USB flash drives, and any other removable media. When you choose an item from the <link linkend=\"places-menu\"><guimenu>Places</guimenu> menu</link>, a <application>Caja File Manager</application> window opens showing that location."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:424
-msgid "<ulink type=\"help\" url=\"help:mate-terminal\"><application>Terminal</application></ulink> gives you access to the system command line."
+#: C/gosoverview.xml:415
+msgid "<link xlink:href=\"help:mate-terminal\" type=\"help\"><application>Terminal</application></link> gives you access to the system command line."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:427
+#: C/gosoverview.xml:418
 msgid "Further standard MATE applications include games, music and video players, a web browser, software accessibility tools, and utilities to manage your system. Your distributor or vendor may have added other applications, such as a word processor and a graphics editor. They may also provide you with a way to install further applications."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:429
+#: C/gosoverview.xml:420
 msgid "All MATE applications have many features in common, which makes it easier to learn how to work with a new MATE application. The rest of this section describes some of these features."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:432
+#. (itstool) path: info/title
+#: C/gosoverview.xml:422
 msgid "Common Features"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:434
+#: C/gosoverview.xml:423
 msgid "The applications that are provided with the MATE Desktop share many common features, such as similar open and save dialogs and similar-looking icons. This is because they have all been developed using the MATE development platform. An application developed using this platform is called a <firstterm>MATE-compliant application</firstterm>. For example, <application>Caja</application> and the <application>pluma</application> text editor are MATE-compliant applications."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:436
+#: C/gosoverview.xml:425
 msgid "Some features of MATE-compliant applications are as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:439
+#: C/gosoverview.xml:428
 msgid "Consistent look-and-feel"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:440
+#: C/gosoverview.xml:429
 msgid "MATE-compliant applications have a consistent look-and-feel. You can use the <link linkend=\"prefs-theme\"><application>Appearance</application> preference tool</link> to change the look-and-feel of your MATE-compliant applications."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:443
+#: C/gosoverview.xml:432
 msgid "Menubars, toolbars, and statusbars"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:444
+#: C/gosoverview.xml:433
 msgid "Most MATE-compliant applications have a menubar, a toolbar, and a statusbar. The menubars usually have a similar structure; for example, the <guimenu>Help</guimenu> menu always contains an <guimenuitem>About</guimenuitem> menu item."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:447
+#: C/gosoverview.xml:436
 msgid "A <firstterm>toolbar</firstterm> is a bar that appears under the menubar. A toolbar contains buttons for the most commonly-used commands. A <firstterm>statusbar</firstterm> is a bar at the bottom of a window that provides information about the current state of what you are viewing in the window. Applications might also contains other bars. For example, <application>Caja</application> contains a location bar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:451
+#: C/gosoverview.xml:440
 msgid "Default shortcut keys"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:452
+#: C/gosoverview.xml:441
 msgid "MATE-compliant applications use the same shortcut keys to perform the same actions. See <xref linkend=\"keyboard-skills\"/> for a list of common shortcut keys."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:456
+#: C/gosoverview.xml:445
 msgid "Drag-and-drop"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:457
+#: C/gosoverview.xml:446
 msgid "When you drag-and-drop something into a MATE-compliant application, it will recognize the format of the items that you dragged and will handle them in an appropriate manner. For example, when you drag an HTML file from a <application>Caja</application> window to a web browser, the file is displayed in HTML format in the browser. However, when you drag the HTML file to a text editor, the file is displayed in plain text format in the text editor."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:468
+#. (itstool) path: info/title
+#: C/gosoverview.xml:457
 msgid "Working With Files"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:469
+#: C/gosoverview.xml:458
 msgid "The work you do with an application is stored in <firstterm>files</firstterm>. These may be on your computer's hard drive, or on a removable device such as a USB flash drive. You <firstterm>open</firstterm> a file to examine it or work on it, and you <firstterm>save</firstterm> a file to store your work. When you are done working with a file, you <firstterm>close</firstterm> it."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:470
+#: C/gosoverview.xml:459
 msgid "All MATE applications use the same dialogs for opening and saving files, presenting you with a consistent interface. The following sections cover the open and the save dialog in detail."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:473
+#. (itstool) path: info/title
+#: C/gosoverview.xml:462
 msgid "Choosing a File to Open"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:474
+#: C/gosoverview.xml:463
 msgid "The <guilabel>Open File</guilabel> dialog allows you to choose a file to open in an application."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:475
+#: C/gosoverview.xml:464
 msgid "The right-hand pane of the dialog lists files and folders in the current location. You can use the mouse or the arrow keys on your keyboard to select a file."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:476
+#: C/gosoverview.xml:465
 msgid "Once a file is selected in the list, perform one of the following actions to open it:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:478
+#: C/gosoverview.xml:467
 msgid "Click <guibutton>Open</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:479
+#: C/gosoverview.xml:468
 msgid "Press <keycap>Return</keycap>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:480
+#: C/gosoverview.xml:469
 msgid "Press <keycap>Spacebar</keycap>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:481
+#: C/gosoverview.xml:470
 msgid "Double-click the file."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:483
+#: C/gosoverview.xml:472
 msgid "If you open a folder or a location instead of a file, the <guilabel>Open File</guilabel> dialog updates to show the contents of that folder or location."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:485
+#: C/gosoverview.xml:474
 msgid "To change the location shown in the right-hand pane, do one of the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:487
+#: C/gosoverview.xml:476
 msgid "Open a folder that is listed in the current location."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:488
+#: C/gosoverview.xml:477
 msgid "Open an item in the left-hand pane. This pane lists places such as your Documents folder, your Home Folder, media such as CDs and flash drives, places on your network, and your <link linkend=\"caja-bookmarks\">bookmarks</link>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:489
+#: C/gosoverview.xml:478
 msgid "Click one of the buttons in the path bar above the file listing pane. This shows the hierarchy of folders that contain your current location. Use the arrow buttons to either side of the button bar if the list of folders is too long to fit."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:492
+#: C/gosoverview.xml:481
 msgid "The lower part of the <guilabel>Open File</guilabel> dialog may contain further options specific to the current application."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:495
+#. (itstool) path: info/title
+#: C/gosoverview.xml:483
 msgid "Filtering the File List"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:496
+#: C/gosoverview.xml:484
 msgid "You can restrict the file list to show only files of certain types. To do this, choose a file type from the drop-down list beneath the file list pane. The list of file types depends on the application you are currently using. For example, a graphics application will list different image file formats, and a text editor will list different types of text file."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:500
+#. (itstool) path: info/title
+#: C/gosoverview.xml:487
 msgid "Find-as-you-type"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:501
+#: C/gosoverview.xml:488
 msgid "If you know the name of the file you want to open, begin typing it: the file list will jump to show you files whose names begin with the characters you type. Arrow keys will now select from only these files. The characters you have typed appear in a pop-up window at the base of the file list."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:502
+#: C/gosoverview.xml:489
 msgid "To cancel find-as-you-type, press <keycap>Esc</keycap>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:506
+#. (itstool) path: info/title
+#: C/gosoverview.xml:492
 msgid "Choosing a folder"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:507
-msgid "You might sometimes need to choose a folder to work with rather than open a file. For example, if you use <ulink type=\"help\" url=\"help:engrampa\"><application>Archive Manager</application></ulink> to extract files from an archive, you need to choose a folder to place the files into. In this case, the files in the current location are greyed out, and pressing <guibutton>Open</guibutton> when a folder is selected will choose that folder."
+#: C/gosoverview.xml:493
+msgid "You might sometimes need to choose a folder to work with rather than open a file. For example, if you use <link xlink:href=\"help:engrampa\" type=\"help\"><application>Archive Manager</application></link> to extract files from an archive, you need to choose a folder to place the files into. In this case, the files in the current location are greyed out, and pressing <guibutton>Open</guibutton> when a folder is selected will choose that folder."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:511
+#. (itstool) path: info/title
+#: C/gosoverview.xml:496
 msgid "Open Location"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:512
+#: C/gosoverview.xml:497
 msgid "You can type a full or relative path to the file you want to open. Press <keycombo><keycap>Ctrl</keycap><keycap>L</keycap></keycombo> or click the button at the top left of the window to show (or hide) the <guilabel>Location</guilabel> field. Alternatively, begin typing a full path starting with <filename>/</filename> to show the <guilabel>Location</guilabel> field."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:513
+#: C/gosoverview.xml:498
 msgid "Type a path from the current location, or an absolute path beginning with <filename>/</filename> or <filename>~/</filename>. The <guilabel>Location</guilabel> field has the following features to simplify the typing of a full filename:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:515
+#: C/gosoverview.xml:500
 msgid "A drop-down of possible file and folder names is displayed once you begin typing. Use <keycap>down arrow</keycap> and <keycap>up arrow</keycap> and <keycap>Return</keycap> to choose from the list."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosoverview.xml:516
+#: C/gosoverview.xml:501
 msgid "If the part of the name typed uniquely identifies a file or folder, the name is auto-completed. Press <keycap>Tab</keycap> to accept the suggested text. For example, if you type \"Do\", and the only object in the folder beginning with \"Do\" is <filename>Documents</filename>, then the entire name appears in the field."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:521
+#. (itstool) path: info/title
+#: C/gosoverview.xml:505
 msgid "Opening Remote Locations"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:522
+#: C/gosoverview.xml:506
 msgid "You can open files in remote locations by choosing the location from the left panel, or by typing a path to a remote location into the <guilabel>Location</guilabel> field."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:523
+#: C/gosoverview.xml:507
 msgid "If you require a password to access the remote location, you will be asked for it when you open it."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:527
+#. (itstool) path: info/title
+#: C/gosoverview.xml:510
 msgid "Adding and Removing Bookmarks"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:528
+#: C/gosoverview.xml:511
 msgid "To add the current location to the bookmarks list, press <guibutton>Add</guibutton>, or right-click a folder in the file list and choose <guimenuitem>Add to Bookmarks</guimenuitem>. You can add any folder that is listed in the current location by dragging it to the bookmarks list."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:529
+#: C/gosoverview.xml:512
 msgid "To remove a bookmark from the list, select it and press <guibutton>Remove</guibutton>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosoverview.xml:530
+#: C/gosoverview.xml:513
 msgid "Changes you make to the bookmarks list also affect the <guimenu>Places</guimenu> menu. For more on bookmarks, see <xref linkend=\"caja-bookmarks\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:533
+#. (itstool) path: info/title
+#: C/gosoverview.xml:516
 msgid "Showing hidden files"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:534
+#: C/gosoverview.xml:517
 msgid "To show hidden files in the file list, right-click in the file list and choose <guimenuitem>Show Hidden Files</guimenuitem>. For more on hidden files, see <xref linkend=\"caja-managing-hidden-files\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:538
+#. (itstool) path: info/title
+#: C/gosoverview.xml:521
 msgid "Saving a File"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:539
+#: C/gosoverview.xml:522
 msgid "The first time you save your work in an application, the <guilabel>Save As</guilabel> dialog will ask you for a location and name for the new file. When you save the file on subsequent occasions it will be updated immediately and you will not be asked to re-enter a location or name for the file. To save to a new file, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Save As</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:540
+#: C/gosoverview.xml:523
 msgid "You can enter a filename and choose a location to save in from the drop-down list of bookmarks and commonly-used locations."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:543
+#. (itstool) path: info/title
+#: C/gosoverview.xml:525
 msgid "Saving in another location"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:544
+#: C/gosoverview.xml:526
 msgid "To save the file in a location not listed in the drop-down list, click the <guilabel>Browse for other folders</guilabel> expansion label. This shows a file browser similar to the one in the <guilabel>Open File</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosoverview.xml:545
+#: C/gosoverview.xml:527
 msgid "The expanded <guilabel>Save File</guilabel> dialog has the same features as the <link linkend=\"filechooser-open\"><guilabel>Open File</guilabel> dialog</link>, such as filtering, find-as-you-type, and adding and removing bookmarks."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:549
+#. (itstool) path: info/title
+#: C/gosoverview.xml:530
 msgid "Replacing an existing file"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:550
+#: C/gosoverview.xml:531
 msgid "If you type in the name of an existing file, you will be asked whether you wish to replace the existing file with your current work. You can also do this by choosing the file you want to overwrite in the browser."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:554
+#. (itstool) path: info/title
+#: C/gosoverview.xml:534
 msgid "Typing a Path"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:555
+#: C/gosoverview.xml:535
 msgid "To specify a path to save a file, type it into the <guilabel>Name</guilabel> field. A drop-down of possible file and folder names is displayed once you begin typing. Use <keycap>down arrow</keycap> and <keycap>up arrow</keycap> and <keycap>Return</keycap> to choose from the list. If only one file or folder matches the partial name you have typed, press <keycap>Tab</keycap> to complete the name."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosoverview.xml:559
+#. (itstool) path: info/title
+#: C/gosoverview.xml:538
 msgid "Creating a New Folder"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosoverview.xml:560
+#: C/gosoverview.xml:539
 msgid "If you would like to create a new folder to save your file in, press the <guibutton>Create Folder</guibutton> button. Type a name for the new folder and press <keycap>Return</keycap>. You can then choose to save your file in the new folder, as you would with any other folder."
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/gospanel.xml:2
+#. (itstool) path: info/title
+#: C/gospanel.xml:7
 msgid "Using the Panels"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/gospanel.xml:11
+#: C/gospanel.xml:16
 msgid "This chapter describes how to use the panels at the top and bottom of the MATE Desktop, how to customize the objects that appear on them, and how to add new panels to the desktop."
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:20
+#: C/gospanel.xml:24
 msgid "<primary>panels</primary> <secondary>introduction</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:25
+#: C/gospanel.xml:29
 msgid "A panel is an area in the MATE Desktop where you have access to certain actions and information, no matter what the state of your application windows. For example, in the default MATE panels, you can launch applications, see the date and time, control the system sound volume, and more."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:26
+#: C/gospanel.xml:30
 msgid "You can customize panels to your liking. You can change their behavior and appearance, and you can add or remove objects from your panels. You can create multiple panels, and choose different properties, objects, and backgrounds for each panel. You can also hide panels."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:27
+#: C/gospanel.xml:31
 msgid "By default, the MATE Desktop contains a panel at the top edge of the screen, and a panel at the bottom edge of the screen. The following sections describe these panels."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:32
+#. (itstool) path: info/title
+#: C/gospanel.xml:35
 msgid "Top Edge Panel"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:35
+#: C/gospanel.xml:38
 msgid "<primary>panels</primary> <secondary>top edge panel</secondary> <see>top edge panel</see>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:40
+#: C/gospanel.xml:43
 msgid "<primary>top edge panel</primary> <secondary>introduction</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:44
+#: C/gospanel.xml:47
 msgid "By default, the top edge panel contains the following objects:"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gospanel.xml:45
-#: C/gospanel.xml:101
+#: C/gospanel.xml:48
+#: C/gospanel.xml:104
 msgid "Your distribution of MATE may have altered this default setup."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:49
+#: C/gospanel.xml:52
 msgid "<application>Menu Bar</application> applet"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:50
+#: C/gospanel.xml:53
 msgid "The Menu Bar contains the <guimenu>Applications</guimenu>, <guimenu>Places</guimenu>, and <guimenu>System</guimenu> menus. For more on the menu bar, see <xref linkend=\"menubar\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:53
+#: C/gospanel.xml:56
 msgid "A set of application launcher icons"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:54
+#: C/gospanel.xml:57
 msgid "The exact number of icons depends on your MATE distribution, but in general you will find at least a launcher for the <application>Web Browser</application>, an <application>Email client</application> and the <application>Help Browser</application>. Click on any launcher icon to open the corresponding application."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:57
+#: C/gospanel.xml:60
 msgid "<application>Notification Area</application> applet"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:58
+#: C/gospanel.xml:61
 msgid "Displays icons from other applications that may require your attention, or that you may want to access without switching from your current application window. For more on this, see <xref linkend=\"panels-notification-area\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:59
+#: C/gospanel.xml:62
 msgid "Until an application adds an icon to the notification area, only a narrow bar is visible."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:65
+#: C/gospanel.xml:68
 msgid "<application>Clock</application> applet"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:66
-msgid "The <application>Clock</application> shows the current time. Click on the time to open a small calendar. You can also view a world map by clicking the <guilabel>Locations</guilabel> expansion label. For more on this, see the <ulink type=\"help\" url=\"help:mate-clock\">Clock Applet Manual</ulink>."
+#: C/gospanel.xml:69
+msgid "The <application>Clock</application> shows the current time. Click on the time to open a small calendar. You can also view a world map by clicking the <guilabel>Locations</guilabel> expansion label. For more on this, see the <link xlink:href=\"help:mate-clock\">Clock Applet Manual</link>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:70
+#: C/gospanel.xml:73
 msgid "<application>Volume Control</application> applet"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:72
+#: C/gospanel.xml:75
 msgid "The <application>Volume Control</application> enables you to control the volume of the speakers on your system. For more on this, see the Volume Control Manual."
 msgstr ""
 
 #. (itstool) path: term/indexterm
-#: C/gospanel.xml:76
+#: C/gospanel.xml:79
 msgid "<primary>top edge panel</primary> <secondary>window list icon</secondary>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:75
+#: C/gospanel.xml:78
 msgid "<_:indexterm-1/> <application>Window Selector</application> icon"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:81
+#: C/gospanel.xml:84
 msgid "The <application>Window Selector</application> lists all of your open windows. To give focus to a window, click on the window selector icon at the extreme right of the top edge panel, then select the window. For more on this, see <xref linkend=\"windows-focus\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:88
+#. (itstool) path: info/title
+#: C/gospanel.xml:91
 msgid "Bottom Edge Panel"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:91
+#: C/gospanel.xml:94
 msgid "<primary>panels</primary> <secondary>bottom edge panel</secondary> <see>bottom edge panel</see>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:96
+#: C/gospanel.xml:99
 msgid "<primary>bottom edge panel</primary> <secondary>introduction</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:100
+#: C/gospanel.xml:103
 msgid "By default, the bottom edge panel contains the following objects:"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:102
+#: C/gospanel.xml:105
 msgid "<primary>bottom edge panel</primary> <secondary>default contents</secondary>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:108
+#: C/gospanel.xml:111
 msgid "<guibutton>Show Desktop</guibutton> button"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:109
+#: C/gospanel.xml:112
 msgid "Click on this button to minimize all open windows and show the desktop. Click it again to restore all the windows to their previous state."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:112
+#: C/gospanel.xml:115
 msgid "<application>Window List</application> applet"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:113
+#: C/gospanel.xml:116
 msgid "Displays a button for each window that is open. The <application>Window List</application> enables you to minimize and restore windows. For more on this, see <xref linkend=\"windowlist\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:116
+#: C/gospanel.xml:119
 msgid "<application>Workspace Switcher</application> applet"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:117
+#: C/gospanel.xml:120
 msgid "Enables you to switch between your workspaces. For more on workspaces, see <xref linkend=\"overview-workspaces\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:123
+#. (itstool) path: info/title
+#: C/gospanel.xml:126
 msgid "Managing Panels"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:128
+#: C/gospanel.xml:130
 msgid "<primary>panels</primary> <secondary>managing</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:132
+#: C/gospanel.xml:134
 msgid "The following sections describe how to manage your panels."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:133
+#: C/gospanel.xml:135
 msgid "To interact with a panel, you must click on a vacant space on the panel rather than on any of the objects it holds. If the hide buttons are visible on the panel, you can also middle-click or right-click on one of them to select the panel."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:135
+#. (itstool) path: info/title
+#: C/gospanel.xml:137
 msgid "Moving a Panel"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:136
+#: C/gospanel.xml:138
 msgid "<primary>panels</primary> <secondary>moving</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:140
+#: C/gospanel.xml:142
 msgid "To move a panel to another side of the screen, press and hold <keycap>ALT</keycap> and drag the panel to its new location. Click on any vacant space on the panel to begin the drag."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:141
+#: C/gospanel.xml:143
 msgid "A panel that is not set to expand to the full width of the screen can be dragged away from the edge of the screen and placed anywhere. See <xref linkend=\"panel-properties\"/> for details on how to set a panel's expand property."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:144
+#. (itstool) path: info/title
+#: C/gospanel.xml:146
 msgid "Panel Properties"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:147
+#: C/gospanel.xml:149
 msgid "<primary>panels</primary> <secondary>modifying properties</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:151
+#: C/gospanel.xml:153
 msgid "You can change the properties of each panel, such as the position of the panel, the hide behavior, and the visual appearance."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:154
+#: C/gospanel.xml:156
 msgid "To modify the properties of a panel, right-click on a vacant space on the panel, then choose <guimenuitem>Properties</guimenuitem>. The <guilabel>Panel Properties</guilabel> dialog contains two tabbed sections, <guilabel>General</guilabel> and <guilabel>Background</guilabel>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:157
+#. (itstool) path: info/title
+#: C/gospanel.xml:158
 msgid "General Properties Tab"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:158
+#: C/gospanel.xml:159
 msgid "In the <guilabel>General</guilabel> tab, you can modify panel size, position, and hiding properties. The following table describes the dialog elements on the <guilabel>General</guilabel> tabbed section:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:177
+#: C/gospanel.xml:178
 msgid "<guilabel>Orientation</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:182
+#: C/gospanel.xml:183
 msgid "Select the position of the panel on your screen. Click on the required position for the panel."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:193
+#: C/gospanel.xml:194
 msgid "Use the spin box to specify the size of the panel."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:198
+#: C/gospanel.xml:199
 msgid "<guilabel>Expand</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:203
+#: C/gospanel.xml:204
 msgid "By default, a panel expands to the full length of the edge of the screen where it is located. A panel that does not expand can be moved away from the screen edges to any part of the screen."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:208
+#: C/gospanel.xml:209
 msgid "<guilabel>Autohide</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:213
+#: C/gospanel.xml:214
 msgid "Select this option if you want the panel to only be fully visible when the mouse pointer is over it. The panel hides off-screen along its longest edge, leaving a narrow part visible along the edge of the desktop. Move the mouse pointer over the visible part of the panel to make it move back into view."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:218
-#: C/gospanel.xml:1457
+#: C/gospanel.xml:219
+#: C/gospanel.xml:1442
 msgid "<guilabel>Show hide buttons</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:223
+#: C/gospanel.xml:224
 msgid "Select this option to display hide buttons at each end of your panel. Clicking on a hide button moves the panel lenthways, hiding it off-screen except for the hide button at the opposite end. Click this hide button to restore the panel to being fully visible."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:229
-#: C/gospanel.xml:1468
+#: C/gospanel.xml:230
+#: C/gospanel.xml:1453
 msgid "<guilabel>Arrows on hide buttons</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:234
+#: C/gospanel.xml:235
 msgid "Select this option to display arrows on the hide buttons, if the hide button is enabled."
 msgstr ""
 
-#. (itstool) path: section/title
+#. (itstool) path: info/title
 #: C/gospanel.xml:244
 msgid "Background Properties Tab"
 msgstr ""
@@ -11479,7 +11471,7 @@ msgstr ""
 msgid "Click <guibutton>Close</guibutton> to close the <guilabel>Panel Properties</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: section/title
+#. (itstool) path: info/title
 #: C/gospanel.xml:330
 msgid "Hiding a Panel"
 msgstr ""
@@ -11529,7 +11521,7 @@ msgstr ""
 msgid "You can set a panel to autohide. When you set autohide, the panel hides automatically when the mouse is not pointing to the panel. The panel reappears when you point to the part of the screen where the panel resides. To set your panel to autohide, <link linkend=\"panel-properties\">modify the properties</link> of the panel."
 msgstr ""
 
-#. (itstool) path: section/title
+#. (itstool) path: info/title
 #: C/gospanel.xml:362
 msgid "Adding a New Panel"
 msgstr ""
@@ -11544,7 +11536,7 @@ msgstr ""
 msgid "To add a panel, right-click on a vacant space on any panel, then choose <guimenuitem>New Panel</guimenuitem>. The new panel is added to the MATE Desktop. The new panel contains no objects. You can customize the new panel to suit your preferences."
 msgstr ""
 
-#. (itstool) path: section/title
+#. (itstool) path: info/title
 #: C/gospanel.xml:372
 msgid "Deleting a Panel"
 msgstr ""
@@ -11564,178 +11556,178 @@ msgstr ""
 msgid "You must always have at least one panel in the MATE Desktop. If you have only one panel in the MATE Desktop, you cannot delete that panel."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:390
+#. (itstool) path: info/title
+#: C/gospanel.xml:389
 msgid "Panel Objects"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:393
+#: C/gospanel.xml:392
 msgid "<primary>panels</primary> <secondary>panel objects</secondary> <see>panel objects</see>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:398
+#: C/gospanel.xml:397
 msgid "This section describes the objects that you can add to and use from your panels."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:401
+#. (itstool) path: info/title
+#: C/gospanel.xml:399
 msgid "Interacting With Panel Objects"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:402
+#: C/gospanel.xml:401
 msgid "<primary>panel objects</primary> <secondary>interacting with</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:406
+#: C/gospanel.xml:405
 msgid "You use the mouse buttons to interact with a panel object in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:412
+#: C/gospanel.xml:411
 msgid "Launches the panel object."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:418
+#: C/gospanel.xml:417
 msgid "Enables you to grab an object, then drag the object to a new location."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:425
+#: C/gospanel.xml:424
 msgid "Opens the panel object popup menu."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:432
+#. (itstool) path: info/title
+#: C/gospanel.xml:430
 msgid "To Select an Applet"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:433
+#: C/gospanel.xml:431
 msgid "<primary>applets</primary> <secondary>selecting</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:437
+#: C/gospanel.xml:435
 msgid "Some restrictions apply on where you can click on an applet in order to display the panel object popup menu, or to move the applet, as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:441
+#: C/gospanel.xml:439
 msgid "Some applets have popup menus of applet-specific commands that open when you right-click on particular parts of the applet. For example, the <application><link linkend=\"windowlist\">Window List</link></application> applet has a vertical handle on the left side, and buttons that represent your windows on the right side. To open the panel object popup menu for the <application>Window List</application> applet, you must right-click on the handle. If you right-click on a button on the right side, a popup menu for the button opens."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:450
+#: C/gospanel.xml:448
 msgid "Some applets have areas that you cannot use to select the applet. For example, the <application>Command Line</application> applet has a field in which you enter commands. You cannot middle-click or right-click on this field to select the applet. Instead, middle-click or right-click on another part of the applet."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:462
+#. (itstool) path: info/title
+#: C/gospanel.xml:458
 msgid "Adding an Object to a Panel"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:470
+#: C/gospanel.xml:465
 msgid "<primary>panel objects</primary> <secondary>adding</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:474
+#: C/gospanel.xml:469
 msgid "To add an object to a panel, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:476
+#: C/gospanel.xml:471
 msgid "Right-click on a vacant space on a panel to open the panel popup menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:479
+#: C/gospanel.xml:474
 msgid "Choose <guisubmenu>Add to Panel</guisubmenu>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:481
+#: C/gospanel.xml:476
 msgid "The <guilabel>Add to Panel</guilabel> dialog opens.The available panel objects are listed alphabetically, with <link linkend=\"launchers\">launchers</link> at the top."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gospanel.xml:482
+#: C/gospanel.xml:477
 msgid "You can type a part of the name or description of an object in the <guilabel>find</guilabel> box. This will narrow the list to those objects that match what you type."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gospanel.xml:483
+#: C/gospanel.xml:478
 msgid "To restore the full list, delete the text in the <guilabel>find</guilabel> box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:486
+#: C/gospanel.xml:481
 msgid "Either drag an object from the list to a panel, or select an object from the list and click <guibutton>Add</guibutton> to add it at the spot on the panel where you first right-clicked."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:492
+#: C/gospanel.xml:486
 msgid "You can also add any item in the <guimenu>Applications</guimenu> menu to the panel: right-click the menu item and choose <guimenuitem>Add this launcher to panel</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:494
+#: C/gospanel.xml:488
 msgid "Each launcher corresponds to a <filename>.desktop</filename> file. You can drag a <filename>.desktop</filename> file on to your panels to add the launcher to the panel."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:501
+#. (itstool) path: info/title
+#: C/gospanel.xml:494
 msgid "Modifying the Properties of an Object"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:504
+#: C/gospanel.xml:497
 msgid "<primary>panel objects</primary> <secondary>modifying properties</secondary>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:510
+#: C/gospanel.xml:503
 msgid "The command that starts a launcher application."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:510
+#: C/gospanel.xml:503
 msgid "The location of the source files for a menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:510
+#: C/gospanel.xml:503
 msgid "The icon that represents the object."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:508
+#: C/gospanel.xml:501
 msgid "Some panel objects, such as launchers and drawers, have a set of associated properties. The properties are different for each type of object. The properties specify details such as the following: <_:itemizedlist-1/>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:511
+#: C/gospanel.xml:504
 msgid "To modify the properties of an object, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/indexterm
-#: C/gospanel.xml:514
+#: C/gospanel.xml:507
 msgid "<primary>panel object popup menu, illustration</primary>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:517
+#: C/gospanel.xml:510
 msgid "Right-click on the object to open the panel object popup menu, as shown in <xref linkend=\"gospanel-FIG-54\"/>."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gospanel.xml:520
+#. (itstool) path: info/title
+#: C/gospanel.xml:512
 msgid "Panel Object Popup Menu"
 msgstr ""
 
@@ -11744,194 +11736,194 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:524
+#: C/gospanel.xml:517
 msgctxt "_"
 msgid "external ref='figures/panel_object_popup_menu.png' md5='35135b4653e42312c3e83f399ec6d406'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:522
+#: C/gospanel.xml:515
 msgid "<imageobject> <imagedata fileref=\"figures/panel_object_popup_menu.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Panel object popup menu. Menu items: Properties, Remove From Panel, Lock, Move.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:534
+#: C/gospanel.xml:527
 msgid "Choose <guimenuitem>Properties</guimenuitem>. Use the <guilabel>Properties</guilabel> dialog to modify the properties as required. The properties in the <guilabel>Properties</guilabel> dialog depend on which object you select in step 1."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:539
+#: C/gospanel.xml:532
 msgid "Close the <guilabel>Properties</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:544
+#. (itstool) path: info/title
+#: C/gospanel.xml:537
 msgid "Moving a Panel Object"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:545
+#: C/gospanel.xml:538
 msgid "<primary>panel objects</primary> <secondary>moving</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:549
+#: C/gospanel.xml:542
 msgid "You can move panel objects within a panel, and from one panel to another panel. You can also move objects between panels and drawers."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:551
+#: C/gospanel.xml:544
 msgid "To move a panel object, middle-click and hold on the object and drag the object to a new location. When you release the middle mouse button, the object anchors at the new location."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:554
+#: C/gospanel.xml:547
 msgid "Alternatively, you can use the panel object popup menu to move an object, as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:558
+#: C/gospanel.xml:551
 msgid "Right-click on the object, then choose <guimenuitem>Move</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:561
+#: C/gospanel.xml:554
 msgid "Point to the new location for the object, then click any mouse button to anchor the object to the new location. This location can be on any panel that is currently in the MATE Desktop."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:566
+#: C/gospanel.xml:559
 msgid "Movement of a panel object affects the position of other objects on the panel. To control how objects move on a panel, you can specify a movement mode. To specify the movement mode, press one of the following keys as you move the panel object:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:578
+#: C/gospanel.xml:571
 msgid "Key"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:581
+#: C/gospanel.xml:574
 msgid "Movement Mode"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:591
+#: C/gospanel.xml:584
 msgid "No key"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:594
+#: C/gospanel.xml:587
 msgid "Switched movement"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:597
+#: C/gospanel.xml:590
 msgid "The object swaps places with other panel objects. Switched movement is the default movement mode."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:603
+#: C/gospanel.xml:596
 msgid "<keycap>Alt</keycap> key"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:606
+#: C/gospanel.xml:599
 msgid "Free movement"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:609
+#: C/gospanel.xml:602
 msgid "The object jumps over other panel objects into the next vacant space on the panel."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:615
+#: C/gospanel.xml:608
 msgid "<keycap>Shift</keycap> key"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:618
+#: C/gospanel.xml:611
 msgid "Push movement"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:621
+#: C/gospanel.xml:614
 msgid "The object pushes other panel objects further along the panel."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:630
+#. (itstool) path: info/title
+#: C/gospanel.xml:623
 msgid "Locking a Panel Object"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:631
+#: C/gospanel.xml:624
 msgid "<primary>panel objects</primary> <secondary>locking</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:635
+#: C/gospanel.xml:628
 msgid "<primary>locking panel objects</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:638
+#: C/gospanel.xml:631
 msgid "You can lock panel objects so that the objects stay in the same position on the panel. Use this if you do not want some panel objects to change position when you move other panel objects."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:641
+#: C/gospanel.xml:634
 msgid "To lock an object to its current location in the panel, right-click on the object to open the panel object popup menu, then select <guimenuitem>Lock To Panel</guimenuitem>. Deselect this to unlock the object."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:645
+#. (itstool) path: info/title
+#: C/gospanel.xml:638
 msgid "Removing a Panel Object"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:646
+#: C/gospanel.xml:639
 msgid "<primary>panel objects</primary> <secondary>removing</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:650
+#: C/gospanel.xml:643
 msgid "To remove an object from a panel, right-click on the object to open the panel object popup menu and then choose <guimenuitem>Remove From Panel</guimenuitem>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:662
+#. (itstool) path: info/title
+#: C/gospanel.xml:654
 msgid "Applets"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:663
+#: C/gospanel.xml:655
 msgid "<primary>applets</primary> <secondary>introduction</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:667
+#: C/gospanel.xml:659
 msgid "<primary>panel objects</primary> <secondary>applets</secondary> <see>applets</see>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:672
+#: C/gospanel.xml:664
 msgid "An applet is a small application whose user interface resides within a panel. The following figure shows the following applets, from left to right:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:677
+#: C/gospanel.xml:669
 msgid "<application><xref linkend=\"windowlist\"/></application>: Displays the windows currently open on your system."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:681
+#: C/gospanel.xml:673
 msgid "<application>Volume Control</application>: Enables you to control the volume of the speaker on your system."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:685
-msgid "<ulink type=\"help\" url=\"help:mate-clock\"><application>Clock</application></ulink>: Shows the current date and time."
+#: C/gospanel.xml:677
+msgid "<link xlink:href=\"help:mate-clock\"><application>Clock</application></link>: Shows the current date and time."
 msgstr ""
 
 #. (itstool) path: imageobject/imagedata
@@ -11939,403 +11931,403 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:691
+#: C/gospanel.xml:683
 msgctxt "_"
 msgid "external ref='figures/sample_applet.png' md5='d61c0b0d5b4a5758c5c8ec210c1682e1'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:689
+#: C/gospanel.xml:681
 msgid "<imageobject> <imagedata fileref=\"figures/sample_applet.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Sample applets. The context describes the graphic.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:701
+#. (itstool) path: info/title
+#: C/gospanel.xml:692
 msgid "Launchers"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:704
+#: C/gospanel.xml:695
 msgid "<primary>panel objects</primary> <secondary>launchers</secondary> <see>launchers</see>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:709
+#: C/gospanel.xml:700
 msgid "A <firstterm>launcher</firstterm> is an object that performs a specific action when you open it."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:710
+#: C/gospanel.xml:701
 msgid "You can find launchers in the panels, in the panel menubar, and on the desktop. A launcher is represented by an icon in all of these locations."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:711
+#: C/gospanel.xml:702
 msgid "You might use a launcher to do any of the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:714
+#: C/gospanel.xml:705
 msgid "Start a particular application."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:717
+#: C/gospanel.xml:708
 msgid "Execute a command."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:720
+#: C/gospanel.xml:711
 msgid "Open a folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:723
+#: C/gospanel.xml:714
 msgid "Open a Web browser at a particular page on the Web."
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/gospanel.xml:728
+#: C/gospanel.xml:719
 msgid "<primary>special URI locations</primary><secondary>and launchers</secondary>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:726
+#: C/gospanel.xml:717
 msgid "Open special <firstterm>Uniform Resource Identifiers</firstterm> (URIs). The MATE Desktop contains special URIs that enable you to access particular functions from the file manager. <_:indexterm-1/>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:733
+#: C/gospanel.xml:724
 msgid "You can modify the properties of a launcher. For example, the properties of a launcher include the name of the launcher, the icon that represents the launcher, and how the launcher runs. For more on this, see <xref linkend=\"launchers-modify\"/>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gospanel.xml:736
+#: C/gospanel.xml:727
 msgid "In certain situations, a launcher in a menu might not show an icon. For example, if it specifies no icon to display, or if the entire menu is set to show no icons."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:741
+#. (itstool) path: info/title
+#: C/gospanel.xml:731
 msgid "Adding a Launcher to a Panel"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:742
+#: C/gospanel.xml:732
 msgid "<primary>launchers</primary> <secondary>adding to panel</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:746
+#: C/gospanel.xml:736
 msgid "You can add a launcher to a panel in one of the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:750
-#: C/gospanel.xml:1369
+#: C/gospanel.xml:740
+#: C/gospanel.xml:1354
 msgid "From the panel popup menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:751
+#: C/gospanel.xml:741
 msgid "Right-click on any vacant space on the panel, then choose <guimenu>Add to Panel</guimenu>. The <link linkend=\"panels-addobject\"><guilabel>Add to Panel</guilabel> dialog</link> opens."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:753
+#: C/gospanel.xml:743
 msgid "To create a new launcher, select <guilabel>Custom Application Launcher</guilabel> from the list. A <guilabel>Create Launcher</guilabel> dialog is displayed. For more information on the properties in this dialog, see <xref linkend=\"launchers-properties\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:756
+#: C/gospanel.xml:746
 msgid "Alternatively, to add an existing launcher to the panel, select <guilabel>Application Launcher</guilabel> from the list. Choose the launcher that you want to add from the list of menu items."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:760
-#: C/gospanel.xml:1381
+#: C/gospanel.xml:750
+#: C/gospanel.xml:1366
 msgid "From any menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:761
+#: C/gospanel.xml:751
 msgid "To add a launcher to a panel from a menu, perform one of the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:764
+#: C/gospanel.xml:754
 msgid "Open a menu that contains the launcher. Drag the launcher on to the panel."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:766
+#: C/gospanel.xml:756
 msgid "Open the menu that contains the launcher and right-click on the title of the launcher. Choose <guimenuitem>Add this launcher to panel</guimenuitem>. This method will only work if the launcher is on a sub-menu of the menu that you opened."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:771
+#: C/gospanel.xml:761
 msgid "From the file manager"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:772
+#: C/gospanel.xml:762
 msgid "To add a launcher to a panel from the file manager, find the <filename>.desktop</filename> file for the launcher in your file system, then drag the <filename>.desktop</filename> file to the panel."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:778
+#. (itstool) path: info/title
+#: C/gospanel.xml:767
 msgid "Modifying a Launcher"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:781
+#: C/gospanel.xml:770
 msgid "<primary>launchers</primary> <secondary>modifying properties</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:785
+#: C/gospanel.xml:774
 msgid "To modify the properties of a launcher in a panel, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:789
+#: C/gospanel.xml:778
 msgid "Right-click on the launcher to open the panel object popup menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:793
+#: C/gospanel.xml:782
 msgid "Choose <guimenuitem>Properties</guimenuitem>. Use the <guilabel>Launcher Properties</guilabel> dialog to modify the properties as required. For more information on the <guilabel>Launcher Properties</guilabel> dialog, see <xref linkend=\"launchers-properties\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:798
+#: C/gospanel.xml:787
 msgid "Click <guibutton>Close</guibutton> to close the <guilabel>Launcher Properties</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:805
+#. (itstool) path: info/title
+#: C/gospanel.xml:792
 msgid "Launcher Properties"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:809
+#: C/gospanel.xml:796
 msgid "When you create or edit a launcher, the following properties can be set:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:813
+#: C/gospanel.xml:800
 msgid "Use the drop-down list to specify whether this launcher starts an application or opens a location:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:815
+#: C/gospanel.xml:802
 msgid "Application"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:817
+#: C/gospanel.xml:804
 msgid "The launcher starts an application."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:820
+#: C/gospanel.xml:807
 msgid "Application in Terminal"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:822
+#: C/gospanel.xml:809
 msgid "The launcher starts an application through a terminal window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:827
+#: C/gospanel.xml:814
 msgid "The launcher opens a file, web page or other location."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:831
+#: C/gospanel.xml:818
 msgid "If you are editing a location launcher, this drop-down list will not be displayed. If you are editing an application launcher, the <guilabel>Location</guilabel> option will not be available."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:838
+#: C/gospanel.xml:825
 msgid "This is the name that is displayed if you add the launcher to a menu or to the desktop."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:842
+#: C/gospanel.xml:829
 msgid "Command"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:844
+#: C/gospanel.xml:831
 msgid "For an application launcher, specify a command to execute when you click on the launcher. For sample commands, see <xref linkend=\"launchers-properties-commands\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:850
+#: C/gospanel.xml:837
 msgid "For a location launcher, specify the location to be opened. Click <guibutton>Browse</guibutton> to select a location on your computer, or type a web address to launch a web page. For sample locations, see <xref linkend=\"launchers-properties-commands\"/>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:856
+#: C/gospanel.xml:843
 msgid "Comment"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:858
+#: C/gospanel.xml:845
 msgid "This is displayed as a tooltip when you point to the launcher icon on the panel."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:864
+#: C/gospanel.xml:851
 msgid "To change the icon for the launcher, click on the button showing the current icon. An icon selector dialog is displayed. Choose an icon from the dialog."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:867
+#. (itstool) path: info/title
+#: C/gospanel.xml:853
 msgid "Launcher Commands and Locations"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:870
+#: C/gospanel.xml:856
 msgid "Examples of commands and locations that you can use in the <guilabel>Launcher Properties</guilabel> dialog can be found below."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:872
+#: C/gospanel.xml:858
 msgid "If you choose <guilabel>Application</guilabel> or <guilabel>Application in Terminal</guilabel> from the <guilabel>Type</guilabel> drop-down box, the <guilabel>Command</guilabel> text box will be displayed. The following table shows some sample commands and the actions that the commands perform:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:881
+#: C/gospanel.xml:867
 msgid "Sample Application Command"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:891
+#: C/gospanel.xml:877
 msgid "<command>pluma</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:896
+#: C/gospanel.xml:882
 msgid "Starts the <application>pluma</application> text editor application."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:901
+#: C/gospanel.xml:887
 msgid "<command>pluma /home/user/loremipsum.txt</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:906
+#: C/gospanel.xml:892
 msgid "Opens the file <filename>/home/user/loremipsum.txt</filename> in the <application>pluma</application> text editor application."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:911
+#: C/gospanel.xml:897
 msgid "<command>caja /home/user/Projects</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:916
-#: C/gospanel.xml:958
+#: C/gospanel.xml:902
+#: C/gospanel.xml:944
 msgid "Opens the folder <filename>/home/user/Projects</filename> in a File Browser window."
 msgstr ""
 
 #. (itstool) path: para/indexterm
-#: C/gospanel.xml:924
+#: C/gospanel.xml:910
 msgid "<primary>special URIs</primary><secondary>launchers</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:922
+#: C/gospanel.xml:908
 msgid "If you choose <guilabel>Location</guilabel> from the <guilabel>Type</guilabel> drop-down box, the <guilabel>Location</guilabel> text box will be displayed. The following table shows some sample locations and the actions that will happen if you click on the launcher:<_:indexterm-1/>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:932
+#: C/gospanel.xml:918
 msgid "Sample Location"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:942
+#: C/gospanel.xml:928
 msgid "<command>file:///home/user/loremipsum.txt</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:947
+#: C/gospanel.xml:933
 msgid "Opens the file <filename>/home/user/loremipsum.txt</filename> in the default viewer for its file type."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:953
+#: C/gospanel.xml:939
 msgid "<command>file:///home/user/Projects</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:963
+#: C/gospanel.xml:949
 msgid "<command>http://www.mate-desktop.org</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:968
+#: C/gospanel.xml:954
 msgid "Opens the MATE website in your default browser."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:973
+#: C/gospanel.xml:959
 msgid "<command>ftp://ftp.mate-desktop.org</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:978
+#: C/gospanel.xml:964
 msgid "Opens the MATE FTP site in your default browser."
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:989
+#: C/gospanel.xml:975
 msgid "<primary>buttons</primary> <secondary>adding to panel</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:993
+#: C/gospanel.xml:979
 msgid "<primary>action buttons</primary> <see>buttons</see>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:997
+#: C/gospanel.xml:983
 msgid "You can add buttons to your panels to provide quick access to common actions and functions."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1000
+#. (itstool) path: info/title
+#: C/gospanel.xml:986
 msgid "Force Quit Button"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1001
+#: C/gospanel.xml:987
 msgid "<primary>buttons</primary> <secondary>Force Quit</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1005
+#: C/gospanel.xml:991
 msgid "<primary>panel objects</primary> <secondary>Force Quit button</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1009
+#: C/gospanel.xml:995
 msgid "<primary>Force Quit button</primary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1012
+#: C/gospanel.xml:998
 msgid "<primary>terminating applications</primary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1015
+#: C/gospanel.xml:1001
 msgid "<primary>applications</primary> <secondary>terminating</secondary>"
 msgstr ""
 
@@ -12344,33 +12336,33 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1022
+#: C/gospanel.xml:1008
 msgctxt "_"
 msgid "external ref='figures/force_quit.png' md5='4e6cd725cd4977eaeab464ce4ff266ce'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1020
+#: C/gospanel.xml:1006
 msgid "<imageobject> <imagedata fileref=\"figures/force_quit.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Force Quit icon.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1029
+#: C/gospanel.xml:1015
 msgid "The <guibutton>Force Quit</guibutton> button allows you to click on a window to force an application to quit. This button is useful if you want to terminate an application that does not respond to your commands, if the application has frozen or crashed, for example."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1033
+#: C/gospanel.xml:1019
 msgid "To add a <guibutton>Force Quit</guibutton> button to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Force Quit</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1037
+#: C/gospanel.xml:1023
 msgid "To terminate an application, click on the <guibutton>Force Quit</guibutton> button, then click on a window from the application that you want to terminate. If you do not want to terminate an application after you have clicked on the <guibutton>Force Quit</guibutton> button, press <keycap>Esc</keycap>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1043
+#. (itstool) path: info/title
+#: C/gospanel.xml:1029
 msgid "Lock Screen Button"
 msgstr ""
 
@@ -12379,104 +12371,102 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1049
-#: C/gosstartsession.xml:139
+#: C/gospanel.xml:1036
+#: C/gosstartsession.xml:141
 msgctxt "_"
 msgid "external ref='figures/lockscreen_icon.png' md5='a5937cc295f73c51d54a0761ae924000'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1047
-#: C/gosstartsession.xml:137
+#: C/gospanel.xml:1034
+#: C/gosstartsession.xml:139
 msgid "<imageobject> <imagedata fileref=\"figures/lockscreen_icon.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Lock screen icon.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1056
+#: C/gospanel.xml:1043
 msgid "<primary>buttons</primary> <secondary>Lock</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1060
+#: C/gospanel.xml:1047
 msgid "<primary>panel objects</primary> <secondary>Lock button</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#. (itstool) path: sect1/indexterm
-#: C/gospanel.xml:1064
-#: C/gosstartsession.xml:153
+#: C/gospanel.xml:1051
+#: C/gosstartsession.xml:155
 msgid "<primary>Lock button</primary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#. (itstool) path: sect1/indexterm
-#: C/gospanel.xml:1067
-#: C/gosstartsession.xml:150
+#: C/gospanel.xml:1054
+#: C/gosstartsession.xml:152
 msgid "<primary>locking screen</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1070
+#: C/gospanel.xml:1057
 msgid "The <guibutton>Lock Screen</guibutton> button locks your screen and activates your screensaver when you click on it. To access your session again, you must enter your password."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1073
+#: C/gospanel.xml:1060
 msgid "To add a <guibutton>Lock Screen</guibutton> button to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Lock Screen</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1075
+#: C/gospanel.xml:1062
 msgid "Right-click on the <guibutton>Lock Screen</guibutton> button to open a menu of screensaver-related commands. <xref linkend=\"gosstartsession-TBL-83\"/> describes the commands that are available from the menu."
 msgstr ""
 
-#. (itstool) path: table/title
-#: C/gospanel.xml:1079
+#. (itstool) path: info/title
+#: C/gospanel.xml:1065
 msgid "Lock Screen Menu Items"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1086
+#: C/gospanel.xml:1072
 msgid "Menu Item"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1096
+#: C/gospanel.xml:1082
 msgid "<guimenuitem>Activate Screensaver</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1101
+#: C/gospanel.xml:1087
 msgid "Activates the screensaver immediately."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1102
+#: C/gospanel.xml:1088
 msgid "This will also lock the screen if you have set <guilabel>Lock screen when screensaver is active</guilabel> in the <application>Screensaver</application> preference tool."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1108
+#: C/gospanel.xml:1094
 msgid "<guimenuitem>Lock Screen</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1113
+#: C/gospanel.xml:1099
 msgid "Locks the screen immediately. This command performs the same function as when you click on the <guibutton>Lock Screen</guibutton> button."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1119
+#: C/gospanel.xml:1105
 msgid "<guimenuitem>Properties</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1124
+#: C/gospanel.xml:1110
 msgid "Opens the <link linkend=\"prefs-screensaver\"><application>Screensaver</application> preference tool</link>, with which you can configure the type of screensaver that is displayed when you lock the screen."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1132
+#. (itstool) path: info/title
+#: C/gospanel.xml:1118
 msgid "Log Out Button"
 msgstr ""
 
@@ -12485,48 +12475,48 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1136
+#: C/gospanel.xml:1122
 msgctxt "_"
 msgid "external ref='figures/logout_icon.png' md5='b695adb45b2eaed0d80203635a70a5bb'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1134
+#: C/gospanel.xml:1120
 msgid "<imageobject> <imagedata fileref=\"figures/logout_icon.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Log Out icon.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1143
+#: C/gospanel.xml:1129
 msgid "<primary>buttons</primary> <secondary>Log Out</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1147
+#: C/gospanel.xml:1133
 msgid "<primary>panel objects</primary> <secondary>Log Out button</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1151
+#: C/gospanel.xml:1137
 msgid "<primary>Log Out button</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1154
+#: C/gospanel.xml:1140
 msgid "The <guibutton>Log Out</guibutton> button allows you to log out of a MATE session or switch to a different user account."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1156
+#: C/gospanel.xml:1142
 msgid "To add a <guibutton>Log Out</guibutton> button to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Log Out</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1160
+#: C/gospanel.xml:1146
 msgid "To log out of your session or switch users, click on the <guibutton>Log Out</guibutton> button and then click on the appropriate button in the dialog that appears."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1165
+#. (itstool) path: info/title
+#: C/gospanel.xml:1151
 msgid "Run Button"
 msgstr ""
 
@@ -12535,53 +12525,53 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1169
+#: C/gospanel.xml:1155
 msgctxt "_"
 msgid "external ref='figures/run_button.png' md5='68e8f81b231ed542e57349c93241f3f7'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1167
+#: C/gospanel.xml:1153
 msgid "<imageobject> <imagedata fileref=\"figures/run_button.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Run Application icon.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1176
+#: C/gospanel.xml:1162
 msgid "<primary>buttons</primary> <secondary>Run</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1180
+#: C/gospanel.xml:1166
 msgid "<primary>panel objects</primary> <secondary>Run button</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1184
+#: C/gospanel.xml:1170
 msgid "<primary>Run button</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1187
+#: C/gospanel.xml:1173
 msgid "The <guibutton>Run</guibutton> button opens the <guilabel>Run Application</guilabel> dialog, which allows you to start an application by choosing it from a list."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1190
+#: C/gospanel.xml:1176
 msgid "To add a <guibutton>Run</guibutton> button to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Run Application</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1194
+#: C/gospanel.xml:1180
 msgid "To open the <application>Run Application</application> dialog, click on the <guibutton>Run</guibutton> button."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1196
+#: C/gospanel.xml:1182
 msgid "For more information on the <guilabel>Run Application</guilabel> dialog, see <xref linkend=\"gospanel-23\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1200
+#. (itstool) path: info/title
+#: C/gospanel.xml:1186
 msgid "Search Button"
 msgstr ""
 
@@ -12590,68 +12580,68 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1204
+#: C/gospanel.xml:1190
 msgctxt "_"
 msgid "external ref='figures/searchtool_button.png' md5='e6210d7a387eccba73a76c215f078611'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1202
+#: C/gospanel.xml:1188
 msgid "<imageobject> <imagedata fileref=\"figures/searchtool_button.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Search Tool icon.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1211
+#: C/gospanel.xml:1197
 msgid "<primary>buttons</primary> <secondary>Search</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1215
+#: C/gospanel.xml:1201
 msgid "<primary>panel objects</primary> <secondary>Search button</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1219
+#: C/gospanel.xml:1205
 msgid "<primary>Search button</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1222
+#: C/gospanel.xml:1208
 msgid "The <guibutton>Search</guibutton> button opens the <application>Search Tool</application>, which allows you to search for files on your computer."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1225
+#: C/gospanel.xml:1211
 msgid "To add a <guibutton>Search</guibutton> button to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Search for Files</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1227
+#: C/gospanel.xml:1213
 msgid "To open the <application>Search Tool</application>, click on the <guibutton>Search</guibutton> button."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1229
-msgid "For more information on the <application>Search Tool</application>, see the <ulink type=\"help\" url=\"help:mate-search-tool\">Search Tool Manual</ulink>."
+#: C/gospanel.xml:1215
+msgid "For more information on the <application>Search Tool</application>, see the <link xlink:href=\"help:mate-search-tool\">Search Tool Manual</link>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1233
+#. (itstool) path: info/title
+#: C/gospanel.xml:1219
 msgid "Show Desktop Button"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1234
+#: C/gospanel.xml:1220
 msgid "<primary>buttons</primary> <secondary>Minimize Windows</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1238
+#: C/gospanel.xml:1224
 msgid "<primary>panel objects</primary> <secondary>Minimize Windows button</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1243
+#: C/gospanel.xml:1229
 msgid "<primary>Minimize Windows button</primary>"
 msgstr ""
 
@@ -12660,98 +12650,98 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1250
+#: C/gospanel.xml:1236
 msgctxt "_"
 msgid "external ref='figures/show_desktop_button.png' md5='c228bbe71372d2a5afb76c3c7943e739'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1248
+#: C/gospanel.xml:1234
 msgid "<imageobject> <imagedata fileref=\"figures/show_desktop_button.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Show Desktop icon.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1257
+#: C/gospanel.xml:1243
 msgid "You can use the <guibutton>Show Desktop</guibutton> button to minimize all open windows and show the desktop."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1258
+#: C/gospanel.xml:1244
 msgid "To add a <guibutton>Show Desktop</guibutton> button to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Show Desktop</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1262
+#: C/gospanel.xml:1248
 msgid "To minimize all windows and show the desktop, click on the <guibutton>Show Desktop</guibutton> button. To restore all windows to their previous state, click it again."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1268
+#. (itstool) path: info/title
+#: C/gospanel.xml:1254
 msgid "Menus"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1273
+#: C/gospanel.xml:1259
 msgid "<primary>menus</primary> <secondary>adding to panel</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1277
+#: C/gospanel.xml:1263
 msgid "<primary>panel objects</primary> <secondary>menus</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1281
+#: C/gospanel.xml:1267
 msgid "You can add the following types of menu to your panels:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1284
+#: C/gospanel.xml:1270
 msgid "<guimenu>Menu Bar</guimenu>: You can access almost all the standard applications, commands, and configuration options from the menus in the Menu Bar. It contains the <guimenu>Applications</guimenu>, <guimenu>Places</guimenu>, and <guimenu>System</guimenu> menus."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1288
+#: C/gospanel.xml:1274
 msgid "To add a <guimenu>Menu Bar</guimenu> to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Menu Bar</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1294
+#: C/gospanel.xml:1280
 msgid "<guimenu>Main Menu</guimenu>: The Main Menu contains the same items as the Menu Bar, but organizes them into one menu instead of three. It takes up less space on the panels as a result."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1297
+#: C/gospanel.xml:1283
 msgid "To add a <guimenu>Main Menu</guimenu> to a panel, right-click on any vacant space on the panel. Choose <guimenu>Add to Panel</guimenu>, then choose <application>Main Menu</application> from the Add to Panel dialog. See <xref linkend=\"panels-addobject\"/> for more on this."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1303
+#: C/gospanel.xml:1289
 msgid "<guimenu>Submenus</guimenu>: You can add a submenu of the Menu Bar or Main Menu directly to the panel. For example, you can add the <guimenu>Games</guimenu> submenu of the <guimenu>Applications</guimenu> menu to the panel."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1306
+#: C/gospanel.xml:1292
 msgid "To add a submenu to a panel, open the submenu, right-click on a launcher, then choose <menuchoice><guimenu>Entire menu</guimenu><guimenuitem>Add this as menu to panel</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1313
+#. (itstool) path: info/title
+#: C/gospanel.xml:1298
 msgid "Drawers"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1314
+#: C/gospanel.xml:1299
 msgid "<primary>panel objects</primary> <secondary>drawers</secondary> <see>drawers</see>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1319
+#: C/gospanel.xml:1304
 msgid "A drawer is an extension of a panel. You can open and close a drawer in the same way that you can show and hide a panel. A drawer can contain all panel objects, including launchers, menus, applets, and other drawers. When you open a drawer, you can use the objects in the same way that you use objects on a panel."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1324
+#: C/gospanel.xml:1309
 msgid "The following figure shows an open drawer that contains two panel objects."
 msgstr ""
 
@@ -12760,198 +12750,198 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1328
+#: C/gospanel.xml:1313
 msgctxt "_"
 msgid "external ref='figures/open_drawer.png' md5='ce13f1ec9eaed826ef4e113de0cd5d9c'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1326
+#: C/gospanel.xml:1311
 msgid "<imageobject> <imagedata fileref=\"figures/open_drawer.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Open drawer. The context describes the graphic.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1335
+#: C/gospanel.xml:1320
 msgid "The arrow on the icon indicates that it represents a drawer or menu."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1337
+#: C/gospanel.xml:1322
 msgid "You can add, move, and remove objects from drawers in the same way that you add, move, and remove objects from panels."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1340
+#. (itstool) path: info/title
+#: C/gospanel.xml:1325
 msgid "To Open and Close a Drawer"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1341
+#: C/gospanel.xml:1326
 msgid "<primary>drawers</primary> <secondary>opening</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1345
+#: C/gospanel.xml:1330
 msgid "<primary>drawers</primary> <secondary>closing</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1349
+#: C/gospanel.xml:1334
 msgid "To open a drawer, click on the drawer's icon in a panel. You can close a drawer in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1353
+#: C/gospanel.xml:1338
 msgid "Click on the drawer's icon."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1356
+#: C/gospanel.xml:1341
 msgid "Click on the drawer hide button."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1361
+#. (itstool) path: info/title
+#: C/gospanel.xml:1346
 msgid "To Add a Drawer to a Panel"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1362
+#: C/gospanel.xml:1347
 msgid "<primary>drawers</primary> <secondary>adding to panel</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1366
+#: C/gospanel.xml:1351
 msgid "You can add a drawer to a panel in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1372
+#: C/gospanel.xml:1357
 msgid "Right-click on any vacant space on the panel, then choose <guimenuitem>Add to Panel</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1374
+#: C/gospanel.xml:1359
 msgid "In the <application>Add to Panel</application> dialog, select <guilabel>Drawer</guilabel>. Click <guibutton>Add</guibutton>, then click <guibutton>Close</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1383
+#: C/gospanel.xml:1368
 msgid "You can add a menu as a drawer object to a panel."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1384
+#: C/gospanel.xml:1369
 msgid "To add a menu as a drawer to a panel, open the menu from the panel. Right-click on any launcher in the menu, then choose <menuchoice><guimenu>Entire menu</guimenu><guimenuitem>Add this as drawer to panel</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1391
+#. (itstool) path: info/title
+#: C/gospanel.xml:1376
 msgid "To Add an Object to a Drawer"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1392
+#: C/gospanel.xml:1377
 msgid "<primary>drawers</primary> <secondary>adding objects to</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1396
+#: C/gospanel.xml:1381
 msgid "You add an object to a drawer in the same way that you add objects to panels. For more information, see <xref linkend=\"panels-addobject\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1400
+#. (itstool) path: info/title
+#: C/gospanel.xml:1385
 msgid "To Modify Drawer Properties"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1401
+#: C/gospanel.xml:1386
 msgid "<primary>drawers</primary> <secondary>modifying properties</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1405
+#: C/gospanel.xml:1390
 msgid "You can modify the properties of each drawer individually. For example, you can change the visual appearance of the drawer and whether it has hide buttons."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1408
+#: C/gospanel.xml:1393
 msgid "To modify properties for a drawer perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1411
+#: C/gospanel.xml:1396
 msgid "Right-click on the drawer, then choose <guimenuitem>Properties</guimenuitem> to display the <guilabel>Drawer Properties</guilabel> dialog. The dialog displays the <guilabel>General</guilabel> tabbed section."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1416
+#: C/gospanel.xml:1401
 msgid "Select the properties for the drawer in the dialog. The following table describes the elements on the <guilabel>General</guilabel> tabbed section:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1440
+#: C/gospanel.xml:1425
 msgid "Specify the width of the drawer when it is open."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1445
+#: C/gospanel.xml:1430
 msgid "<guilabel>Icon</guilabel>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1450
+#: C/gospanel.xml:1435
 msgid "Choose an icon to represent the drawer. Click on the <guibutton>Icon</guibutton> button to display an icon selector dialog. Choose an icon from the dialog and click <guibutton>OK</guibutton> to confirm your choice."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1462
+#: C/gospanel.xml:1447
 msgid "Select this option to display hide buttons on your drawer. When you click one of the buttons, the drawer will close."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1473
+#: C/gospanel.xml:1458
 msgid "Select this option to display arrows on the hide buttons, if the hide buttons are enabled."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1482
+#: C/gospanel.xml:1467
 msgid "You can use the <guilabel>Background</guilabel> tabbed section to set the background for the drawer. For information on how to complete the <guilabel>Background</guilabel> tabbed section, see <xref linkend=\"panel-properties\"/>. You can also drag a color or image on to a drawer to set the color or image as the background of the drawer. For more information, see <xref linkend=\"panel-properties-background\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1488
+#: C/gospanel.xml:1473
 msgid "Click <guibutton>Close</guibutton> to close the <guilabel>Drawer Properties</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1495
+#. (itstool) path: info/title
+#: C/gospanel.xml:1479
 msgid "Default Panel Objects"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1497
+#: C/gospanel.xml:1482
 msgid "This section covers the panel objects that appear in the default MATE desktop."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1500
+#. (itstool) path: info/title
+#: C/gospanel.xml:1484
 msgid "Window Selector Applet"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1503
+#: C/gospanel.xml:1488
 msgid "<primary>top edge panel</primary> <secondary>window selector icon</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1507
+#: C/gospanel.xml:1492
 msgid "<primary>window selector</primary> <secondary>top edge panel</secondary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1511
+#: C/gospanel.xml:1496
 msgid "You can view a list of all windows that are currently open. You can also choose a window to give focus to. To view the window list, click on the <application>Window Selector</application> applet. The following figure shows an example of the <application>Window Selector</application> applet:"
 msgstr ""
 
@@ -12960,43 +12950,43 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1518
+#: C/gospanel.xml:1503
 msgctxt "_"
 msgid "external ref='figures/openwindows_menu.png' md5='5de74eda192636868298a97043530d75'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1516
+#: C/gospanel.xml:1501
 msgid "<imageobject> <imagedata fileref=\"figures/openwindows_menu.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Window selector applet displayed from the top edge panel.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1525
+#: C/gospanel.xml:1510
 msgid "To give focus to a window, select the window from the <application>Window Selector</application> applet."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1526
+#: C/gospanel.xml:1511
 msgid "The <application>Window Selector</application> lists the windows in all workspaces. The windows in all workspaces other than the current workspace are listed under a separator line."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1532
+#. (itstool) path: info/title
+#: C/gospanel.xml:1516
 msgid "Notification Area Applet"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1535
+#: C/gospanel.xml:1520
 msgid "<primary>applets</primary> <secondary>Notification Area</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1539
+#: C/gospanel.xml:1524
 msgid "<primary>panel objects</primary> <secondary>Notification Area applet</secondary>"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gospanel.xml:1544
+#: C/gospanel.xml:1529
 msgid "<primary>Notification Area applet</primary>"
 msgstr ""
 
@@ -13005,23 +12995,23 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1550
+#: C/gospanel.xml:1535
 msgctxt "_"
 msgid "external ref='figures/notification_area_icon.png' md5='973b76c720b51d9495208ab2d62ecdec'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1548
+#: C/gospanel.xml:1533
 msgid "<imageobject> <imagedata fileref=\"figures/notification_area_icon.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Notification Area icon.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1557
+#: C/gospanel.xml:1542
 msgid "The <application>Notification Area</application> applet displays icons from various applications to indicate activity in the application. For example, when you use the <application>CD Player</application> application to play a CD, a CD icon is displayed in the <application>Notification Area</application> applet. The graphic above illustrates the CD icon in the <application>Notification Area</application> applet."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1566
+#. (itstool) path: info/title
+#: C/gospanel.xml:1550
 msgid "Menu Bar"
 msgstr ""
 
@@ -13030,930 +13020,930 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gospanel.xml:1570
+#: C/gospanel.xml:1554
 msgctxt "_"
 msgid "external ref='figures/menu_bar_applet.png' md5='8f4bca946498664c1cddd238a5a23498'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gospanel.xml:1568
+#: C/gospanel.xml:1552
 msgid "<imageobject> <imagedata fileref=\"figures/menu_bar_applet.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Menu Bar applet. Menus: Applications, Places, System.</phrase> </textobject>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1577
+#: C/gospanel.xml:1561
 msgid "The <application>Menu Bar</application> contains the <guimenu>Applications</guimenu>, <guimenu>Places</guimenu>, and <guimenu>System</guimenu> menus. You can access almost all the standard applications, commands, and configuration options from the <application>Menu Bar</application>. For more on using the Menu Bar, see <xref linkend=\"menubar\"/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1588
+#. (itstool) path: info/title
+#: C/gospanel.xml:1571
 msgid "Window List"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1590
+#: C/gospanel.xml:1572
 msgid "The <application>Window List</application> applet enables you to manage the windows that are open on the MATE desktop. Window List uses a button to represent each window or group of windows that is open. The state of the buttons in the applet varies depending on the state of the window that the button represents. The following table explains the possible states of the <application>Window List</application> buttons."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1597
+#: C/gospanel.xml:1579
 msgid "State"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1598
+#: C/gospanel.xml:1580
 msgid "Indicates..."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1603
+#: C/gospanel.xml:1585
 msgid "The button is pressed in."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1604
+#: C/gospanel.xml:1586
 msgid "The window has focus."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1607
+#: C/gospanel.xml:1589
 msgid "The button appears faded. The button text is surrounded by square brackets."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1608
+#: C/gospanel.xml:1590
 msgid "The window is minimized."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1611
+#: C/gospanel.xml:1593
 msgid "The button is not pressed in, and is not faded."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1612
+#: C/gospanel.xml:1594
 msgid "The window is displayed on the desktop and is not minimized."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1615
+#: C/gospanel.xml:1597
 msgid "There is a number in parentheses at the end of the button title."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gospanel.xml:1616
+#: C/gospanel.xml:1598
 msgid "The button represents a group of buttons."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1625
+#: C/gospanel.xml:1606
 msgid "You can use <application>Window List</application> to perform the following tasks:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1628
+#: C/gospanel.xml:1609
 msgid "To give focus to a window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1629
+#: C/gospanel.xml:1610
 msgid "If you click on the Window List button that represents a window that is on the desktop but does not have focus, the applet gives focus to the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1632
+#: C/gospanel.xml:1613
 msgid "To minimize a window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1633
+#: C/gospanel.xml:1614
 msgid "If you click on the Window List button that represents the window that has focus, the applet minimizes the window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1636
+#: C/gospanel.xml:1617
 msgid "To restore a minimized window"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1637
+#: C/gospanel.xml:1618
 msgid "If you click on the Window List button that represents a minimized window, the applet restores the window."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1641
+#: C/gospanel.xml:1622
 msgid "You can change the order of the Window List buttons by dragging a button to a different location on the Window List."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gospanel.xml:1646
+#. (itstool) path: info/title
+#: C/gospanel.xml:1626
 msgid "Preferences"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gospanel.xml:1647
+#: C/gospanel.xml:1627
 msgid "To configure the <application>Window List</application>, right-click on the handle to the left of the window buttons, then choose <guimenuitem>Preferences</guimenuitem>. The following preferences can be changed:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:1656
+#: C/gospanel.xml:1636
 msgid "<guilabel>Window List Content</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1658
+#: C/gospanel.xml:1638
 msgid "To specify which windows to display in the Window List, select one of the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1661
+#: C/gospanel.xml:1641
 msgid "<guilabel>Show windows from current workspace</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1662
+#: C/gospanel.xml:1642
 msgid "Select this option to only show the windows that are open in the current workspace."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1664
+#: C/gospanel.xml:1644
 msgid "<guilabel>Show windows from all workspaces</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1665
+#: C/gospanel.xml:1645
 msgid "Select this option to show the windows that are open in all workspaces."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:1671
+#: C/gospanel.xml:1651
 msgid "<guilabel>Window Grouping</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1673
+#: C/gospanel.xml:1653
 msgid "To specify when the Window List should group windows that belong to the same application, select one of the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1676
+#: C/gospanel.xml:1656
 msgid "<guilabel>Never group windows</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1677
+#: C/gospanel.xml:1657
 msgid "Select this option to never group windows of the same application under one button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1680
+#: C/gospanel.xml:1660
 msgid "<guilabel>Group windows when space is limited</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1681
+#: C/gospanel.xml:1661
 msgid "Select this option to group windows of the same application under one button when the space on the panel is restricted."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1684
+#: C/gospanel.xml:1664
 msgid "<guilabel>Always group windows</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1685
+#: C/gospanel.xml:1665
 msgid "Select this option to always group windows of the same application under one button."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gospanel.xml:1691
+#: C/gospanel.xml:1671
 msgid "<guilabel>Restoring Minimized Windows</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1693
+#: C/gospanel.xml:1673
 msgid "To define how the Window List behaves when you restore windows, select one of the following options."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1696
+#: C/gospanel.xml:1676
 msgid "<guilabel>Restore to current workspace</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1697
+#: C/gospanel.xml:1677
 msgid "Select this option to restore a window from the applet to the current workspace, even if the window did not previously reside in the current workspace."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1699
+#: C/gospanel.xml:1679
 msgid "<guilabel>Restore to native workspace</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1700
+#: C/gospanel.xml:1680
 msgid "Select this option to switch to the workspace in which a window originally resided when you restore the window from the applet."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gospanel.xml:1703
+#: C/gospanel.xml:1683
 msgid "These options are only available if <guilabel>Show windows from all workspaces</guilabel> is selected in the <guilabel>Window List Content</guilabel> section of the dialog."
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/gosstartsession.xml:2
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:6
 msgid "Desktop Sessions"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/gosstartsession.xml:11
+#: C/gosstartsession.xml:15
 msgid "This chapter provides the information you need to log in to and shut down MATE, and to start, manage, and end a desktop session."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/gosstartsession.xml:15
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:18
 msgid "Starting a Session"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:16
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:19
 msgid "<primary>sessions</primary> <secondary>starting</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:20
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:23
 msgid "A <firstterm>session</firstterm> is the period you spend using MATE, between logging in and logging out. During a session, you use your applications, print, browse the web, and so on."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:21
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:24
 msgid "Logging in to MATE begins your session. The login screen is your gateway to the MATE Desktop: it is where you enter your username and password and select options such as the language you want MATE to use for your session."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosstartsession.xml:22
+#: C/gosstartsession.xml:25
 msgid "Normally, logging out ends the session, but you can choose to save the state of your session and restore it next time you use MATE: see <xref linkend=\"gosstartsession-2\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosstartsession.xml:45
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:47
 msgid "Logging in to MATE"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/gosstartsession.xml:46
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:48
 msgid "<primary>sessions</primary> <secondary>logging in</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/gosstartsession.xml:50
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:52
 msgid "<primary>logging in</primary> <secondary>to session</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/gosstartsession.xml:54
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:56
 msgid "<primary>start session</primary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosstartsession.xml:57
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:59
 msgid "To log in to a session, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:60
+#: C/gosstartsession.xml:62
 msgid "On the login screen, click on the <guilabel>Session</guilabel> icon. Choose the MATE Desktop from the list of available desktop environments. Most users will not need to perform this step, as MATE is usually the default desktop environment already."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:66
-#: C/gosstartsession.xml:111
+#: C/gosstartsession.xml:68
+#: C/gosstartsession.xml:113
 msgid "Enter your username in the <guilabel>Username</guilabel> field on the login screen, then press <keycap>Return</keycap>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:70
-#: C/gosstartsession.xml:115
+#: C/gosstartsession.xml:72
+#: C/gosstartsession.xml:117
 msgid "Enter your password in the <guilabel>Password</guilabel> field on the login screen, then press <keycap>Return</keycap>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosstartsession.xml:74
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:76
 msgid "When you log in successfully, MATE will take a short amount of time to start up. When it is ready, you will see the Desktop and you can begin using your computer."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosstartsession.xml:75
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:77
 msgid "The first time you log in, the session manager starts a new session. If you have logged in before and saved the settings for the previous session when you logged out, then the session manager restores your previous session."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosstartsession.xml:79
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:81
 msgid "If you want to shut down or restart the system before you log in, click on the <guilabel>System</guilabel> icon on the login screen. A dialog is displayed. Select the option that you require, then click <guibutton>OK</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosstartsession.xml:82
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:84
 msgid "Your system distributor or vendor may have altered the login screen so that it no longer has a <guilabel>System</guilabel> icon. In this case, the option to shut down the computer may be found by clicking the <guilabel>Other</guilabel> icon, or by clicking a separate <guibutton>Shut Down</guibutton> button."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosstartsession.xml:90
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:92
 msgid "Using a Different Language"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/gosstartsession.xml:91
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:93
 msgid "<primary>sessions</primary> <secondary>different language, logging in</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/gosstartsession.xml:96
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:98
 msgid "<primary>language, logging in in different</primary>"
 msgstr ""
 
-#. (itstool) path: sect2/indexterm
-#: C/gosstartsession.xml:99
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:101
 msgid "<primary>logging in</primary> <secondary>to session in different language</secondary>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosstartsession.xml:103
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:105
 msgid "To log in to a session in a different language, perform the following actions."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:107
+#: C/gosstartsession.xml:109
 msgid "On the login screen, click on the <guilabel>Language</guilabel> icon. Choose the language you require from the list of available languages."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosstartsession.xml:120
+#: C/gosstartsession.xml:122
 msgid "When you log in to a session in a different language, you are changing the language for the user interface but are not changing the keyboard layout. To choose a different keyboard layout, use the <application>Keyboard Indicator</application> applet."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosstartsession.xml:126
+#: C/gosstartsession.xml:128
 msgid "Your system distributor or vendor may have altered the login screen so that it no longer has a <guilabel>Language</guilabel> icon. In this case, the option to change the session's language may be found by clicking the <guilabel>Other</guilabel> icon."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/gosstartsession.xml:133
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:135
 msgid "Locking Your Screen"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:146
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:148
 msgid "<primary>sessions</primary> <secondary>locking screen</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:156
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:158
 msgid "Locking your screen prevents access to your applications and information, allowing you to leave your computer unattended. While your screen is locked, the screensaver runs."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:158
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:160
 msgid "To lock the screen, perform one of the following actions:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:162
+#: C/gosstartsession.xml:164
 msgid "Choose <menuchoice><guimenu>System</guimenu><guimenuitem>Lock Screen</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:165
+#: C/gosstartsession.xml:167
 msgid "If the <guibutton>Lock Screen</guibutton> button is present on a panel, click on the <guibutton>Lock Screen</guibutton> button."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosstartsession.xml:167
+#: C/gosstartsession.xml:169
 msgid "The <guibutton>Lock Screen</guibutton> button is not present on the panels by default. To add it, see <xref linkend=\"panels-addobject\"/>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:170
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:172
 msgid "To unlock the screen, move your mouse or press any key, enter your password in the locked screen dialog, then press <keycap>Return</keycap>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:171
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:173
 msgid "If another user wants to use the computer while it is locked, they can move the mouse or press a key and then click <guibutton>Switch User</guibutton>. The login screen will be displayed, and they can log in using their user account. They will not be able to access any of your applications or information. When they log out, the screen will be locked again and you can access your session by unlocking the screen."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:172
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:174
 msgid "You can leave a message for a user who has locked their screen. Move the mouse or press any key and then click <guibutton>Leave Message</guibutton>. Type your message into the box and press <guibutton>Save</guibutton>. Your message will be displayed when the user unlocks their screen."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/gosstartsession.xml:176
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:177
 msgid "Setting Programs to Start Automatically When You Log In"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:181
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:182
 msgid "<primary>sessions</primary> <secondary>startup</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:185
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:186
 msgid "You can choose for certain programs to be started automatically when you log in to a session. For example, you might want a web browser to be started as soon as you log in. Programs which start automatically when you log in are called <firstterm>startup programs</firstterm>. Startup programs are automatically saved and safely closed by the session manager when you log out, and are restarted when you log in."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:191
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:192
 msgid "The <application>Sessions</application> preference tool allows you to define which programs are started automatically when you log in. It has two tabs, the <guilabel>Startup Programs</guilabel> tab and the <guilabel>Options</guilabel> tab."
 msgstr ""
 
-#. (itstool) path: sect2/title
+#. (itstool) path: info/title
 #: C/gosstartsession.xml:197
 msgid "Startup Programs Tab"
 msgstr ""
 
-#. (itstool) path: sect2/para
+#. (itstool) path: section/para
 #: C/gosstartsession.xml:201
 msgid "You can use the Startup Programs tab to add, modify, and remove startup programs."
 msgstr ""
 
-#. (itstool) path: sect2/para
+#. (itstool) path: section/para
 #: C/gosstartsession.xml:203
 msgid "A list of startup programs is displayed on this tab. The list shows a short description of each program, along with a checkbox which denotes whether the startup program is enabled or not. Programs which are not enabled will not be started automatically when you log in."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/gosstartsession.xml:209
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:208
 msgid "Enabling/Disabling Startup Programs"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosstartsession.xml:210
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:209
 msgid "To enable a program to start up automatically, check the checkbox corresponding to that program."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosstartsession.xml:212
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:211
 msgid "To disable a program from starting automatically, uncheck the checkbox."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/gosstartsession.xml:216
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:215
 msgid "Adding A New Startup Program"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosstartsession.xml:217
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:216
 msgid "To add a new startup program, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: step/para
-#: C/gosstartsession.xml:220
+#: C/gosstartsession.xml:219
 msgid "Click <guibutton>Add</guibutton>. This will open the <application>Add Startup Program</application> dialog box."
 msgstr ""
 
 #. (itstool) path: step/para
-#: C/gosstartsession.xml:224
+#: C/gosstartsession.xml:223
 msgid "Use the <guilabel>Name</guilabel> text box to specify a name for the new startup program."
 msgstr ""
 
 #. (itstool) path: step/para
-#: C/gosstartsession.xml:228
+#: C/gosstartsession.xml:227
 msgid "Use the <guilabel>Command</guilabel> text box to specify the command which will invoke the application. For example, the command <userinput>pluma</userinput> will start the <application>Pluma Text Editor</application>. If you do not know the exact command, click <guibutton>Browse</guibutton> to choose the path of the command."
 msgstr ""
 
 #. (itstool) path: step/para
-#: C/gosstartsession.xml:235
+#: C/gosstartsession.xml:234
 msgid "Enter a description of the application in the <guilabel>Comments</guilabel> text box. You will see this as the description of the program in the list of startup programs."
 msgstr ""
 
 #. (itstool) path: step/para
-#: C/gosstartsession.xml:240
+#: C/gosstartsession.xml:239
 msgid "Click <guibutton>Add</guibutton>. The application will be added to the list of startup programs with its checkbox in the checked (enabled) state."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/gosstartsession.xml:247
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:246
 msgid "Removing A Startup Program"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosstartsession.xml:248
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:247
 msgid "To remove a startup program, select it from the list of startup programs and click <guibutton>Remove</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/gosstartsession.xml:252
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:251
 msgid "Editing A Startup Program"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosstartsession.xml:253
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:252
 msgid "To edit an existing startup program, select it from the list of startup programs and click <guibutton>Edit</guibutton>. A dialog will appear which allows you to edit the properties of the program. See <xref linkend=\"gosstartsession-212\"/> for more information on the options available in this dialog."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosstartsession.xml:262
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:260
 msgid "Session Options Tab"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosstartsession.xml:266
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:264
 msgid "The session manager can remember which applications you have running when you log out and can automatically restart them when you log in again. If you would like this to happen every time you log out, check <guilabel>Automatically remember running applications when logging out</guilabel>. If you would like this to happen only once, click <guibutton>Remember Currently Running Application</guibutton> before logging out."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/gosstartsession.xml:277
+#. (itstool) path: info/title
+#: C/gosstartsession.xml:274
 msgid "Ending a Session"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:280
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:277
 msgid "<primary>sessions</primary> <secondary>ending</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:284
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:281
 msgid "<primary>sessions</primary> <secondary>logging out</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:288
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:285
 msgid "<primary>logging out</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:291
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:288
 msgid "<primary>quit</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/indexterm
-#: C/gosstartsession.xml:294
+#. (itstool) path: section/indexterm
+#: C/gosstartsession.xml:291
 msgid "<primary>shutdown</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:310
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:307
 msgid "When you have finished using your computer, you can choose to do one of the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:313
+#: C/gosstartsession.xml:310
 msgid "Log out, leaving the computer ready for another user to begin working with it. To log out of MATE, choose <menuchoice><guimenu>System</guimenu><guimenuitem>Log Out <replaceable>username</replaceable></guimenuitem></menuchoice> ."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:316
+#: C/gosstartsession.xml:313
 msgid "Shut down your computer and switch off the power. To shut down, choose <menuchoice><guimenu>System</guimenu><guimenuitem>Shut Down</guimenuitem></menuchoice> and click <guibutton>Shut Down</guibutton> on the dialog that appears."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosstartsession.xml:319
+#: C/gosstartsession.xml:316
 msgid "Depending on your computer's configuration, you can also <firstterm>Hibernate</firstterm> your computer. During hibernation, less power is used, but all the applications and documents that you have open are preserved and will still be open when you resume from hibernation. You can resume from hibernation by moving your mouse or pressing a key."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosstartsession.xml:324
+#: C/gosstartsession.xml:321
 msgid "Some vendors and distributors allow you to hibernate your computer in two ways, often called Hibernate and <firstterm>Suspend</firstterm>. Both of these will preserve your open files and applications, but one will switch off the power to your computer while the other will leave the computer running in a state that uses less power."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:327
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:324
 msgid "When you end a session, applications with unsaved work will warn you. You can choose to save your work, or cancel the command to log out or shut down."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosstartsession.xml:329
+#. (itstool) path: section/para
+#: C/gosstartsession.xml:326
 msgid "Before you end a session, you might want to save your current settings so that you can restore the session later. In the <link linkend=\"prefs-sessions\"><application>Sessions</application></link> preference tool, you can select an option to automatically save your current settings."
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/gostools.xml:3
+#. (itstool) path: info/title
+#: C/gostools.xml:7
 msgid "Tools and Utilities"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/gostools.xml:6
+#: C/gostools.xml:10
 msgid "This section describes some tools and utilities in the MATE Desktop."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:10
+#. (itstool) path: info/title
+#: C/gostools.xml:13
 msgid "Running Applications"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gostools.xml:13
+#: C/gostools.xml:16
 msgid "<primary>Run Application dialog, using</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:16
+#: C/gostools.xml:19
 msgid "The <guilabel>Run Application</guilabel> dialog gives you access to the command line. When you run a command in the <guilabel>Run Application</guilabel> dialog, you cannot receive output from the command."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:21
+#: C/gostools.xml:24
 msgid "To run a command from the command line perform the following steps:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:28
+#: C/gostools.xml:31
 msgid "From a panel"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:29
+#: C/gostools.xml:32
 msgid "You can add the <application>Run Application</application> button to any panel. See <xref linkend=\"panels-addobject\"/>. Click on the <guibutton>Run Application</guibutton> panel button to open the <guilabel>Run Application</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:32
+#: C/gostools.xml:35
 msgid "Using shortcut keys"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:34
+#: C/gostools.xml:37
 msgid "Press <keycombo><keycap>Alt</keycap><keycap>F2</keycap></keycombo>. You can change the shortcut keys that display the <guilabel>Run Application</guilabel> dialog in the <link linkend=\"prefs-keyboard-shortcuts\"><application>Keyboard Shortcuts</application> preference tool</link>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:25
+#: C/gostools.xml:28
 msgid "Open the <guilabel>Run Application</guilabel> dialog in any of the following ways: <_:variablelist-1/>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:43
+#: C/gostools.xml:46
 msgid "The <guilabel>Run Application</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:46
+#: C/gostools.xml:49
 msgid "Enter the command that you want to run in the blank field, or choose from the list of known applications."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:47
+#: C/gostools.xml:50
 msgid "If you enter only the location of a file, an appropriate application will launch to open it. If you enter a web page address, your default web browser will open the page. Prefix the web page address with http://, as in http://www.mate-desktop.org."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:50
+#: C/gostools.xml:53
 msgid "To choose a command that you ran previously, click the down arrow button beside the command field, then choose the command to run."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:54
+#: C/gostools.xml:57
 msgid "You can also use the <guibutton>Run with file</guibutton> button to choose a file to append to the command line. For example, you can enter <application>emacs</application> as the command, then choose a file to edit."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:59
+#: C/gostools.xml:62
 msgid "Select the <guilabel>Run in terminal</guilabel> option to run the application or command in a terminal window. Choose this option for an application or command that does not create a window in which to run."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:64
+#: C/gostools.xml:67
 msgid "Click on the <guibutton>Run</guibutton> button on the <guilabel>Run Application</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:70
+#. (itstool) path: info/title
+#: C/gostools.xml:72
 msgid "Taking Screenshots"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gostools.xml:73
+#: C/gostools.xml:75
 msgid "<primary>screenshots, taking</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:76
+#: C/gostools.xml:78
 msgid "You can take a screenshot in any of the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:79
+#: C/gostools.xml:81
 msgid "From any panel"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:80
+#: C/gostools.xml:82
 msgid "You can add a <guibutton>Take Screenshot</guibutton> button to any panel. For instructions on how to do this, see <xref linkend=\"panels-addobject\"/>. Click on the <guibutton>Take Screenshot</guibutton> button to take a screenshot of the entire screen."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:84
+#: C/gostools.xml:86
 msgid "Use shortcut keys"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:85
+#: C/gostools.xml:87
 msgid "To take a screenshot, use the following shortcut keys:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:93
+#: C/gostools.xml:95
 msgid "Default Shortcut Keys"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:108
+#: C/gostools.xml:110
 msgid "Takes a screenshot of the entire screen."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:113
+#: C/gostools.xml:115
 msgid "<keycombo><keycap>Alt</keycap><keycap>Print Screen</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:116
+#: C/gostools.xml:118
 msgid "Takes a screenshot of the window which is active."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:122
+#: C/gostools.xml:124
 msgid "You can use the <link linkend=\"prefs-keyboard-shortcuts\"><application>Keyboard Shortcuts</application> preference tool</link> to modify the default shortcut keys."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:126
+#: C/gostools.xml:128
 msgid "From the Menubar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:127
+#: C/gostools.xml:129
 msgid "Choose <menuchoice><guimenu>Applications</guimenu><guimenuitem>Accessories</guimenuitem> <guimenuitem>Take Screenshot</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:131
+#: C/gostools.xml:133
 msgid "From the Terminal"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:132
+#: C/gostools.xml:134
 msgid "You can use the <command>mate-screenshot</command> command to take a screenshot. The <command>mate-screenshot</command> command takes a screenshot of the entire screen, and displays the <guilabel>Save Screenshot</guilabel> dialog. Use the <guilabel>Save Screenshot</guilabel> dialog to save the screenshot."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:138
+#: C/gostools.xml:140
 msgid "You can also use options on the <command>mate-screenshot</command> command as follows:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:159
+#: C/gostools.xml:161
 msgid "<command>--window</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:164
+#: C/gostools.xml:166
 msgid "Takes a screenshot of the window that has focus."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:169
+#: C/gostools.xml:171
 msgid "<command>--delay=<replaceable>seconds</replaceable></command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:174
+#: C/gostools.xml:176
 msgid "Takes a screenshot after the specified number of seconds, and displays the <guilabel>Save Screenshot</guilabel> dialog. Use the <guilabel>Save Screenshot</guilabel> dialog to save the screenshot."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:184
+#: C/gostools.xml:186
 msgid "<command>--include-border</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:189
+#: C/gostools.xml:191
 msgid "Takes a screenshot including the border of the window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:194
+#: C/gostools.xml:196
 msgid "<command>--remove-border</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:199
+#: C/gostools.xml:201
 msgid "Takes a screenshot without the border of the window."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:204
+#: C/gostools.xml:206
 msgid "<command>--border-effect=shadow</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:209
+#: C/gostools.xml:211
 msgid "Takes a screenshot and adds a shadow bevel effect around it."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:214
+#: C/gostools.xml:216
 msgid "<command>--border-effect=border</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:219
+#: C/gostools.xml:221
 msgid "Takes a screenshot and adds a border effect around it."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:224
+#: C/gostools.xml:226
 msgid "<command>--interactive</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:229
+#: C/gostools.xml:231
 msgid "Opens a window that lets you set options before taking the screenshot."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:234
+#: C/gostools.xml:236
 msgid "<command>--help</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/gostools.xml:239
+#: C/gostools.xml:241
 msgid "Displays the options for the command."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:248
+#: C/gostools.xml:250
 msgid "When you take a screenshot, the <guilabel>Save Screenshot</guilabel> dialog opens. To save the screenshot as an image file, enter the filename for the screenshot, choose a location from the drop-down list and click the <guilabel>Save</guilabel> button. You can also use the <guilabel>Copy to Clipboard</guilabel> button to copy the image to the clipboard or transfer it to another application by drag-and-drop."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:258
+#. (itstool) path: info/title
+#: C/gostools.xml:259
 msgid "Yelp Help Browser"
 msgstr ""
 
 #. (itstool) path: section/indexterm
-#: C/gostools.xml:259
+#: C/gostools.xml:260
 msgid "<primary>Yelp</primary>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:267
+#: C/gostools.xml:266
 msgid "The <application>Yelp Help Browser</application> application allows you to view documentation regarding MATE and other components through a variety of formats. These formats include docbook files, HTML help pages, man pages and info pages (support for man pages and info pages may optionally be compiled in). Despite the different formats supported, Yelp does its best to provide a unified look and feel regardless of the original document format."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:274
+#: C/gostools.xml:273
 msgid "<application>Yelp Help Browser</application> is internationalized, meaning that it has support to view documents in different languages. The documents must be localized or translated for each language and installed properly for Yelp Help Browser to be able to view them."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:283
+#. (itstool) path: info/title
+#: C/gostools.xml:281
 msgid "Starting Yelp"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:286
+#. (itstool) path: info/title
+#: C/gostools.xml:283
 msgid "To Start <application>Yelp Help Browser</application>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:288
+#: C/gostools.xml:284
 msgid "You can start <application>Yelp Help Browser</application> in the following ways:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:292
+#: C/gostools.xml:288
 msgid "<guimenu>System</guimenu> Menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:295
+#: C/gostools.xml:291
 msgid "Choose <application>Help</application>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:300
+#: C/gostools.xml:296
 msgid "Command Line"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:303
+#: C/gostools.xml:299
 msgid "Execute the following command: <command>yelp</command>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:311
+#. (itstool) path: info/title
+#: C/gostools.xml:306
 msgid "Interface"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:313
+#: C/gostools.xml:307
 msgid "When you start <application>Yelp Help Browser</application>, you will see the following window appear."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gostools.xml:317
+#. (itstool) path: info/title
+#: C/gostools.xml:310
 msgid "<application>Yelp Help Browser</application> Window"
 msgstr ""
 
@@ -13962,273 +13952,263 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gostools.xml:321
+#: C/gostools.xml:313
 msgctxt "_"
 msgid "external ref='figures/yelp_window.png' md5='c7138987ae131fe2c57846a281245d31'"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:316
+#: C/gostools.xml:310
 msgid "<_:figure-1/><application>Yelp Help Browser</application> contains the following elements in <xref linkend=\"fig-yelp-window\"/>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:329
-msgid "<interface>Menubar</interface>"
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/gostools.xml:334
+#: C/gostools.xml:325
 msgid "<guimenu>File</guimenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:337
+#: C/gostools.xml:328
 msgid "Use this menu to Open a New Window, view the About this Document page, Print the current document, or Close the window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:344
+#: C/gostools.xml:335
 msgid "<guimenu>Edit</guimenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:347
+#: C/gostools.xml:338
 msgid "Use this menu to Copy, Select all, Find..., or to set your Preferences."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:353
+#: C/gostools.xml:344
 msgid "<guimenu>Go</guimenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:356
+#: C/gostools.xml:347
 msgid "Use this menu to navigate Back, Forward, to the Help Topics page. When viewing a DocBook document, use this menu to navigate to the Next Section, Previous Section or to the Contents."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:364
+#: C/gostools.xml:355
 msgid "<guimenu>Bookmarks</guimenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:367
+#: C/gostools.xml:358
 msgid "Use this menu to Add Bookmark(s), or Edit Bookmark(s)."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:373
+#: C/gostools.xml:364
 msgid "<guimenu>Help</guimenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:376
+#: C/gostools.xml:367
 msgid "View information about Yelp Help Browser and contributors to the project through the <guimenuitem>About</guimenuitem> menuitem. Open this document with the <guimenuitem>Contents</guimenuitem> menuitem or by pressing <keycap>F1</keycap>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:388
-msgid "<interface>Toolbar</interface>"
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/gostools.xml:393
+#: C/gostools.xml:384
 msgid "<guibutton>Back</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:396
+#: C/gostools.xml:387
 msgid "Use this button to navigate back in your document history."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:402
+#: C/gostools.xml:393
 msgid "<guibutton>Forward</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:405
+#: C/gostools.xml:396
 msgid "Use this button to navigate forward in your document history."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:411
+#: C/gostools.xml:402
 msgid "<guibutton>Help Topics</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:414
+#: C/gostools.xml:405
 msgid "Use this button to return to the main table of contents (shown in <xref linkend=\"fig-yelp-window\"/>)."
 msgstr ""
 
-#. (itstool) path: varlistentry/term
-#: C/gostools.xml:423
-msgid "<interface>Browser Pane</interface>"
+#. (itstool) path: term/interface
+#: C/gostools.xml:414
+msgid "Browser Pane"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:426
+#: C/gostools.xml:417
 msgid "The browser pane is where you will be presented with the table of contents or the documentation. Use the table of contents to navigate to the documentation you need."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:438
+#. (itstool) path: info/title
+#: C/gostools.xml:428
 msgid "Using Yelp"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:441
+#. (itstool) path: info/title
+#: C/gostools.xml:430
 msgid "Open a Document"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:447
+#: C/gostools.xml:435
 msgid "In an application, click <menuchoice> <guimenu>Help</guimenu> <guimenuitem>Contents</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:455
+#: C/gostools.xml:443
 msgid "Use the Table of Contents to navigate to the desired document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:458
+#: C/gostools.xml:446
 msgid "You can drag a Docbook XML file from Caja to the Yelp window or launcher."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:461
+#: C/gostools.xml:449
 msgid "Press the <keycap>F1</keycap> key."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:443
+#: C/gostools.xml:431
 msgid "To open a document in <application>Yelp Help Browser</application>: <_:itemizedlist-1/>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:466
+#: C/gostools.xml:454
 msgid "Alternatively, you may view a particular document by invoking Yelp Help Browser from the command line or dragging files to Yelp. See <xref linkend=\"yelp-open-specific\"/> for more on this."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:472
+#. (itstool) path: info/title
+#: C/gostools.xml:458
 msgid "Open a New Window"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:474
+#: C/gostools.xml:459
 msgid "To open a new window:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:478
+#: C/gostools.xml:463
 msgid "Click <menuchoice> <guimenu>File</guimenu> <guimenuitem>New Window</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:486
+#: C/gostools.xml:471
 msgid "Use the key combination <keycombo><keycap>Ctrl</keycap><keycap>N</keycap></keycombo>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:493
+#. (itstool) path: info/title
+#: C/gostools.xml:477
 msgid "About This Document"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:495
+#: C/gostools.xml:478
 msgid "To view information about the currently open document:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:499
+#: C/gostools.xml:482
 msgid "Click <menuchoice> <guimenu>File</guimenu> <guimenuitem>About This Document</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gostools.xml:506
+#: C/gostools.xml:489
 msgid "This option is only available for DocBook documentation. Legal notices and documentation contributors are usually listed in this section."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:513
+#. (itstool) path: info/title
+#: C/gostools.xml:495
 msgid "Print a Page"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:515
+#: C/gostools.xml:496
 msgid "To print any page that you are able to view in <application>Yelp Help Browser</application>:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:519
+#: C/gostools.xml:500
 msgid "Click <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print this Page</guimenuitem> </menuchoice>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:529
+#. (itstool) path: info/title
+#: C/gostools.xml:509
 msgid "Print a Document"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:531
+#: C/gostools.xml:510
 msgid "To print an entire document:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:535
+#: C/gostools.xml:514
 msgid "Click <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print this Document</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gostools.xml:542
+#: C/gostools.xml:521
 msgid "This option is only available for DocBook documentation."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:548
+#. (itstool) path: info/title
+#: C/gostools.xml:526
 msgid "Close a Window"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:550
+#: C/gostools.xml:527
 msgid "To close a window in <application>Yelp Help Browser</application>, do the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:554
+#: C/gostools.xml:531
 msgid "Click <menuchoice> <guimenu>File</guimenu> <guimenuitem>Close Window</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:562
+#: C/gostools.xml:539
 msgid "Use the key combination <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:569
+#. (itstool) path: info/title
+#: C/gostools.xml:545
 msgid "Set Preferences"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:571
+#: C/gostools.xml:546
 msgid "To set your preferences in <application>Yelp Help Browser</application>:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:575
+#: C/gostools.xml:550
 msgid "Click <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:573
+#: C/gostools.xml:548
 msgid "<_:itemizedlist-1/>A window will appear that looks like <xref linkend=\"yelp-preferences\"/>:"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gostools.xml:585
+#. (itstool) path: info/title
+#: C/gostools.xml:558
 msgid "<application>Yelp Help Browser</application> Preferences Window"
 msgstr ""
 
@@ -14237,225 +14217,225 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gostools.xml:589
+#: C/gostools.xml:561
 msgctxt "_"
 msgid "external ref='figures/yelp_preferences.png' md5='b8beb6c866957938b5e39bc7f72611ec'"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:584
+#: C/gostools.xml:558
 msgid "<_:figure-1/>The options that are available in this dialog have the following functions:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:597
+#: C/gostools.xml:569
 msgid "<guilabel>Use system fonts</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:600
+#: C/gostools.xml:572
 msgid "Check this option to display documentation using the default fonts used by the MATE Desktop."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:603
+#: C/gostools.xml:575
 msgid "To choose your own fonts to display documentation, uncheck this option and click on the buttons next to the text <guilabel>Variable Width</guilabel> or <guilabel>Fixed Width</guilabel>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:610
+#: C/gostools.xml:582
 msgid "<guilabel>Variable Width</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:613
+#: C/gostools.xml:585
 msgid "This is the font to use when a static or fixed width font is not required. The majority of text will be of this type."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:620
+#: C/gostools.xml:592
 msgid "<guilabel>Fixed Width</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:623
+#: C/gostools.xml:595
 msgid "This is the font to use when all text characters need to be of the same size. This font is usually used to indicate commands, program blocks, or other text that falls under these categories."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:634
+#: C/gostools.xml:606
 msgid "<guilabel>Browse with caret</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:637
+#: C/gostools.xml:609
 msgid "Click this option if you would like see a caret or cursor in the <xref linkend=\"yelp-browser-pane\"/>. This allows you to browse the document more easily by showing where the cursor is located in the document."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:647
+#. (itstool) path: info/title
+#: C/gostools.xml:618
 msgid "Go Back in Document History"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:649
+#: C/gostools.xml:619
 msgid "To go back in the document history:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:653
+#: C/gostools.xml:623
 msgid "Click <menuchoice> <guimenu>Go</guimenu> <guimenuitem>Back</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:661
+#: C/gostools.xml:631
 msgid "Use the key combination <keycombo><keycap>Alt</keycap><keycap>Left</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:666
-msgid "Use the <guibutton>Back</guibutton> button in the <interface>Toolbar</interface>"
+#: C/gostools.xml:636
+msgid "Use the <guibutton>Back</guibutton> button in the <_:interface-1/>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:673
+#. (itstool) path: info/title
+#: C/gostools.xml:642
 msgid "Go Forward in Document History"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:675
+#: C/gostools.xml:643
 msgid "To go forward in the document history:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:679
+#: C/gostools.xml:647
 msgid "Click <menuchoice> <guimenu>Go</guimenu> <guimenuitem>Forward</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:687
+#: C/gostools.xml:655
 msgid "Use the key combination <keycombo><keycap>Alt</keycap><keycap>Right</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:692
-msgid "Use the <guibutton>Forward</guibutton> button in the <interface>Toolbar</interface>"
+#: C/gostools.xml:660
+msgid "Use the <guibutton>Forward</guibutton> button in the <_:interface-1/>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:699
+#. (itstool) path: info/title
+#: C/gostools.xml:666
 msgid "Go to Help Topics"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:701
+#: C/gostools.xml:667
 msgid "To go to the Help Topics:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:705
+#: C/gostools.xml:671
 msgid "Click <menuchoice> <guimenu>Go</guimenu> <guimenuitem>Help Topics</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:713
+#: C/gostools.xml:679
 msgid "Use the key combination <keycombo><keycap>Alt</keycap><keycap>Home</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:718
-msgid "Use the <guibutton>Help Topics</guibutton> button in the <interface>Toolbar</interface>"
+#: C/gostools.xml:684
+msgid "Use the <guibutton>Help Topics</guibutton> button in the <_:interface-1/>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:725
+#. (itstool) path: info/title
+#: C/gostools.xml:690
 msgid "Go to Previous Section"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:727
+#: C/gostools.xml:691
 msgid "To go to the previous section:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:731
+#: C/gostools.xml:695
 msgid "Click <menuchoice> <guimenu>Go</guimenu> <guimenuitem>Previous Section</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:739
+#: C/gostools.xml:703
 msgid "Use the key combination <keycombo><keycap>Alt</keycap><keycap>Up</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gostools.xml:743
-#: C/gostools.xml:767
-#: C/gostools.xml:786
+#: C/gostools.xml:707
+#: C/gostools.xml:731
+#: C/gostools.xml:750
 msgid "This option is only available in DocBook formatted documents."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:749
+#. (itstool) path: info/title
+#: C/gostools.xml:712
 msgid "Go to Next Section"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:751
+#: C/gostools.xml:715
 msgid "To go to the next section:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:755
+#: C/gostools.xml:719
 msgid "Click <menuchoice> <guimenu>Go</guimenu> <guimenuitem>Next Section</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:763
+#: C/gostools.xml:727
 msgid "Use the key combination <keycombo><keycap>Alt</keycap><keycap>Down</keycap></keycombo>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:773
+#. (itstool) path: info/title
+#: C/gostools.xml:736
 msgid "Go to Contents"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:775
+#: C/gostools.xml:739
 msgid "To go to the contents for a document:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:779
+#: C/gostools.xml:743
 msgid "Click <menuchoice> <guimenu>Go</guimenu> <guimenuitem>Contents</guimenuitem> </menuchoice>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:792
+#. (itstool) path: info/title
+#: C/gostools.xml:755
 msgid "Add a Bookmark"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:794
+#: C/gostools.xml:758
 msgid "To add a bookmark for a particular document:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:798
+#: C/gostools.xml:762
 msgid "Click <menuchoice> <guimenu>Bookmarks</guimenu> <guimenuitem>Add Bookmark</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:806
+#: C/gostools.xml:770
 msgid "Use the key combination <keycombo><keycap>Ctrl</keycap><keycap>D</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:796
+#: C/gostools.xml:760
 msgid "<_:itemizedlist-1/>A window will appear that looks like <xref linkend=\"yelp-add-bookmark\"/>."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gostools.xml:813
+#. (itstool) path: info/title
+#: C/gostools.xml:775
 msgid "Add Bookmark Window"
 msgstr ""
 
@@ -14464,43 +14444,45 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gostools.xml:817
+#: C/gostools.xml:778
 msgctxt "_"
 msgid "external ref='figures/yelp_add_bookmark.png' md5='562a62662f47655337c9bf341ef69f6e'"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:812
+#: C/gostools.xml:775
 msgid "<_:figure-1/>Enter your desired bookmark title in to the <guilabel>Title</guilabel> text entry field. Then click <guibutton>Add</guibutton> to add the bookmark, or click <guibutton>Cancel</guibutton> to cancel the request."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:827
+#. (itstool) path: info/title
+#: C/gostools.xml:787
 msgid "Edit Bookmarks"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:829
+#: C/gostools.xml:788
 msgid "To edit your collection of bookmarks:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:833
+#: C/gostools.xml:792
 msgid "Click <menuchoice> <guimenu>Bookmarks</guimenu> <guimenuitem>Edit Bookmarks...</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:840
+#: C/gostools.xml:799
 msgid "Use the key combination <keycombo><keycap>Ctrl</keycap><keycap>B</keycap></keycombo>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:831
+#: C/gostools.xml:790
 msgid "<_:itemizedlist-1/>A window will appear that looks like <xref linkend=\"yelp-edit-bookmarks\"/>."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gostools.xml:847
+#. (itstool) path: info/title
+#. (itstool) path: para/interface
+#: C/gostools.xml:804
+#: C/gostools.xml:841
 msgid "Edit Bookmarks Window"
 msgstr ""
 
@@ -14509,166 +14491,166 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gostools.xml:851
+#: C/gostools.xml:807
 msgctxt "_"
 msgid "external ref='figures/yelp_edit_bookmarks.png' md5='6fb478c10bb9df68dc8d82f3ed4ac89b'"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:846
+#: C/gostools.xml:804
 msgid "<_:figure-1/>You can manage your bookmarks using this window in the following ways:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:859
+#: C/gostools.xml:815
 msgid "<guibutton>Open</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:862
+#: C/gostools.xml:818
 msgid "Use this button to open the selected bookmark in a new window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:868
+#: C/gostools.xml:824
 msgid "<guibutton>Rename</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:871
+#: C/gostools.xml:827
 msgid "Use this button to rename the title of your bookmark."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:877
+#: C/gostools.xml:833
 msgid "<guibutton>Remove</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:880
+#: C/gostools.xml:836
 msgid "Use this button to delete the bookmark from your collection."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:857
-msgid "<_:variablelist-1/>Once you are finished managing your bookmarks, click the <guibutton>Close</guibutton> button to exit the <interface>Edit Bookmarks Window</interface>."
+#: C/gostools.xml:813
+msgid "<_:variablelist-1/>Once you are finished managing your bookmarks, click the <guibutton>Close</guibutton> button to exit the <_:interface-2/>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:890
+#. (itstool) path: info/title
+#: C/gostools.xml:845
 msgid "Get Help"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:892
+#: C/gostools.xml:846
 msgid "To get help to use <application>Yelp Help Browser</application> (and see this document):"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:897
+#: C/gostools.xml:851
 msgid "Click <menuchoice> <guimenu>Help</guimenu> <guimenuitem>Contents</guimenuitem> </menuchoice>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:910
+#. (itstool) path: info/title
+#: C/gostools.xml:863
 msgid "Advanced Features"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:914
+#. (itstool) path: info/title
+#: C/gostools.xml:865
 msgid "Opening Specific Documents"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:917
+#. (itstool) path: info/title
+#: C/gostools.xml:867
 msgid "Opening Documents from the File Manager"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:918
+#: C/gostools.xml:868
 msgid "To open a document, such as an XML file, from the file manager, open the document in <application>Caja</application> File Manager, or drag the icon from <application>Caja</application> to the <application>Yelp</application> document pane or launcher."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:924
+#. (itstool) path: info/title
+#: C/gostools.xml:872
 msgid "Using the Command Line to Open Documents"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:926
+#: C/gostools.xml:873
 msgid "Yelp Help Browser supports opening documents from the command line. There are a number of URIs (Uniform Resource Identifiers) that can be used. These include:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:932
+#: C/gostools.xml:879
 msgid "<option>file:</option>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:935
+#: C/gostools.xml:882
 msgid "Use this URI when you want to access a file with yelp, for example:"
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gostools.xml:938
+#: C/gostools.xml:885
 #, no-wrap
 msgid ""
 "<userinput>yelp file:///usr/share/help/C/mate-control-center/config-mouse.xml</userinput>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:944
+#: C/gostools.xml:891
 msgid "<option>help:</option>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:947
+#: C/gostools.xml:894
 msgid "Use this URI when you want to access MATE help documents, which are typically written in DocBook format."
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gostools.xml:950
+#: C/gostools.xml:897
 #, no-wrap
 msgid ""
 "<userinput>yelp help:mate-terminal</userinput>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:952
+#: C/gostools.xml:899
 msgid "If you want to open the help document at a particular section, append a slash to the end of the URI, followed by the section id."
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gostools.xml:955
+#: C/gostools.xml:902
 #, no-wrap
 msgid ""
 "<userinput>yelp help:mate-user-guide/yelp-advanced-cmdline</userinput>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:960
+#: C/gostools.xml:907
 msgid "<option>man:</option>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:963
+#: C/gostools.xml:910
 msgid "Use this URI when you want to access a particular man page. You can append the section of the man page you would like to view if there are multiple man pages with the same name. The section number should be enclosed in parentheses and therefore it may be necessary to escape the argument so that the shell does not interpret the parenthesis."
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gostools.xml:970
+#: C/gostools.xml:917
 #, no-wrap
 msgid ""
 "<userinput>yelp man:mate-panel</userinput>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:972
+#: C/gostools.xml:919
 msgid "or"
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gostools.xml:974
+#: C/gostools.xml:921
 #, no-wrap
 msgid ""
 "<userinput>yelp 'man:intro(1)'</userinput>\n"
@@ -14676,134 +14658,134 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gostools.xml:980
+#: C/gostools.xml:927
 msgid "<option>info:</option>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:983
+#: C/gostools.xml:930
 msgid "Use this URI when you want to access a particular GNU info page."
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gostools.xml:986
+#: C/gostools.xml:933
 #, no-wrap
 msgid ""
 "<userinput>yelp info:make</userinput>"
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:995
+#. (itstool) path: info/title
+#: C/gostools.xml:940
 msgid "Refreshing Content on Demand"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:997
+#: C/gostools.xml:941
 msgid "<application>Yelp Help Browser</application> supports the <keycombo><keycap>Ctrl</keycap><keycap>R</keycap></keycombo> shortcut keys, which will reload the DocBook document that is currently open. This allows developers to view changes to documents as they are made."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:1005
+#. (itstool) path: info/title
+#: C/gostools.xml:948
 msgid "More Information"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:1007
+#: C/gostools.xml:949
 msgid "This section details some helper applications which <application>Yelp Help Browser</application> uses, and provides resources where you can get more information about <application>Yelp Help Browser</application>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:1012
+#. (itstool) path: info/title
+#: C/gostools.xml:953
 msgid "Scrollkeeper"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:1014
+#: C/gostools.xml:954
 msgid "<application>Yelp Help Browser</application> uses scrollkeeper to generate the table of contents for DocBook and HTML documentation, and also keep track of translations for each document."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:1020
+#. (itstool) path: info/title
+#: C/gostools.xml:959
 msgid "MATE Documentation Utilites"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:1022
+#: C/gostools.xml:960
 msgid "The documentation distributed with MATE uses this set of utilities for a variety of things:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:1027
+#: C/gostools.xml:965
 msgid "Ease translation of documents to different languages."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:1031
+#: C/gostools.xml:969
 msgid "Provide a set of tools to help package and install documentation into the correct location and register the documentation with scrollkeeper."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gostools.xml:1037
+#: C/gostools.xml:975
 msgid "Perform conversion from DocBook format to a format suitable for display."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:1025
-msgid "<_:itemizedlist-1/><application>Yelp Help Browser</application> relies on <ulink url=\"help:mate-doc-xslt\">MATE XSLT Stylesheets</ulink> to perform conversion from DocBook to HTML. <ulink url=\"help:mate-doc-make\">MATE Documentation Build Utilities</ulink> are relied upon by application authors to install and register documentation within the help system."
+#: C/gostools.xml:963
+msgid "<_:itemizedlist-1/><application>Yelp Help Browser</application> relies on <link xlink:href=\"help:mate-doc-xslt\">MATE XSLT Stylesheets</link> to perform conversion from DocBook to HTML. <link xlink:href=\"help:mate-doc-make\">MATE Documentation Build Utilities</link> are relied upon by application authors to install and register documentation within the help system."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:1046
+#. (itstool) path: info/title
+#: C/gostools.xml:983
 msgid "Homepage and Mailing List"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:1048
-msgid "For further information on <application>Yelp Help Browser</application>, please visit the Documentation Project homepage, <ulink url=\"http://mate-desktop.org\"/>, or subscribe to the mailing list, <ulink type=\"http\" url=\"http://ml.mate-desktop.org/listinfo/mate-dev\"/>."
+#: C/gostools.xml:984
+msgid "For further information on <application>Yelp Help Browser</application>, please visit the Documentation Project homepage, <uri xlink:href=\"http://mate-desktop.org\">http://mate-desktop.org</uri>, or subscribe to the mailing list, <uri xlink:href=\"http://ml.mate-desktop.org/listinfo/mate-dev\">http://ml.mate-desktop.org/listinfo/mate-dev</uri>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gostools.xml:1054
+#. (itstool) path: info/title
+#: C/gostools.xml:989
 msgid "Joining the MATE Documentation Project"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gostools.xml:1056
-msgid "If you are interested in helping produce and update documentation for the MATE project, please visit the Documentation Project homepage: <ulink url=\"http://wiki.mate-desktop.org/dev-doc:doc-team-guide?s[]=users[]=guide#mate_documentation_team\"/>"
+#: C/gostools.xml:990
+msgid "If you are interested in helping produce and update documentation for the MATE project, please visit the Documentation Project homepage: <uri xlink:href=\"http://wiki.mate-desktop.org/dev-doc:doc-team-guide?s[]=users[]=guide#mate_documentation_team\">http://wiki.mate-desktop.org/dev-doc:doc-team-guide?s[]=users[]=guide#mate_documentation_team</uri>"
 msgstr ""
 
-#. (itstool) path: chapter/title
-#: C/gosdconf.xml:3
+#. (itstool) path: info/title
+#: C/gosdconf.xml:8
 msgid "Desktop Settings Storage"
 msgstr ""
 
 #. (itstool) path: highlights/para
-#: C/gosdconf.xml:6
+#: C/gosdconf.xml:11
 msgid "This chapter describes how are your MATE desktop settings stored, and how to retrieve or modify them using the <command>dconf</command> or <command>gsettings</command> command line tools, or the <application>Dconf Editor</application> GUI application."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosdconf.xml:17
+#. (itstool) path: section/para
+#: C/gosdconf.xml:20
 msgid "The settings of your MATE desktop are managed and stored by <application>dconf</application>, which is a key-based configuration system for hardware and software configurations."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosdconf.xml:23
+#. (itstool) path: section/para
+#: C/gosdconf.xml:26
 msgid "<application>dconf</application> uses several database files in GVDB binary format, one database per file. A dconf profile consists of a single file, in plain text format, which contains a list of database files in GVDB format. All dconf profiles are stored in the <filename class=\"directory\">/etc/dconf/profile</filename> folder."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosdconf.xml:28
+#. (itstool) path: section/para
+#: C/gosdconf.xml:31
 msgid "In most systems, there is no dconf profile file since they only use the default database, user.db which is stored in ~/.config/dconf/user. In such case, there is no system-wide setting, i.e. users just have their own settings."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosdconf.xml:31
+#. (itstool) path: section/para
+#: C/gosdconf.xml:34
 msgid "Example of content for the user profile (/etc/dconf/profile/user file):"
 msgstr ""
 
-#. (itstool) path: sect1/literallayout
-#: C/gosdconf.xml:35
+#. (itstool) path: section/literallayout
+#: C/gosdconf.xml:38
 #, no-wrap
 msgid ""
 "user-db: user\n"
@@ -14812,67 +14794,67 @@ msgid ""
 "system-db: distro"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosdconf.xml:40
+#. (itstool) path: section/para
+#: C/gosdconf.xml:43
 msgid "The previous dconf profile contains 4 GVDB files, one per line."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:46
+#: C/gosdconf.xml:49
 msgid "<database class=\"name\">user</database> is the name of the user's databases. They are usually located in the <filename class=\"directory\">~/.config/dconf</filename> folder"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:49
+#: C/gosdconf.xml:52
 msgid "<database class=\"name\">local</database>, <database class=\"name\">site</database> and <database class=\"name\">distro</database> are system databases. They are usually located in the <filename class=\"directory\">/etc/dconf/db</filename> folder"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/gosdconf.xml:53
+#. (itstool) path: section/para
+#: C/gosdconf.xml:56
 msgid "Each one of these databases store key-value pairs using a hash map data structure, which can map string keys to GVariant values in a way that is extremely efficient for lookups. The lookup preference is determined by the order of appearance in the dconf profile file, user's databases have the highest preference in the previous dconf profile example. The keys from multiple configuration sources coexist in a logical tree structure. MATE Desktop key-value hashmap entries are under the /org/mate logical node, which are usually stored in user's databases."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/gosdconf.xml:60
-msgid "Refer to the <ulink url=\"man:dconf(7)\" type=\"man\"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>7</manvolnum></citerefentry></ulink> for more information about the dconf configuration system."
+#: C/gosdconf.xml:63
+msgid "Refer to the <link xlink:href=\"man:dconf(7)\"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>7</manvolnum></citerefentry></link> for more information about the dconf configuration system."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosdconf.xml:64
+#. (itstool) path: info/title
+#: C/gosdconf.xml:66
 msgid "To read the value of a dconf key"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:66
+#. (itstool) path: section/para
+#: C/gosdconf.xml:69
 msgid "The value of a dconf key can be read using the <command>dconf</command> or <command>gsettings</command> command line tools, or the <application>Dconf Editor</application> GUI application."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:70
+#. (itstool) path: section/para
+#: C/gosdconf.xml:73
 msgid "This section shows how to read the background picture of your MATE desktop, this values is stored in the dconf key:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:75
-#: C/gosdconf.xml:179
+#: C/gosdconf.xml:78
+#: C/gosdconf.xml:182
 msgid "/org/mate/desktop/background/picture-filename"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:79
-#: C/gosdconf.xml:183
+#. (itstool) path: section/para
+#: C/gosdconf.xml:82
+#: C/gosdconf.xml:186
 msgid "The following figure displays the full path to this dconf key. Note that the other directories have not been expanded, or they have been removed, and only are showed the keys for dconf directory:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:85
-#: C/gosdconf.xml:188
+#: C/gosdconf.xml:88
+#: C/gosdconf.xml:191
 msgid "/org/mate/desktop/background/"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gosdconf.xml:90
-#: C/gosdconf.xml:193
+#. (itstool) path: info/title
+#: C/gosdconf.xml:92
+#: C/gosdconf.xml:195
 msgid "/org/mate/desktop/background/ dconf directory"
 msgstr ""
 
@@ -14881,45 +14863,45 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosdconf.xml:93
+#: C/gosdconf.xml:96
 msgctxt "_"
 msgid "external ref='figures/org_mate_desktop_background_logical_view.png' md5='657d280ac9bef4a700c8f46561072828'"
 msgstr ""
 
 #. (itstool) path: figure/mediaobject
-#: C/gosdconf.xml:91
+#: C/gosdconf.xml:94
 msgid "<imageobject> <imagedata fileref=\"figures/org_mate_desktop_background_logical_view.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Figure showing the contents of /org/mate/desktop/background/ dconf directory.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:101
+#. (itstool) path: section/para
+#: C/gosdconf.xml:104
 msgid "You can read the value of a dconf key:"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/gosdconf.xml:106
-#: C/gosdconf.xml:209
+#. (itstool) path: info/title
+#: C/gosdconf.xml:108
+#: C/gosdconf.xml:211
 msgid "Using the dconf-editor GUI application"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:107
+#. (itstool) path: section/para
+#: C/gosdconf.xml:110
 msgid "To show the value of a dconf key using the <application>Dconf Editor</application> application, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:112
-#: C/gosdconf.xml:216
+#: C/gosdconf.xml:115
+#: C/gosdconf.xml:219
 msgid "Choose <menuchoice><guimenu>Applications</guimenu><guimenuitem>System Tools</guimenuitem><guimenuitem>dconf Editor</guimenuitem></menuchoice> from the top panel."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:115
+#: C/gosdconf.xml:118
 msgid "Click on the folders to get the full path to the dconf directory."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gosdconf.xml:120
+#. (itstool) path: info/title
+#: C/gosdconf.xml:122
 msgid "Dconf-Editor showing the value of /org/mate/desktop/background/picture-filename key"
 msgstr ""
 
@@ -14928,105 +14910,104 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosdconf.xml:124
+#: C/gosdconf.xml:127
 msgctxt "_"
 msgid "external ref='figures/picture_filename_dconf_key_view.png' md5='f03c4f0335a297d49495410dc37b5888'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gosdconf.xml:122
+#: C/gosdconf.xml:125
 msgid "<imageobject> <imagedata fileref=\"figures/picture_filename_dconf_key_view.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Dconf-Editor showing the value of /org/mate/desktop/background/picture-filename key</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/gosdconf.xml:135
-#: C/gosdconf.xml:245
+#. (itstool) path: info/title
+#: C/gosdconf.xml:137
+#: C/gosdconf.xml:247
 msgid "Using the dconf command line tool"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:136
+#. (itstool) path: section/para
+#: C/gosdconf.xml:139
 msgid "To read the value of a dconf key using the <command>dconf</command> command line tool, run the following command:"
 msgstr ""
 
-#. (itstool) path: sect3/screen
-#: C/gosdconf.xml:139
+#. (itstool) path: section/screen
+#: C/gosdconf.xml:142
 #, no-wrap
 msgid ""
 "$ dconf read /org/mate/desktop/background/picture-filename\n"
 "'/usr/share/backgrounds/mate/desktop/MATE-Stripes-Dark.png'"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:141
-#: C/gosdconf.xml:158
-#: C/gosdconf.xml:251
-#: C/gosdconf.xml:267
+#. (itstool) path: section/para
+#: C/gosdconf.xml:144
+#: C/gosdconf.xml:161
+#: C/gosdconf.xml:254
+#: C/gosdconf.xml:270
 msgid "Synopsis:"
 msgstr ""
 
-#. (itstool) path: sect3/synopsis
-#: C/gosdconf.xml:144
+#. (itstool) path: section/synopsis
+#: C/gosdconf.xml:147
 #, no-wrap
 msgid ""
 "dconf read [-d] KEY"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:145
-#: C/gosdconf.xml:308
-msgid "Refer to the <ulink url=\"man:dconf\" type=\"man\"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>dconf</command> command line tool."
+#. (itstool) path: section/para
+#: C/gosdconf.xml:148
+#: C/gosdconf.xml:311
+msgid "Refer to the <link xlink:href=\"man:dconf\"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>dconf</command> command line tool."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosdconf.xml:148
+#: C/gosdconf.xml:151
 msgid "You can use the <keycap>Tab</keycap> key to auto complete the path to the dconf key."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/gosdconf.xml:152
-#: C/gosdconf.xml:261
+#. (itstool) path: info/title
+#: C/gosdconf.xml:154
+#: C/gosdconf.xml:263
 msgid "Using the gsettings command line tool"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:153
+#. (itstool) path: section/para
+#: C/gosdconf.xml:156
 msgid "To read the value of a dconf key using the <command>gsettings</command> command line tool, run the following command:"
 msgstr ""
 
-#. (itstool) path: sect3/screen
-#: C/gosdconf.xml:156
+#. (itstool) path: section/screen
+#: C/gosdconf.xml:159
 #, no-wrap
 msgid ""
 "$ gsettings get org.mate.background picture-filename\n"
 "'/usr/share/backgrounds/mate/desktop/MATE-Stripes-Dark.png'"
 msgstr ""
 
-#. (itstool) path: sect3/synopsis
-#: C/gosdconf.xml:161
+#. (itstool) path: section/synopsis
+#: C/gosdconf.xml:164
 #, no-wrap
 msgid ""
 "gsettings [--schemadir SCHEMADIR] get SCHEMA[:PATH] KEY"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:162
-msgid "Refer to the <ulink url=\"man:gsettings\" type=\"man\"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>gsettings</command> command line tool."
+#. (itstool) path: section/para
+#: C/gosdconf.xml:165
+msgid "Refer to the <link xlink:href=\"man:gsettings\"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>gsettings</command> command line tool."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosdconf.xml:169
+#. (itstool) path: info/title
+#: C/gosdconf.xml:171
 msgid "To change the value of a dconf key"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:171
+#. (itstool) path: section/para
+#: C/gosdconf.xml:174
 msgid "The value of a dconf key can be modified using the <command>dconf</command> command or the <application>Dconf Editor</application> application."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:174
+#. (itstool) path: section/para
+#: C/gosdconf.xml:177
 msgid "This section shows how to change the background picture of your MATE desktop, this values is stored in the dconf key:"
 msgstr ""
 
@@ -15035,43 +15016,43 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosdconf.xml:196
+#: C/gosdconf.xml:199
 msgctxt "_"
 msgid "external ref='figures/org_mate_desktop_background_only_logical_view.png' md5='ba63c30934dd9cc0379f54d0cc90850a'"
 msgstr ""
 
 #. (itstool) path: figure/mediaobject
-#: C/gosdconf.xml:194
+#: C/gosdconf.xml:197
 msgid "<imageobject> <imagedata fileref=\"figures/org_mate_desktop_background_only_logical_view.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Figure showing the contents of /org/mate/desktop/background/ dconf directory.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:204
+#. (itstool) path: section/para
+#: C/gosdconf.xml:207
 msgid "You can mofify the value of a dconf key:"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:210
+#. (itstool) path: section/para
+#: C/gosdconf.xml:213
 msgid "To edit the background picture of your MATE desktop in <application>Dconf Editor</application>, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:219
+#: C/gosdconf.xml:222
 msgid "Click on the folders to get the full path to the dconf directory, and then click on the dconf key to edit its value."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:222
+#: C/gosdconf.xml:225
 msgid "Enter the new value in <guilabel>Custom value</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:225
+#: C/gosdconf.xml:228
 msgid "Click on the Check mark button to apply the change."
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/gosdconf.xml:230
+#. (itstool) path: info/title
+#: C/gosdconf.xml:232
 msgid "Editing the value of /org/mate/desktop/background/picture-filename key in Dconf-Editor dialog"
 msgstr ""
 
@@ -15080,91 +15061,91 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/gosdconf.xml:234
+#: C/gosdconf.xml:237
 msgctxt "_"
 msgid "external ref='figures/picture_filename_dconf_key_edit.png' md5='6c51950700e166ae8e96193b1ac8d0cc'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/gosdconf.xml:232
+#: C/gosdconf.xml:235
 msgid "<imageobject> <imagedata fileref=\"figures/picture_filename_dconf_key_edit.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Editing the value of /org/mate/desktop/background/picture-filename key in Dconf-Editor dialog</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:246
-#: C/gosdconf.xml:262
+#. (itstool) path: section/para
+#: C/gosdconf.xml:249
+#: C/gosdconf.xml:265
 msgid "To change the background picture of your MATE desktop, run the following command:"
 msgstr ""
 
-#. (itstool) path: sect3/screen
-#: C/gosdconf.xml:249
+#. (itstool) path: section/screen
+#: C/gosdconf.xml:252
 #, no-wrap
 msgid ""
 "$ dconf write /org/mate/desktop/background/picture-filename \\\n"
 "\"'/usr/share/backgrounds/mate/desktop/MATE-Stripes-Light.png'\""
 msgstr ""
 
-#. (itstool) path: sect3/synopsis
-#: C/gosdconf.xml:254
+#. (itstool) path: section/synopsis
+#: C/gosdconf.xml:257
 #, no-wrap
 msgid ""
 "dconf write KEY VALUE"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:255
-msgid "Refer to the <ulink url=\"man:dconf\" type=\"man\"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>dconf</command>."
+#. (itstool) path: section/para
+#: C/gosdconf.xml:258
+msgid "Refer to the <link xlink:href=\"man:dconf\"><citerefentry><refentrytitle>dconf</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>dconf</command>."
 msgstr ""
 
-#. (itstool) path: sect3/screen
-#: C/gosdconf.xml:265
+#. (itstool) path: section/screen
+#: C/gosdconf.xml:268
 #, no-wrap
 msgid ""
 "$ gsettings set org.mate.background picture-filename \\\n"
 "\"'/usr/share/backgrounds/mate/desktop/MATE-Stripes-Light.png'\""
 msgstr ""
 
-#. (itstool) path: sect3/synopsis
-#: C/gosdconf.xml:270
+#. (itstool) path: section/synopsis
+#: C/gosdconf.xml:273
 #, no-wrap
 msgid ""
 "gsettings [--schemadir SCHEMADIR] set SCHEMA[:PATH] KEY VALUE"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/gosdconf.xml:271
-msgid "Refer to the <ulink url=\"man:gsettings\" type=\"man\"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> for more information on how to use <command>dconf</command>."
+#. (itstool) path: section/para
+#: C/gosdconf.xml:274
+msgid "Refer to the <link xlink:href=\"man:gsettings\"><citerefentry><refentrytitle>gsettings</refentrytitle><manvolnum>1</manvolnum></citerefentry></link> for more information on how to use <command>dconf</command>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosdconf.xml:278
+#. (itstool) path: info/title
+#: C/gosdconf.xml:280
 msgid "To change the value of several dconf keys"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconf.xml:280
+#. (itstool) path: section/para
+#: C/gosdconf.xml:283
 msgid "To change the value of several dconf keys at the same time, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:285
+#: C/gosdconf.xml:288
 msgid "Dump the contents of a dconf directory to a new plain text file:"
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gosdconf.xml:286
+#: C/gosdconf.xml:289
 #, no-wrap
 msgid ""
 "$ dconf dump /org/mate/desktop/background/ &gt; file.dconf"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:289
+#: C/gosdconf.xml:292
 msgid "Make changes in the plain text file"
 msgstr ""
 
 #. (itstool) path: listitem/literallayout
-#: C/gosdconf.xml:290
+#: C/gosdconf.xml:293
 #, no-wrap
 msgid ""
 "[/]\n"
@@ -15177,2598 +15158,1728 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconf.xml:299
+#: C/gosdconf.xml:302
 msgid "Load the contents of the plain text file to a dconf directory"
 msgstr ""
 
 #. (itstool) path: listitem/screen
-#: C/gosdconf.xml:300
+#: C/gosdconf.xml:303
 #, no-wrap
 msgid ""
 "$ dconf load /org/mate/desktop/background/ &lt; file.dconf"
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/gosdconf.xml:303
+#: C/gosdconf.xml:306
 msgid "You can also dump/load several directories at once, e.g. to back up and restore all configurations of your MATE desktop:"
 msgstr ""
 
 #. (itstool) path: tip/screen
-#: C/gosdconf.xml:304
+#: C/gosdconf.xml:307
 #, no-wrap
 msgid ""
 "$ dconf dump /org/mate/ &gt; backup.dconf\n"
 "$ dconf load /org/mate/ &lt; backup.dconf"
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/gosdconfkeys.xml:3
+#. (itstool) path: info/title
+#: C/gosdconfkeys.xml:5
 msgid "List of Dconf Keys of MATE Desktop"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:5
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:8
 msgid "Dconf Directory: /org/mate/desktop/accessibility/keyboard/"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/gosdconfkeys.xml:6
-#: C/gosdconfkeys.xml:229
-#: C/gosdconfkeys.xml:252
-#: C/gosdconfkeys.xml:285
-#: C/gosdconfkeys.xml:318
-#: C/gosdconfkeys.xml:361
-#: C/gosdconfkeys.xml:394
-#: C/gosdconfkeys.xml:427
-#: C/gosdconfkeys.xml:460
-#: C/gosdconfkeys.xml:563
-#: C/gosdconfkeys.xml:626
-#: C/gosdconfkeys.xml:649
-#: C/gosdconfkeys.xml:1034
-#: C/gosdconfkeys.xml:1137
-#: C/gosdconfkeys.xml:1260
-#: C/gosdconfkeys.xml:1363
-#: C/gosdconfkeys.xml:1436
-#: C/gosdconfkeys.xml:1469
-#: C/gosdconfkeys.xml:1502
+#. (itstool) path: section/para
+#: C/gosdconfkeys.xml:9
+#: C/gosdconfkeys.xml:234
+#: C/gosdconfkeys.xml:259
+#: C/gosdconfkeys.xml:294
+#: C/gosdconfkeys.xml:329
+#: C/gosdconfkeys.xml:374
+#: C/gosdconfkeys.xml:399
+#: C/gosdconfkeys.xml:434
+#: C/gosdconfkeys.xml:469
+#: C/gosdconfkeys.xml:504
+#: C/gosdconfkeys.xml:609
+#: C/gosdconfkeys.xml:674
+#: C/gosdconfkeys.xml:699
+#: C/gosdconfkeys.xml:1086
+#: C/gosdconfkeys.xml:1191
+#: C/gosdconfkeys.xml:1316
+#: C/gosdconfkeys.xml:1421
+#: C/gosdconfkeys.xml:1496
+#: C/gosdconfkeys.xml:1531
+#: C/gosdconfkeys.xml:1566
 msgid "To obtain the list of dconf keys, run one of the following commands:"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:8
-msgid "$ dconf list /org/mate/desktop/accessibility/keyboard/ $ gsettings list-keys org.mate.accessibility-keyboard"
-msgstr ""
-
-#. (itstool) path: para/command
-#: C/gosdconfkeys.xml:12
-#: C/gosdconfkeys.xml:235
-#: C/gosdconfkeys.xml:258
-#: C/gosdconfkeys.xml:291
-#: C/gosdconfkeys.xml:324
-#: C/gosdconfkeys.xml:367
-#: C/gosdconfkeys.xml:400
-#: C/gosdconfkeys.xml:433
-#: C/gosdconfkeys.xml:466
-#: C/gosdconfkeys.xml:569
-#: C/gosdconfkeys.xml:632
-#: C/gosdconfkeys.xml:655
-#: C/gosdconfkeys.xml:1040
-#: C/gosdconfkeys.xml:1143
-#: C/gosdconfkeys.xml:1266
-#: C/gosdconfkeys.xml:1369
-#: C/gosdconfkeys.xml:1442
-#: C/gosdconfkeys.xml:1475
-#: C/gosdconfkeys.xml:1508
-msgid "dconf"
-msgstr ""
-
-#. (itstool) path: para/command
-#: C/gosdconfkeys.xml:12
-#: C/gosdconfkeys.xml:235
-#: C/gosdconfkeys.xml:258
-#: C/gosdconfkeys.xml:291
-#: C/gosdconfkeys.xml:324
-#: C/gosdconfkeys.xml:367
-#: C/gosdconfkeys.xml:400
-#: C/gosdconfkeys.xml:433
-#: C/gosdconfkeys.xml:466
-#: C/gosdconfkeys.xml:569
-#: C/gosdconfkeys.xml:632
-#: C/gosdconfkeys.xml:655
-#: C/gosdconfkeys.xml:1040
-#: C/gosdconfkeys.xml:1143
-#: C/gosdconfkeys.xml:1266
-#: C/gosdconfkeys.xml:1369
-#: C/gosdconfkeys.xml:1442
-#: C/gosdconfkeys.xml:1475
-#: C/gosdconfkeys.xml:1508
-msgid "gsettings"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/gosdconfkeys.xml:11
-#: C/gosdconfkeys.xml:234
-#: C/gosdconfkeys.xml:257
-#: C/gosdconfkeys.xml:290
-#: C/gosdconfkeys.xml:323
-#: C/gosdconfkeys.xml:366
-#: C/gosdconfkeys.xml:399
-#: C/gosdconfkeys.xml:432
-#: C/gosdconfkeys.xml:465
-#: C/gosdconfkeys.xml:568
-#: C/gosdconfkeys.xml:631
-#: C/gosdconfkeys.xml:654
-#: C/gosdconfkeys.xml:1039
-#: C/gosdconfkeys.xml:1142
-#: C/gosdconfkeys.xml:1265
-#: C/gosdconfkeys.xml:1368
-#: C/gosdconfkeys.xml:1441
-#: C/gosdconfkeys.xml:1474
-#: C/gosdconfkeys.xml:1507
-msgid "In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available. The list also contains an example to read the value of the key using the <_:command-1/> or <_:command-2/> commands."
-msgstr ""
-
-#. (itstool) path: variablelist/title
+#. (itstool) path: section/para
 #: C/gosdconfkeys.xml:14
-#: C/gosdconfkeys.xml:237
-#: C/gosdconfkeys.xml:260
-#: C/gosdconfkeys.xml:293
-#: C/gosdconfkeys.xml:326
-#: C/gosdconfkeys.xml:369
-#: C/gosdconfkeys.xml:402
-#: C/gosdconfkeys.xml:435
-#: C/gosdconfkeys.xml:468
-#: C/gosdconfkeys.xml:571
-#: C/gosdconfkeys.xml:634
-#: C/gosdconfkeys.xml:657
-#: C/gosdconfkeys.xml:1042
-#: C/gosdconfkeys.xml:1145
-#: C/gosdconfkeys.xml:1268
-#: C/gosdconfkeys.xml:1371
-#: C/gosdconfkeys.xml:1444
-#: C/gosdconfkeys.xml:1477
-#: C/gosdconfkeys.xml:1510
+#: C/gosdconfkeys.xml:239
+#: C/gosdconfkeys.xml:264
+#: C/gosdconfkeys.xml:299
+#: C/gosdconfkeys.xml:334
+#: C/gosdconfkeys.xml:379
+#: C/gosdconfkeys.xml:404
+#: C/gosdconfkeys.xml:439
+#: C/gosdconfkeys.xml:474
+#: C/gosdconfkeys.xml:509
+#: C/gosdconfkeys.xml:614
+#: C/gosdconfkeys.xml:679
+#: C/gosdconfkeys.xml:704
+#: C/gosdconfkeys.xml:1091
+#: C/gosdconfkeys.xml:1196
+#: C/gosdconfkeys.xml:1321
+#: C/gosdconfkeys.xml:1426
+#: C/gosdconfkeys.xml:1501
+#: C/gosdconfkeys.xml:1536
+#: C/gosdconfkeys.xml:1571
+msgid "In the following list of dconf keys, the data type of the dconf key is shown in parentheses, next to its description, if available. The list also contains an example to read the value of the key using the <command>dconf</command> or <command>gsettings</command> commands."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/gosdconfkeys.xml:18
+#: C/gosdconfkeys.xml:243
+#: C/gosdconfkeys.xml:268
+#: C/gosdconfkeys.xml:303
+#: C/gosdconfkeys.xml:338
+#: C/gosdconfkeys.xml:383
+#: C/gosdconfkeys.xml:408
+#: C/gosdconfkeys.xml:443
+#: C/gosdconfkeys.xml:478
+#: C/gosdconfkeys.xml:513
+#: C/gosdconfkeys.xml:618
+#: C/gosdconfkeys.xml:683
+#: C/gosdconfkeys.xml:708
+#: C/gosdconfkeys.xml:1095
+#: C/gosdconfkeys.xml:1200
+#: C/gosdconfkeys.xml:1325
+#: C/gosdconfkeys.xml:1430
+#: C/gosdconfkeys.xml:1505
+#: C/gosdconfkeys.xml:1540
+#: C/gosdconfkeys.xml:1575
 msgid "List of dconf keys"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:16
+#: C/gosdconfkeys.xml:21
 msgid "enable"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:18
-#: C/gosdconfkeys.xml:28
-#: C/gosdconfkeys.xml:38
-#: C/gosdconfkeys.xml:58
-#: C/gosdconfkeys.xml:78
-#: C/gosdconfkeys.xml:88
-#: C/gosdconfkeys.xml:128
-#: C/gosdconfkeys.xml:148
-#: C/gosdconfkeys.xml:158
-#: C/gosdconfkeys.xml:168
-#: C/gosdconfkeys.xml:178
-#: C/gosdconfkeys.xml:218
-#: C/gosdconfkeys.xml:575
-#: C/gosdconfkeys.xml:585
-#: C/gosdconfkeys.xml:595
-#: C/gosdconfkeys.xml:605
-#: C/gosdconfkeys.xml:615
-#: C/gosdconfkeys.xml:1149
-#: C/gosdconfkeys.xml:1159
+#: C/gosdconfkeys.xml:23
+#: C/gosdconfkeys.xml:33
+#: C/gosdconfkeys.xml:43
+#: C/gosdconfkeys.xml:63
+#: C/gosdconfkeys.xml:83
+#: C/gosdconfkeys.xml:93
+#: C/gosdconfkeys.xml:133
+#: C/gosdconfkeys.xml:153
+#: C/gosdconfkeys.xml:163
+#: C/gosdconfkeys.xml:173
+#: C/gosdconfkeys.xml:183
+#: C/gosdconfkeys.xml:223
+#: C/gosdconfkeys.xml:623
+#: C/gosdconfkeys.xml:633
+#: C/gosdconfkeys.xml:643
+#: C/gosdconfkeys.xml:653
+#: C/gosdconfkeys.xml:663
+#: C/gosdconfkeys.xml:1205
+#: C/gosdconfkeys.xml:1215
 msgid "(b)"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:20
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/enable $ gsettings get org.mate.accessibility-keyboard enable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:26
+#: C/gosdconfkeys.xml:31
 msgid "feature-state-change-beep"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:30
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/feature-state-change-beep $ gsettings get org.mate.accessibility-keyboard feature-state-change-beep"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:36
+#: C/gosdconfkeys.xml:41
 msgid "timeout-enable"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:40
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/timeout-enable $ gsettings get org.mate.accessibility-keyboard timeout-enable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:46
+#: C/gosdconfkeys.xml:51
 msgid "timeout"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:48
-#: C/gosdconfkeys.xml:1169
-#: C/gosdconfkeys.xml:1179
-#: C/gosdconfkeys.xml:1189
-#: C/gosdconfkeys.xml:1209
-#: C/gosdconfkeys.xml:1219
+#: C/gosdconfkeys.xml:53
+#: C/gosdconfkeys.xml:1225
+#: C/gosdconfkeys.xml:1235
+#: C/gosdconfkeys.xml:1245
+#: C/gosdconfkeys.xml:1265
+#: C/gosdconfkeys.xml:1275
 msgid "(i)"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:50
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/timeout $ gsettings get org.mate.accessibility-keyboard timeout"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:56
+#: C/gosdconfkeys.xml:61
 msgid "bouncekeys-enable"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:60
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/bouncekeys-enable $ gsettings get org.mate.accessibility-keyboard bouncekeys-enable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:66
+#: C/gosdconfkeys.xml:71
 msgid "bouncekeys-delay"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:68
+#: C/gosdconfkeys.xml:73
 msgid "(i) Ignore multiple presses of the _same_ key within @delay milliseconds."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:70
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/bouncekeys-delay $ gsettings get org.mate.accessibility-keyboard bouncekeys-delay"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:76
+#: C/gosdconfkeys.xml:81
 msgid "bouncekeys-beep-reject"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:80
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/bouncekeys-beep-reject $ gsettings get org.mate.accessibility-keyboard bouncekeys-beep-reject"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:86
+#: C/gosdconfkeys.xml:91
 msgid "mousekeys-enable"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:90
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-enable $ gsettings get org.mate.accessibility-keyboard mousekeys-enable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:96
+#: C/gosdconfkeys.xml:101
 msgid "mousekeys-max-speed"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:98
+#: C/gosdconfkeys.xml:103
 msgid "(i) How many pixels per second to move at the maximum speed."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:100
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-max-speed $ gsettings get org.mate.accessibility-keyboard mousekeys-max-speed"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:106
+#: C/gosdconfkeys.xml:111
 msgid "mousekeys-accel-time"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:108
+#: C/gosdconfkeys.xml:113
 msgid "(i) How many milliseconds it takes to go from 0 to maximum speed."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:110
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-accel-time $ gsettings get org.mate.accessibility-keyboard mousekeys-accel-time"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:116
+#: C/gosdconfkeys.xml:121
 msgid "mousekeys-init-delay"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:118
+#: C/gosdconfkeys.xml:123
 msgid "(i) How many milliseconds to wait before mouse movement keys start to operate."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:120
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/mousekeys-init-delay $ gsettings get org.mate.accessibility-keyboard mousekeys-init-delay"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:126
+#: C/gosdconfkeys.xml:131
 msgid "slowkeys-enable"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:130
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-enable $ gsettings get org.mate.accessibility-keyboard slowkeys-enable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:136
+#: C/gosdconfkeys.xml:141
 msgid "slowkeys-delay"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:138
+#: C/gosdconfkeys.xml:143
 msgid "(i) Do not accept a key as being pressed unless held for @delay milliseconds."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:140
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-delay $ gsettings get org.mate.accessibility-keyboard slowkeys-delay"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:146
+#: C/gosdconfkeys.xml:151
 msgid "slowkeys-beep-press"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:150
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-beep-press $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-press"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:156
+#: C/gosdconfkeys.xml:161
 msgid "slowkeys-beep-accept"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:160
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-beep-accept $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-accept"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:166
+#: C/gosdconfkeys.xml:171
 msgid "slowkeys-beep-reject"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:170
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/slowkeys-beep-reject $ gsettings get org.mate.accessibility-keyboard slowkeys-beep-reject"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:176
+#: C/gosdconfkeys.xml:181
 msgid "stickykeys-enable"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:180
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-enable $ gsettings get org.mate.accessibility-keyboard stickykeys-enable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:186
+#: C/gosdconfkeys.xml:191
 msgid "stickykeys-latch-to-lock"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:188
+#: C/gosdconfkeys.xml:193
 msgid "(b) Latch modifiers when pressed twice in a row until the same modifier is pressed again."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:190
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-latch-to-lock $ gsettings get org.mate.accessibility-keyboard stickykeys-latch-to-lock"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:196
+#: C/gosdconfkeys.xml:201
 msgid "stickykeys-two-key-off"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:198
+#: C/gosdconfkeys.xml:203
 msgid "(b) Disable if two keys are pressed at the same time."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:200
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-two-key-off $ gsettings get org.mate.accessibility-keyboard stickykeys-two-key-off"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:206
+#: C/gosdconfkeys.xml:211
 msgid "stickykeys-modifier-beep"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:208
+#: C/gosdconfkeys.xml:213
 msgid "(b) Beep when a modifier is pressed."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:210
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/stickykeys-modifier-beep $ gsettings get org.mate.accessibility-keyboard stickykeys-modifier-beep"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:216
+#: C/gosdconfkeys.xml:221
 msgid "togglekeys-enable"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:220
-msgid "$ dconf read /org/mate/desktop/accessibility/keyboard/togglekeys-enable $ gsettings get org.mate.accessibility-keyboard togglekeys-enable"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:228
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:233
 msgid "Dconf Directory: /org/mate/desktop/accessibility/startup/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:231
-msgid "$ dconf list /org/mate/desktop/accessibility/startup/ $ gsettings list-keys org.mate.accessibility-startup"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:239
+#: C/gosdconfkeys.xml:246
 msgid "exec-ats"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:241
+#: C/gosdconfkeys.xml:248
 msgid "(as) List of assistive technology applications to start when logging into the MATE desktop."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:243
-msgid "$ dconf read /org/mate/desktop/accessibility/startup/exec-ats $ gsettings get org.mate.accessibility-startup exec-ats"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:251
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:258
 msgid "Dconf Directory: /org/mate/desktop/applications/at/mobility/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:254
-msgid "$ dconf list /org/mate/desktop/applications/at/mobility/ $ gsettings list-keys org.mate.applications-at-mobility"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:262
-#: C/gosdconfkeys.xml:295
-#: C/gosdconfkeys.xml:328
-#: C/gosdconfkeys.xml:371
-#: C/gosdconfkeys.xml:404
-#: C/gosdconfkeys.xml:437
+#: C/gosdconfkeys.xml:271
+#: C/gosdconfkeys.xml:306
+#: C/gosdconfkeys.xml:341
+#: C/gosdconfkeys.xml:386
+#: C/gosdconfkeys.xml:411
+#: C/gosdconfkeys.xml:446
+#: C/gosdconfkeys.xml:481
 msgid "exec"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:264
+#: C/gosdconfkeys.xml:273
 msgid "(s) Preferred Mobility assistive technology application to be used for login, menu, or command line."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:266
-msgid "$ dconf read /org/mate/desktop/applications/at/mobility/exec $ gsettings get org.mate.applications-at-mobility exec"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:272
-#: C/gosdconfkeys.xml:305
+#: C/gosdconfkeys.xml:281
+#: C/gosdconfkeys.xml:316
 msgid "startup"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:274
+#: C/gosdconfkeys.xml:283
 msgid "(b) MATE to start preferred Mobility assistive technology application during login."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:276
-msgid "$ dconf read /org/mate/desktop/applications/at/mobility/startup $ gsettings get org.mate.applications-at-mobility startup"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:284
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:293
 msgid "Dconf Directory: /org/mate/desktop/applications/at/visual/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:287
-msgid "$ dconf list /org/mate/desktop/applications/at/visual/ $ gsettings list-keys org.mate.applications-at-visual"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:297
+#: C/gosdconfkeys.xml:308
 msgid "(s) Preferred Visual assistive technology application to be used for login, menu, or command line."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:299
-msgid "$ dconf read /org/mate/desktop/applications/at/visual/exec $ gsettings get org.mate.applications-at-visual exec"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:307
+#: C/gosdconfkeys.xml:318
 msgid "(b) MATE to start preferred Visual assistive technology application during login."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:309
-msgid "$ dconf read /org/mate/desktop/applications/at/visual/startup $ gsettings get org.mate.applications-at-visual startup"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:317
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:328
 msgid "Dconf Directory: /org/mate/desktop/applications/browser/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:320
-msgid "$ dconf list /org/mate/desktop/applications/browser/ $ gsettings list-keys org.mate.applications-browser"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:330
+#: C/gosdconfkeys.xml:343
 msgid "(s) Default browser for all URLs."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:332
-msgid "$ dconf read /org/mate/desktop/applications/browser/exec $ gsettings get org.mate.applications-browser exec"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:338
-#: C/gosdconfkeys.xml:381
-#: C/gosdconfkeys.xml:414
+#: C/gosdconfkeys.xml:351
+#: C/gosdconfkeys.xml:421
+#: C/gosdconfkeys.xml:456
 msgid "needs-term"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:340
+#: C/gosdconfkeys.xml:353
 msgid "(b) Whether the default browser needs a terminal to run."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:342
-msgid "$ dconf read /org/mate/desktop/applications/browser/needs-term $ gsettings get org.mate.applications-browser needs-term"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:348
+#: C/gosdconfkeys.xml:361
 msgid "nremote"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:350
+#: C/gosdconfkeys.xml:363
 msgid "(b) Whether the default browser understands netscape remote."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:352
-msgid "$ dconf read /org/mate/desktop/applications/browser/nremote $ gsettings get org.mate.applications-browser nremote"
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:373
+msgid "Dconf Directory: /org/mate/desktop/applications/calculator/"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:360
+#. (itstool) path: listitem/para
+#: C/gosdconfkeys.xml:388
+msgid "(s) Calculator program to use when starting applications that require one."
+msgstr ""
+
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:398
 msgid "Dconf Directory: /org/mate/desktop/applications/calendar/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:363
-msgid "$ dconf list /org/mate/desktop/applications/calendar/ $ gsettings list-keys org.mate.applications-office.calendar"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:373
+#: C/gosdconfkeys.xml:413
 msgid "(s) Default calendar application"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:375
-msgid "$ dconf read /org/mate/desktop/applications/calendar/exec $ gsettings get org.mate.applications-office.calendar exec"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:383
+#: C/gosdconfkeys.xml:423
 msgid "(b) Whether the default calendar application needs a terminal to run"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:385
-msgid "$ dconf read /org/mate/desktop/applications/calendar/needs-term $ gsettings get org.mate.applications-office.calendar needs-term"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:393
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:433
 msgid "Dconf Directory: /org/mate/desktop/applications/tasks/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:396
-msgid "$ dconf list /org/mate/desktop/applications/tasks/ $ gsettings list-keys org.mate.applications-office.tasks"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:406
+#: C/gosdconfkeys.xml:448
 msgid "(s) Default tasks application"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:408
-msgid "$ dconf read /org/mate/desktop/applications/tasks/exec $ gsettings get org.mate.applications-office.tasks exec"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:416
+#: C/gosdconfkeys.xml:458
 msgid "(b) Whether the default tasks application needs a terminal to run"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:418
-msgid "$ dconf read /org/mate/desktop/applications/tasks/needs-term $ gsettings get org.mate.applications-office.tasks needs-term"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:426
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:468
 msgid "Dconf Directory: /org/mate/desktop/applications/terminal/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:429
-msgid "$ dconf list /org/mate/desktop/applications/terminal/ $ gsettings list-keys org.mate.applications-terminal"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:439
+#: C/gosdconfkeys.xml:483
 msgid "(s) Terminal program to use when starting applications that require one."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:441
-msgid "$ dconf read /org/mate/desktop/applications/terminal/exec $ gsettings get org.mate.applications-terminal exec"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:447
+#: C/gosdconfkeys.xml:491
 msgid "exec-arg"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:449
+#: C/gosdconfkeys.xml:493
 msgid "(s) Argument used to execute programs in the terminal defined by the 'exec' key."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:451
-msgid "$ dconf read /org/mate/desktop/applications/terminal/exec-arg $ gsettings get org.mate.applications-terminal exec-arg"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:459
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:503
 msgid "Dconf Directory: /org/mate/desktop/background/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:462
-msgid "$ dconf list /org/mate/desktop/background/ $ gsettings list-keys org.mate.background"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:470
+#: C/gosdconfkeys.xml:516
 msgid "draw-background"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:472
+#: C/gosdconfkeys.xml:518
 msgid "(b) Have MATE draw the desktop background."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:474
-msgid "$ dconf read /org/mate/desktop/background/draw-background $ gsettings get org.mate.background draw-background"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:480
+#: C/gosdconfkeys.xml:526
 msgid "show-desktop-icons"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:482
+#: C/gosdconfkeys.xml:528
 msgid "(b) Have MATE file manager (Caja) draw the desktop icons."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:484
-msgid "$ dconf read /org/mate/desktop/background/show-desktop-icons $ gsettings get org.mate.background show-desktop-icons"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:490
+#: C/gosdconfkeys.xml:536
 msgid "background-fade"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:492
+#: C/gosdconfkeys.xml:538
 msgid "(b) If set to true, then MATE will change the desktop background with a fading effect."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:494
-msgid "$ dconf read /org/mate/desktop/background/background-fade $ gsettings get org.mate.background background-fade"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:500
+#: C/gosdconfkeys.xml:546
 msgid "picture-options"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:502
+#: C/gosdconfkeys.xml:548
 msgid "() Determines how the image set by wallpaper_filename is rendered. Possible values are \"wallpaper\", \"centered\", \"scaled\", \"stretched\", \"zoom\", \"spanned\"."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:504
-msgid "$ dconf read /org/mate/desktop/background/picture-options $ gsettings get org.mate.background picture-options"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:510
+#: C/gosdconfkeys.xml:556
 msgid "picture-filename"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:512
+#: C/gosdconfkeys.xml:558
 msgid "(s) File to use for the background image."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:514
-msgid "$ dconf read /org/mate/desktop/background/picture-filename $ gsettings get org.mate.background picture-filename"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:520
+#: C/gosdconfkeys.xml:566
 msgid "picture-opacity"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:522
+#: C/gosdconfkeys.xml:568
 msgid "(i) Opacity with which to draw the background picture."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:524
-msgid "$ dconf read /org/mate/desktop/background/picture-opacity $ gsettings get org.mate.background picture-opacity"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:530
+#: C/gosdconfkeys.xml:576
 msgid "primary-color"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:532
+#: C/gosdconfkeys.xml:578
 msgid "(s) Left or Top color when drawing gradients, or the solid color."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:534
-msgid "$ dconf read /org/mate/desktop/background/primary-color $ gsettings get org.mate.background primary-color"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:540
+#: C/gosdconfkeys.xml:586
 msgid "secondary-color"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:542
+#: C/gosdconfkeys.xml:588
 msgid "(s) Right or Bottom color when drawing gradients, not used for solid color."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:544
-msgid "$ dconf read /org/mate/desktop/background/secondary-color $ gsettings get org.mate.background secondary-color"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:550
+#: C/gosdconfkeys.xml:596
 msgid "color-shading-type"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:552
+#: C/gosdconfkeys.xml:598
 msgid "() How to shade the background color. Possible values are \"horizontal-gradient\", \"vertical-gradient\", and \"solid\"."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:554
-msgid "$ dconf read /org/mate/desktop/background/color-shading-type $ gsettings get org.mate.background color-shading-type"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:562
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:608
 msgid "Dconf Directory: /org/mate/debug/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:565
-msgid "$ dconf list /org/mate/debug/ $ gsettings list-keys org.mate.debug"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:573
+#: C/gosdconfkeys.xml:621
 msgid "caja"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:577
-msgid "$ dconf read /org/mate/debug/caja $ gsettings get org.mate.debug caja"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:583
+#: C/gosdconfkeys.xml:631
 msgid "marco"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:587
-msgid "$ dconf read /org/mate/debug/marco $ gsettings get org.mate.debug marco"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:593
+#: C/gosdconfkeys.xml:641
 msgid "mate-session"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:597
-msgid "$ dconf read /org/mate/debug/mate-session $ gsettings get org.mate.debug mate-session"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:603
+#: C/gosdconfkeys.xml:651
 msgid "mate-settings-daemon"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:607
-msgid "$ dconf read /org/mate/debug/mate-settings-daemon $ gsettings get org.mate.debug mate-settings-daemon"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:613
+#: C/gosdconfkeys.xml:661
 msgid "mate-panel"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:617
-msgid "$ dconf read /org/mate/debug/mate-panel $ gsettings get org.mate.debug mate-panel"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:625
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:673
 msgid "Dconf Directory: /org/mate/desktop/file-views/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:628
-msgid "$ dconf list /org/mate/desktop/file-views/ $ gsettings list-keys org.mate.file-views"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:636
-#: C/gosdconfkeys.xml:769
+#: C/gosdconfkeys.xml:686
+#: C/gosdconfkeys.xml:821
 msgid "icon-theme"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:638
+#: C/gosdconfkeys.xml:688
 msgid "(s) Theme used for displaying file icons."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:640
-msgid "$ dconf read /org/mate/desktop/file-views/icon-theme $ gsettings get org.mate.file-views icon-theme"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:648
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:698
 msgid "Dconf Directory: /org/mate/desktop/interface/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:651
-msgid "$ dconf list /org/mate/desktop/interface/ $ gsettings list-keys org.mate.interface"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:659
+#: C/gosdconfkeys.xml:711
 msgid "accessibility"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:661
+#: C/gosdconfkeys.xml:713
 msgid "(b) Whether Applications should have accessibility support."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:663
-msgid "$ dconf read /org/mate/desktop/interface/accessibility $ gsettings get org.mate.interface accessibility"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:669
+#: C/gosdconfkeys.xml:721
 msgid "enable-animations"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:671
+#: C/gosdconfkeys.xml:723
 msgid "(b) Whether animations should be displayed. Note: This is a global key, it changes the behaviour of the window manager, the panel etc."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:673
-msgid "$ dconf read /org/mate/desktop/interface/enable-animations $ gsettings get org.mate.interface enable-animations"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:679
+#: C/gosdconfkeys.xml:731
 msgid "menus-have-tearoff"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:681
+#: C/gosdconfkeys.xml:733
 msgid "(b) Whether menus should have a tearoff."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:683
-msgid "$ dconf read /org/mate/desktop/interface/menus-have-tearoff $ gsettings get org.mate.interface menus-have-tearoff"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:689
+#: C/gosdconfkeys.xml:741
 msgid "toolbar-style"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:691
+#: C/gosdconfkeys.xml:743
 msgid "(s) Toolbar Style. Valid values are \"both\", \"both-horiz\", \"icons\", and \"text\"."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:693
-msgid "$ dconf read /org/mate/desktop/interface/toolbar-style $ gsettings get org.mate.interface toolbar-style"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:699
+#: C/gosdconfkeys.xml:751
 msgid "menus-have-icons"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:701
+#: C/gosdconfkeys.xml:753
 msgid "(b) Whether menus may display an icon next to a menu entry."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:703
-msgid "$ dconf read /org/mate/desktop/interface/menus-have-icons $ gsettings get org.mate.interface menus-have-icons"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:709
+#: C/gosdconfkeys.xml:761
 msgid "buttons-have-icons"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:711
+#: C/gosdconfkeys.xml:763
 msgid "(b) Whether buttons may display an icon in addition to the button text."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:713
-msgid "$ dconf read /org/mate/desktop/interface/buttons-have-icons $ gsettings get org.mate.interface buttons-have-icons"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:719
+#: C/gosdconfkeys.xml:771
 msgid "menubar-detachable"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:721
+#: C/gosdconfkeys.xml:773
 msgid "(b) Whether the user can detach menubars and move them around."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:723
-msgid "$ dconf read /org/mate/desktop/interface/menubar-detachable $ gsettings get org.mate.interface menubar-detachable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:729
+#: C/gosdconfkeys.xml:781
 msgid "toolbar-detachable"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:731
+#: C/gosdconfkeys.xml:783
 msgid "(b) Whether the user can detach toolbars and move them around."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:733
-msgid "$ dconf read /org/mate/desktop/interface/toolbar-detachable $ gsettings get org.mate.interface toolbar-detachable"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:739
+#: C/gosdconfkeys.xml:791
 msgid "toolbar-icons-size"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:741
+#: C/gosdconfkeys.xml:793
 msgid "(s) Size of icons in toolbars, either \"small-toolbar\" or \"large-toolbar\"."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:743
-msgid "$ dconf read /org/mate/desktop/interface/toolbar-icons-size $ gsettings get org.mate.interface toolbar-icons-size"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:749
+#: C/gosdconfkeys.xml:801
 msgid "cursor-blink"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:751
+#: C/gosdconfkeys.xml:803
 msgid "(b) Whether the cursor should blink."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:753
-msgid "$ dconf read /org/mate/desktop/interface/cursor-blink $ gsettings get org.mate.interface cursor-blink"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:759
+#: C/gosdconfkeys.xml:811
 msgid "cursor-blink-time"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:761
+#: C/gosdconfkeys.xml:813
 msgid "(i) Length of the cursor blink cycle, in milliseconds."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:763
-msgid "$ dconf read /org/mate/desktop/interface/cursor-blink-time $ gsettings get org.mate.interface cursor-blink-time"
-msgstr ""
-
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:771
+#: C/gosdconfkeys.xml:823
 msgid "(s) Icon theme to use for the panel, Caja etc."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:773
-msgid "$ dconf read /org/mate/desktop/interface/icon-theme $ gsettings get org.mate.interface icon-theme"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:779
+#: C/gosdconfkeys.xml:831
 msgid "gtk-theme"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:781
-#: C/gosdconfkeys.xml:791
+#: C/gosdconfkeys.xml:833
+#: C/gosdconfkeys.xml:843
 msgid "(s) Basename of the default theme used by gtk+."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:783
-msgid "$ dconf read /org/mate/desktop/interface/gtk-theme $ gsettings get org.mate.interface gtk-theme"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:789
+#: C/gosdconfkeys.xml:841
 msgid "gtk-key-theme"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:793
-msgid "$ dconf read /org/mate/desktop/interface/gtk-key-theme $ gsettings get org.mate.interface gtk-key-theme"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:799
+#: C/gosdconfkeys.xml:851
 msgid "gtk-color-scheme"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:801
+#: C/gosdconfkeys.xml:853
 msgid "(s) A '\\n' separated list of \"name:color\" as defined by the 'gtk-color-scheme' setting"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:803
-msgid "$ dconf read /org/mate/desktop/interface/gtk-color-scheme $ gsettings get org.mate.interface gtk-color-scheme"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:809
+#: C/gosdconfkeys.xml:861
 msgid "font-name"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:811
+#: C/gosdconfkeys.xml:863
 msgid "(s) Name of the default font used by gtk+."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:813
-msgid "$ dconf read /org/mate/desktop/interface/font-name $ gsettings get org.mate.interface font-name"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:819
+#: C/gosdconfkeys.xml:871
 msgid "gtk-im-preedit-style"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:821
+#: C/gosdconfkeys.xml:873
 msgid "(s) Name of the GTK+ input method Preedit Style used by gtk+."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:823
-msgid "$ dconf read /org/mate/desktop/interface/gtk-im-preedit-style $ gsettings get org.mate.interface gtk-im-preedit-style"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:829
+#: C/gosdconfkeys.xml:881
 msgid "gtk-im-status-style"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:831
+#: C/gosdconfkeys.xml:883
 msgid "(s) Name of the GTK+ input method Status Style used by gtk+."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:833
-msgid "$ dconf read /org/mate/desktop/interface/gtk-im-status-style $ gsettings get org.mate.interface gtk-im-status-style"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:839
+#: C/gosdconfkeys.xml:891
 msgid "gtk-im-module"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:841
+#: C/gosdconfkeys.xml:893
 msgid "(s) Name of the input method module used by GTK+."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:843
-msgid "$ dconf read /org/mate/desktop/interface/gtk-im-module $ gsettings get org.mate.interface gtk-im-module"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:849
+#: C/gosdconfkeys.xml:901
 msgid "gtk-dialogs-use-header"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:851
+#: C/gosdconfkeys.xml:903
 msgid "(b) Whether builtin GTK+ dialogs such as the file chooser, the color chooser or the font chooser will use a header bar at the top to show action widgets, or an action area at the bottom. This setting does not affect custom dialogs using GtkDialog directly, or message dialogs."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:853
-msgid "$ dconf read /org/mate/desktop/interface/gtk-dialogs-use-header $ gsettings get org.mate.interface gtk-dialogs-use-header"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:859
+#: C/gosdconfkeys.xml:911
 msgid "gtk-overlay-scrolling"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:861
+#: C/gosdconfkeys.xml:913
 msgid "(b) Whether built-in GTK+ scrolled windows will use overlay scrolling. Overlay scrolling hides and reduces the size of the scrollbar until it gets focus."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:863
-msgid "$ dconf read /org/mate/desktop/interface/gtk-overlay-scrolling $ gsettings get org.mate.interface gtk-overlay-scrolling"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:869
+#: C/gosdconfkeys.xml:921
 msgid "gtk-enable-animations"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:871
+#: C/gosdconfkeys.xml:923
 msgid "(b) Whether to enable toolkit-wide animations."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:873
-msgid "$ dconf read /org/mate/desktop/interface/gtk-enable-animations $ gsettings get org.mate.interface gtk-enable-animations"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:879
+#: C/gosdconfkeys.xml:931
 msgid "document-font-name"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:881
+#: C/gosdconfkeys.xml:933
 msgid "(s) Name of the default font used for reading documents."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:883
-msgid "$ dconf read /org/mate/desktop/interface/document-font-name $ gsettings get org.mate.interface document-font-name"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:889
+#: C/gosdconfkeys.xml:941
 msgid "monospace-font-name"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:891
+#: C/gosdconfkeys.xml:943
 msgid "(s) Name of a monospaced (fixed-width) font for use in locations like terminals."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:893
-msgid "$ dconf read /org/mate/desktop/interface/monospace-font-name $ gsettings get org.mate.interface monospace-font-name"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:899
+#: C/gosdconfkeys.xml:951
 msgid "use-custom-font"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:901
+#: C/gosdconfkeys.xml:953
 msgid "(b) Whether to use a custom font in gtk+ applications."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:903
-msgid "$ dconf read /org/mate/desktop/interface/use-custom-font $ gsettings get org.mate.interface use-custom-font"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:909
+#: C/gosdconfkeys.xml:961
 msgid "status-bar-meter-on-right"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:911
+#: C/gosdconfkeys.xml:963
 msgid "(b) Whether to display a status bar meter on the right."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:913
-msgid "$ dconf read /org/mate/desktop/interface/status-bar-meter-on-right $ gsettings get org.mate.interface status-bar-meter-on-right"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:919
+#: C/gosdconfkeys.xml:971
 msgid "file-chooser-backend"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:921
+#: C/gosdconfkeys.xml:973
 msgid "(s) Module to use as the filesystem model for the GtkFileChooser widget. Possible values are \"gio\" and \"gtk+\"."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:923
-msgid "$ dconf read /org/mate/desktop/interface/file-chooser-backend $ gsettings get org.mate.interface file-chooser-backend"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:929
+#: C/gosdconfkeys.xml:981
 msgid "menubar-accel"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:931
+#: C/gosdconfkeys.xml:983
 msgid "(s) Keyboard shortcut to open the menu bars."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:933
-msgid "$ dconf read /org/mate/desktop/interface/menubar-accel $ gsettings get org.mate.interface menubar-accel"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:939
+#: C/gosdconfkeys.xml:991
 msgid "show-input-method-menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:941
+#: C/gosdconfkeys.xml:993
 msgid "(b) Whether the context menus of entries and text views should offer to change the input method."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:943
-msgid "$ dconf read /org/mate/desktop/interface/show-input-method-menu $ gsettings get org.mate.interface show-input-method-menu"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:949
+#: C/gosdconfkeys.xml:1001
 msgid "show-unicode-menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:951
+#: C/gosdconfkeys.xml:1003
 msgid "(b) Whether the context menus of entries and text views should offer to insert control characters."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:953
-msgid "$ dconf read /org/mate/desktop/interface/show-unicode-menu $ gsettings get org.mate.interface show-unicode-menu"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:959
+#: C/gosdconfkeys.xml:1011
 msgid "gtk-decoration-layout"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:961
+#: C/gosdconfkeys.xml:1013
 msgid "(s) This setting determines which buttons should be put in the titlebar of client-side decorated windows, and whether they should be placed at the left of right. See https://developer.gnome.org/gtk3/stable/GtkSettings.html#GtkSettings--gtk-decoration-layout."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:963
-msgid "$ dconf read /org/mate/desktop/interface/gtk-decoration-layout $ gsettings get org.mate.interface gtk-decoration-layout"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:969
+#: C/gosdconfkeys.xml:1021
 msgid "gtk-shell-shows-app-menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:971
+#: C/gosdconfkeys.xml:1023
 msgid "(b) This setting determines where application menu will be displayed - in a window or on a panel with MenuModel protocol. See https://developer.gnome.org/gtk3/stable/GtkSettings.html#GtkSettings--gtk-shell-shows-app-menu."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:973
-msgid "$ dconf read /org/mate/desktop/interface/gtk-shell-shows-app-menu $ gsettings get org.mate.interface gtk-shell-shows-app-menu"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:979
+#: C/gosdconfkeys.xml:1031
 msgid "gtk-shell-shows-menubar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:981
+#: C/gosdconfkeys.xml:1033
 msgid "(b) This setting determines where window menubars will be displayed - in a window or on a panel with MenuModel protocol. See https://developer.gnome.org/gtk3/stable/GtkSettings.html#GtkSettings--gtk-shell-shows-menubar."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:983
-msgid "$ dconf read /org/mate/desktop/interface/gtk-shell-shows-menubar $ gsettings get org.mate.interface gtk-shell-shows-menubar"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:989
+#: C/gosdconfkeys.xml:1041
 msgid "automatic-mnemonics"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:991
+#: C/gosdconfkeys.xml:1043
 msgid "(b) Whether mnemonics should be automatically shown and hidden when the user presses the Alt key."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:993
-msgid "$ dconf read /org/mate/desktop/interface/automatic-mnemonics $ gsettings get org.mate.interface automatic-mnemonics"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:999
+#: C/gosdconfkeys.xml:1051
 msgid "window-scaling-factor"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1001
+#: C/gosdconfkeys.xml:1053
 msgid "(i) This controls the GTK scale factor that maps from window coordinates to the actual device pixels. On traditional systems this is 1, but on very high density displays (e.g. HiDPI, Retina) this can be a higher value (often 2). Set to 0 to auto-detect."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1003
-msgid "$ dconf read /org/mate/desktop/interface/window-scaling-factor $ gsettings get org.mate.interface window-scaling-factor"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1009
+#: C/gosdconfkeys.xml:1061
 msgid "window-scaling-factor-qt-sync"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1011
+#: C/gosdconfkeys.xml:1063
 msgid "(b) This setting determines whether MATE controls the scale factor for QT applications. Enable to synchronize with the GTK scale factor when initializing the session, disable to control this value elsewhere. Requires restarting your session."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1013
-msgid "$ dconf read /org/mate/desktop/interface/window-scaling-factor-qt-sync $ gsettings get org.mate.interface window-scaling-factor-qt-sync"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1019
+#: C/gosdconfkeys.xml:1071
 msgid "gtk-enable-primary-paste"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1021
+#: C/gosdconfkeys.xml:1073
 msgid "(b) If true, gtk+ uses the primary paste selection, usually triggered by a middle mouse button click."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1025
-msgid "$ dconf read /org/mate/desktop/interface/gtk-enable-primary-paste $ gsettings get org.mate.interface gtk-enable-primary-paste"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:1033
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:1085
 msgid "Dconf Directory: /org/mate/desktop/lockdown/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1036
-msgid "$ dconf list /org/mate/desktop/lockdown/ $ gsettings list-keys org.mate.lockdown"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1044
+#: C/gosdconfkeys.xml:1098
 msgid "disable-command-line"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1046
+#: C/gosdconfkeys.xml:1100
 msgid "(b) Prevent the user from accessing the terminal or specifying a command line to be executed. For example, this would disable access to the panel's \"Run Application\" dialog."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1048
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-command-line $ gsettings get org.mate.lockdown disable-command-line"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1054
+#: C/gosdconfkeys.xml:1108
 msgid "disable-save-to-disk"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1056
+#: C/gosdconfkeys.xml:1110
 msgid "(b) Prevent the user from saving files to disk. For example, this would disable access to all applications' \"Save as\" dialogs."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1058
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-save-to-disk $ gsettings get org.mate.lockdown disable-save-to-disk"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1064
+#: C/gosdconfkeys.xml:1118
 msgid "disable-printing"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1066
+#: C/gosdconfkeys.xml:1120
 msgid "(b) Prevent the user from printing. For example, this would disable access to all applications' \"Print\" dialogs."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1068
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-printing $ gsettings get org.mate.lockdown disable-printing"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1074
+#: C/gosdconfkeys.xml:1128
 msgid "disable-print-setup"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1076
+#: C/gosdconfkeys.xml:1130
 msgid "(b) Prevent the user from modifying print settings. For example, this would disable access to all applications' \"Print Setup\" dialogs."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1078
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-print-setup $ gsettings get org.mate.lockdown disable-print-setup"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1084
+#: C/gosdconfkeys.xml:1138
 msgid "disable-user-switching"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1086
+#: C/gosdconfkeys.xml:1140
 msgid "(b) Prevent the user from switching to another account while his session is active."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1088
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-user-switching $ gsettings get org.mate.lockdown disable-user-switching"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1094
+#: C/gosdconfkeys.xml:1148
 msgid "disable-lock-screen"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1096
+#: C/gosdconfkeys.xml:1150
 msgid "(b) Prevent the user from locking the screen."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1098
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-lock-screen $ gsettings get org.mate.lockdown disable-lock-screen"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1104
+#: C/gosdconfkeys.xml:1158
 msgid "disable-application-handlers"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1106
+#: C/gosdconfkeys.xml:1160
 msgid "(b) Prevent running any URL or MIME type handler applications."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1108
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-application-handlers $ gsettings get org.mate.lockdown disable-application-handlers"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1114
+#: C/gosdconfkeys.xml:1168
 msgid "disable-theme-settings"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1116
+#: C/gosdconfkeys.xml:1170
 msgid "(b) Prevent the user from changing theme settings."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1118
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-theme-settings $ gsettings get org.mate.lockdown disable-theme-settings"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1124
+#: C/gosdconfkeys.xml:1178
 msgid "disable-log-out"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1126
+#: C/gosdconfkeys.xml:1180
 msgid "(b) Prevent the user from logging out."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1128
-msgid "$ dconf read /org/mate/desktop/lockdown/disable-log-out $ gsettings get org.mate.lockdown disable-log-out"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:1136
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:1190
 msgid "Dconf Directory: /org/mate/desktop/peripherals/keyboard/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1139
-msgid "$ dconf list /org/mate/desktop/peripherals/keyboard/ $ gsettings list-keys org.mate.peripherals-keyboard"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1147
+#: C/gosdconfkeys.xml:1203
 msgid "repeat"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1151
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/repeat $ gsettings get org.mate.peripherals-keyboard repeat"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1157
+#: C/gosdconfkeys.xml:1213
 msgid "click"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1161
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/click $ gsettings get org.mate.peripherals-keyboard click"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1167
+#: C/gosdconfkeys.xml:1223
 msgid "rate"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1171
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/rate $ gsettings get org.mate.peripherals-keyboard rate"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1177
+#: C/gosdconfkeys.xml:1233
 msgid "delay"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1181
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/delay $ gsettings get org.mate.peripherals-keyboard delay"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1187
+#: C/gosdconfkeys.xml:1243
 msgid "click-volume"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1191
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/click-volume $ gsettings get org.mate.peripherals-keyboard click-volume"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1197
+#: C/gosdconfkeys.xml:1253
 msgid "bell-mode"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1199
+#: C/gosdconfkeys.xml:1255
 msgid "(s) possible values are \"on\", \"off\", and \"custom\"."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1201
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/bell-mode $ gsettings get org.mate.peripherals-keyboard bell-mode"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1207
+#: C/gosdconfkeys.xml:1263
 msgid "bell-pitch"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1211
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/bell-pitch $ gsettings get org.mate.peripherals-keyboard bell-pitch"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1217
+#: C/gosdconfkeys.xml:1273
 msgid "bell-duration"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1221
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/bell-duration $ gsettings get org.mate.peripherals-keyboard bell-duration"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1227
+#: C/gosdconfkeys.xml:1283
 msgid "bell-custom-file"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1229
+#: C/gosdconfkeys.xml:1285
 msgid "(s) File name of the bell sound to be played."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1231
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/bell-custom-file $ gsettings get org.mate.peripherals-keyboard bell-custom-file"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1237
+#: C/gosdconfkeys.xml:1293
 msgid "remember-numlock-state"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1239
+#: C/gosdconfkeys.xml:1295
 msgid "(b) When set to true, MATE will remember the state of the NumLock LED between sessions."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1241
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/remember-numlock-state $ gsettings get org.mate.peripherals-keyboard remember-numlock-state"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1247
+#: C/gosdconfkeys.xml:1303
 msgid "numlock-state"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1249
+#: C/gosdconfkeys.xml:1305
 msgid "() The remembered state of the NumLock LED."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1251
-msgid "$ dconf read /org/mate/desktop/peripherals/keyboard/numlock-state $ gsettings get org.mate.peripherals-keyboard numlock-state"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:1259
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:1315
 msgid "Dconf Directory: /org/mate/desktop/peripherals/mouse/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1262
-msgid "$ dconf list /org/mate/desktop/peripherals/mouse/ $ gsettings list-keys org.mate.peripherals-mouse"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1270
+#: C/gosdconfkeys.xml:1328
 msgid "left-handed"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1272
+#: C/gosdconfkeys.xml:1330
 msgid "(b) Swap left and right mouse buttons for left-handed mice."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1274
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/left-handed $ gsettings get org.mate.peripherals-mouse left-handed"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1280
+#: C/gosdconfkeys.xml:1338
 msgid "motion-acceleration"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1282
+#: C/gosdconfkeys.xml:1340
 msgid "(d) Acceleration multiplier for mouse motion. A value of -1 is the system default."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1284
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/motion-acceleration $ gsettings get org.mate.peripherals-mouse motion-acceleration"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1290
+#: C/gosdconfkeys.xml:1348
 msgid "motion-threshold"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1292
+#: C/gosdconfkeys.xml:1350
 msgid "(i) Distance in pixels the pointer must move before accelerated mouse motion is activated. A value of -1 is the system default."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1294
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/motion-threshold $ gsettings get org.mate.peripherals-mouse motion-threshold"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1300
+#: C/gosdconfkeys.xml:1358
 msgid "drag-threshold"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1302
+#: C/gosdconfkeys.xml:1360
 msgid "(i) Distance before a drag is started."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1304
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/drag-threshold $ gsettings get org.mate.peripherals-mouse drag-threshold"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1310
+#: C/gosdconfkeys.xml:1368
 msgid "double-click"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1312
+#: C/gosdconfkeys.xml:1370
 msgid "(i) Length of a double click."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1314
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/double-click $ gsettings get org.mate.peripherals-mouse double-click"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1320
+#: C/gosdconfkeys.xml:1378
 msgid "middle-button-enabled"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1322
+#: C/gosdconfkeys.xml:1380
 msgid "(b) Enables middle mouse button emulation through simultaneous left and right button click."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1324
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/middle-button-enabled $ gsettings get org.mate.peripherals-mouse middle-button-enabled"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1330
+#: C/gosdconfkeys.xml:1388
 msgid "locate-pointer"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1332
+#: C/gosdconfkeys.xml:1390
 msgid "(b) Highlights the current location of the pointer when the Control key is pressed and released."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1334
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/locate-pointer $ gsettings get org.mate.peripherals-mouse locate-pointer"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1340
+#: C/gosdconfkeys.xml:1398
 msgid "cursor-theme"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1342
+#: C/gosdconfkeys.xml:1400
 msgid "(s) Cursor theme name."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1344
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/cursor-theme $ gsettings get org.mate.peripherals-mouse cursor-theme"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1350
+#: C/gosdconfkeys.xml:1408
 msgid "cursor-size"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1352
+#: C/gosdconfkeys.xml:1410
 msgid "(i) Size of the cursor referenced by cursor_theme."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1354
-msgid "$ dconf read /org/mate/desktop/peripherals/mouse/cursor-size $ gsettings get org.mate.peripherals-mouse cursor-size"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:1362
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:1420
 msgid "Dconf Directory: /org/mate/desktop/sound/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1365
-msgid "$ dconf list /org/mate/desktop/sound/ $ gsettings list-keys org.mate.sound"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1373
+#: C/gosdconfkeys.xml:1433
 msgid "default-mixer-device"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1375
+#: C/gosdconfkeys.xml:1435
 msgid "(s) The default mixer device used by the multimedia key bindings."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1377
-msgid "$ dconf read /org/mate/desktop/sound/default-mixer-device $ gsettings get org.mate.sound default-mixer-device"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1383
+#: C/gosdconfkeys.xml:1443
 msgid "default-mixer-tracks"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1385
+#: C/gosdconfkeys.xml:1445
 msgid "(as) The default mixer tracks used by the multimedia key bindings."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1387
-msgid "$ dconf read /org/mate/desktop/sound/default-mixer-tracks $ gsettings get org.mate.sound default-mixer-tracks"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1393
+#: C/gosdconfkeys.xml:1453
 msgid "enable-esd"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1395
+#: C/gosdconfkeys.xml:1455
 msgid "(b) Enable sound server startup."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1397
-msgid "$ dconf read /org/mate/desktop/sound/enable-esd $ gsettings get org.mate.sound enable-esd"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1403
+#: C/gosdconfkeys.xml:1463
 msgid "event-sounds"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1405
+#: C/gosdconfkeys.xml:1465
 msgid "(b) Whether to play sounds on user events."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1407
-msgid "$ dconf read /org/mate/desktop/sound/event-sounds $ gsettings get org.mate.sound event-sounds"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1413
+#: C/gosdconfkeys.xml:1473
 msgid "theme-name"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1415
+#: C/gosdconfkeys.xml:1475
 msgid "(s) The XDG sound theme to use for event sounds."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1417
-msgid "$ dconf read /org/mate/desktop/sound/theme-name $ gsettings get org.mate.sound theme-name"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1423
+#: C/gosdconfkeys.xml:1483
 msgid "input-feedback-sounds"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1425
+#: C/gosdconfkeys.xml:1485
 msgid "(b) Whether to play sounds on input events."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1427
-msgid "$ dconf read /org/mate/desktop/sound/input-feedback-sounds $ gsettings get org.mate.sound input-feedback-sounds"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:1435
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:1495
 msgid "Dconf Directory: /org/mate/desktop/thumbnail-cache/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1438
-msgid "$ dconf list /org/mate/desktop/thumbnail-cache/ $ gsettings list-keys org.mate.thumbnail-cache"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1446
+#: C/gosdconfkeys.xml:1508
 msgid "maximum-age"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1448
+#: C/gosdconfkeys.xml:1510
 msgid "(i) Maximum age for thumbnails in the cache, in days. Set to -1 to disable cleaning."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1450
-msgid "$ dconf read /org/mate/desktop/thumbnail-cache/maximum-age $ gsettings get org.mate.thumbnail-cache maximum-age"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1456
+#: C/gosdconfkeys.xml:1518
 msgid "maximum-size"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1458
+#: C/gosdconfkeys.xml:1520
 msgid "(i) Maximum size of the thumbnail cache, in megabytes. Set to -1 to disable cleaning."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1460
-msgid "$ dconf read /org/mate/desktop/thumbnail-cache/maximum-size $ gsettings get org.mate.thumbnail-cache maximum-size"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:1468
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:1530
 msgid "Dconf Directory: /org/mate/desktop/thumbnailers/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1471
-msgid "$ dconf list /org/mate/desktop/thumbnailers/ $ gsettings list-keys org.mate.thumbnailers"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1479
+#: C/gosdconfkeys.xml:1543
 msgid "disable-all"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1481
+#: C/gosdconfkeys.xml:1545
 msgid "(b) Set to true to disable all external thumbnailer programs, independent on whether they are independently disabled/enabled."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1483
-msgid "$ dconf read /org/mate/desktop/thumbnailers/disable-all $ gsettings get org.mate.thumbnailers disable-all"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1489
+#: C/gosdconfkeys.xml:1553
 msgid "disable"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1491
+#: C/gosdconfkeys.xml:1555
 msgid "(as) Thumbnails will not be created for files whose mime-type is contained in the list."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1493
-msgid "$ dconf read /org/mate/desktop/thumbnailers/disable $ gsettings get org.mate.thumbnailers disable"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/gosdconfkeys.xml:1501
+#. (itstool) path: section/title
+#: C/gosdconfkeys.xml:1565
 msgid "Dconf Directory: /org/mate/desktop/typing-break/"
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1504
-msgid "$ dconf list /org/mate/desktop/typing-break/ $ gsettings list-keys org.mate.typing-break"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1512
+#: C/gosdconfkeys.xml:1578
 msgid "type-time"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1514
+#: C/gosdconfkeys.xml:1580
 msgid "(i) Number of minutes of typing time before break mode starts."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1516
-msgid "$ dconf read /org/mate/desktop/typing-break/type-time $ gsettings get org.mate.typing-break type-time"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1522
+#: C/gosdconfkeys.xml:1588
 msgid "break-time"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1524
+#: C/gosdconfkeys.xml:1590
 msgid "(i) Number of minutes that the typing break should last."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1526
-msgid "$ dconf read /org/mate/desktop/typing-break/break-time $ gsettings get org.mate.typing-break break-time"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1532
+#: C/gosdconfkeys.xml:1598
 msgid "allow-postpone"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1534
+#: C/gosdconfkeys.xml:1600
 msgid "(b) Whether or not the typing break screen can be postponed."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1536
-msgid "$ dconf read /org/mate/desktop/typing-break/allow-postpone $ gsettings get org.mate.typing-break allow-postpone"
-msgstr ""
-
 #. (itstool) path: varlistentry/term
-#: C/gosdconfkeys.xml:1542
+#: C/gosdconfkeys.xml:1608
 msgid "enabled"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/gosdconfkeys.xml:1544
+#: C/gosdconfkeys.xml:1610
 msgid "(b) Whether or not keyboard locking is enabled."
 msgstr ""
 
-#. (itstool) path: para/screen
-#: C/gosdconfkeys.xml:1546
-msgid "$ dconf read /org/mate/desktop/typing-break/enabled $ gsettings get org.mate.typing-break enabled"
-msgstr ""
-
 #. (itstool) path: appendix/para
-#: C/gosfeedback.xml:3
+#: C/gosfeedback.xml:9
 msgid "This section contains information on reporting bugs in MATE, making suggestions and comments about MATE applications or documentation, and ways in which you can help MATE."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosfeedback.xml:7
+#. (itstool) path: info/title
+#: C/gosfeedback.xml:11
 msgid "Reporting Bugs"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosfeedback.xml:9
+#: C/gosfeedback.xml:13
 msgid "If you have found a bug in a MATE application, please report it! Developers do read all the bug reports and try to fix these bugs. Please try to be as specific as possible when describing the circumstances under which the bug shows (What commands did you enter? Which buttons did you click?). If there were any error messages, be sure to include them, too."
 msgstr ""
 
-#. (itstool) path: para/application
-#: C/gosfeedback.xml:18
-#: C/gosfeedback.xml:35
-msgid "Bug Buddy"
+#. (itstool) path: section/para
+#: C/gosfeedback.xml:21
+msgid "The easiest way to report bugs is by using <application>Bug Buddy</application>, MATE's built-in bug reporting tool. This will launch automatically in the event that an application crashes. The details MATE developers need are automatically collected, but you can further help by giving information about what you were doing when the crash took place."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosfeedback.xml:17
-msgid "The easiest way to report bugs is by using <_:application-1/>, MATE's built-in bug reporting tool. This will launch automatically in the event that an application crashes. The details MATE developers need are automatically collected, but you can further help by giving information about what you were doing when the crash took place."
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/gosfeedback.xml:23
-msgid "MATE bug tracking database"
+#: C/gosfeedback.xml:24
+msgid "You can also submit bugs and browse the list of known bugs by connecting to the <link xlink:href=\"https://github.com/mate-desktop/\">MATE bug tracking database</link>. You will need to register before you can submit any bugs this way."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosfeedback.xml:20
-msgid "You can also submit bugs and browse the list of known bugs by connecting to the <_:ulink-1/>. You will need to register before you can submit any bugs this way."
+#: C/gosfeedback.xml:30
+msgid "Please note that some of MATE applications are developed outside of MATE, or by commercial companies (these products are still free software). For example, <application>blueman</application>, a bluetooth application, is developed at <link xlink:href=\"https://github.com/blueman-project/blueman/\">GitHub</link>. Bug reports and comments about these products should be directed to the respective organization or company. If you are using <application>Bug Buddy</application>, it will automatically send bug reports to the correct database."
 msgstr ""
 
-#. (itstool) path: para/application
-#: C/gosfeedback.xml:31
-msgid "blueman"
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/gosfeedback.xml:33
-msgid "GitHub"
-msgstr ""
-
-#. (itstool) path: section/para
-#: C/gosfeedback.xml:28
-msgid "Please note that some of MATE applications are developed outside of MATE, or by commercial companies (these products are still free software). For example, <_:application-1/>, a bluetooth application, is developed at <_:ulink-2/>. Bug reports and comments about these products should be directed to the respective organization or company. If you are using <_:application-3/>, it will automatically send bug reports to the correct database."
-msgstr ""
-
-#. (itstool) path: section/title
+#. (itstool) path: info/title
 #: C/gosfeedback.xml:43
 msgid "Suggestions and Comments"
 msgstr ""
 
-#. (itstool) path: para/guilabel
-#: C/gosfeedback.xml:50
-msgid "Severity: Enhancement"
-msgstr ""
-
 #. (itstool) path: section/para
 #: C/gosfeedback.xml:45
-msgid "If you have a suggestion or want to request a new feature for one of the applications, it can also be done using the bug tracking database. Submit your suggestion as a bug report as described in <_:xref-1/> and at the appropriate step select <_:guilabel-2/>."
+msgid "If you have a suggestion or want to request a new feature for one of the applications, it can also be done using the bug tracking database. Submit your suggestion as a bug report as described in <xref linkend=\"feedback-bugs\"/> and at the appropriate step select <guilabel>Severity: Enhancement</guilabel>."
 msgstr ""
 
-#. (itstool) path: section/title
-#: C/gosfeedback.xml:55
+#. (itstool) path: info/title
+#: C/gosfeedback.xml:54
 msgid "Documentation Comments"
 msgstr ""
 
-#. (itstool) path: para/guilabel
-#: C/gosfeedback.xml:62
-msgid "Component: docs"
+#. (itstool) path: section/para
+#: C/gosfeedback.xml:56
+msgid "If you found an inaccuracy or misprint in one of MATE documents, or have any comments or suggestions about documentation, please let us know! The easiest way of doing so is by submitting a bug report as explained before and selecting <guilabel>Component: docs</guilabel> at appropriate steps (or <guilabel>general</guilabel> if there is no <guilabel>docs</guilabel> component). If your comment is about general MATE documentation (such as <citetitle>MATE Users Guide</citetitle>) rather than specific application manual, select <guilabel>Product: mate-user-docs</guilabel>."
 msgstr ""
 
-#. (itstool) path: para/guilabel
-#: C/gosfeedback.xml:63
-msgid "general"
-msgstr ""
-
-#. (itstool) path: para/guilabel
-#: C/gosfeedback.xml:64
-msgid "docs"
-msgstr ""
-
-#. (itstool) path: para/citetitle
-#: C/gosfeedback.xml:65
-msgid "MATE Users Guide"
-msgstr ""
-
-#. (itstool) path: para/guilabel
+#. (itstool) path: section/para
 #: C/gosfeedback.xml:67
-msgid "Product: mate-user-docs"
+msgid "Alternatively, you can just send your comments by email to the <link xlink:href=\"http://ml.mate-desktop.org/listinfo\">MATE Documentation Project</link> mailing list."
 msgstr ""
 
-#. (itstool) path: section/para
-#: C/gosfeedback.xml:58
-msgid "If you found an inaccuracy or misprint in one of MATE documents, or have any comments or suggestions about documentation, please let us know! The easiest way of doing so is by submitting a bug report as explained before and selecting <_:guilabel-1/> at appropriate steps (or <_:guilabel-2/> if there is no <_:guilabel-3/> component). If your comment is about general MATE documentation (such as <_:citetitle-4/>) rather than specific application manual, select <_:guilabel-5/>."
-msgstr ""
-
-#. (itstool) path: section/para
-#: C/gosfeedback.xml:69
-msgid "Alternatively, you can just send your comments by email to the <_:ulink-1/> mailing list."
-msgstr ""
-
-#. (itstool) path: section/title
-#: C/gosfeedback.xml:80
+#. (itstool) path: info/title
+#: C/gosfeedback.xml:75
 msgid "Joining the MATE Project"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosfeedback.xml:81
+#: C/gosfeedback.xml:76
 msgid "We hope you enjoy using MATE and that you find working with MATE productive. However, there is always room for improvement."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosfeedback.xml:82
+#: C/gosfeedback.xml:77
 msgid "MATE invites you to join our free software community if you have some spare time. There are many different fields. MATE needs programmers, but it also needs translators, documentation writers, testers, artists, writers, and more."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/gosfeedback.xml:83
-msgid "http://live.gnome.org/JoinMate"
+#. (itstool) path: section/para
+#: C/gosfeedback.xml:78
+msgid "For more information on joining MATE, please visit <link xlink:href=\"http://live.gnome.org/JoinMate\">http://live.gnome.org/JoinMate</link>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/gosfeedback.xml:83
-msgid "For more information on joining MATE, please visit <_:ulink-1/>."
+#: C/gosfeedback.xml:79
+msgid "For more information on giving feedback on MATE, such as bug reports, suggestions, and corrections to documentation, see <xref linkend=\"feedback-bugs\"/>."
 msgstr ""
 
-#. (itstool) path: section/para
-#: C/gosfeedback.xml:84
-msgid "For more information on giving feedback on MATE, such as bug reports, suggestions, and corrections to documentation, see <_:xref-1/>."
-msgstr ""
-
-#. (itstool) path: glossary/title
-#: C/glossary.xml:2
+#. (itstool) path: info/title
+#: C/glossary.xml:6
 msgid "Glossary"
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:4
+#: C/glossary.xml:9
 msgid "applet"
 msgstr ""
 
-#. (itstool) path: para/application
-#: C/glossary.xml:7
-msgid "Volume Control"
-msgstr ""
-
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:6
-msgid "An applet is a small, interactive application that resides within a panel, for example the <_:application-1/>. Each applet has a simple user interface that you can operate with the mouse or keyboard."
+#: C/glossary.xml:11
+msgid "An applet is a small, interactive application that resides within a panel, for example the <application>Volume Control</application>. Each applet has a simple user interface that you can operate with the mouse or keyboard."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:13
+#: C/glossary.xml:18
 msgid "desktop"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:15
+#: C/glossary.xml:20
 msgid "The part of the MATE Desktop where there are no interface graphical items, such as panels and windows."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:20
+#: C/glossary.xml:25
 msgid "desktop background"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:22
+#: C/glossary.xml:27
 msgid "The image or color that is applied to your desktop."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:26
+#: C/glossary.xml:31
 msgid "desktop object"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:28
+#: C/glossary.xml:33
 msgid "An icon on your desktop that you can use to open your files, folders, and applications. You can use desktop objects to provide convenient access to files, folders, and applications that you use frequently."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:34
+#: C/glossary.xml:39
 msgid "DNS name"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:36
+#: C/glossary.xml:41
 msgid "A unique alphabetic identifier for a computer on a network."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:40
+#: C/glossary.xml:45
 msgid "drawer"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:42
+#: C/glossary.xml:47
 msgid "A drawer is a sliding extension to a panel that you can open or close from a drawer icon."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:47
+#: C/glossary.xml:52
 msgid "file extension"
 msgstr ""
 
-#. (itstool) path: para/filename
-#: C/glossary.xml:49
-msgid "picture.jpeg"
-msgstr ""
-
-#. (itstool) path: para/filename
-#: C/glossary.xml:49
-msgid "jpeg"
+#. (itstool) path: glossdef/para
+#: C/glossary.xml:54
+msgid "The final portion of a file's name, after the last period (.) in the name. For example, the file extension of the file <filename>picture.jpeg</filename> is <filename>jpeg</filename>."
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:49
-msgid "The final portion of a file's name, after the last period (.) in the name. For example, the file extension of the file <_:filename-1/> is <_:filename-2/>."
-msgstr ""
-
-#. (itstool) path: para/application
-#: C/glossary.xml:50
-#: C/glossary.xml:65
-#: C/glossary.xml:117
-#: C/glossary.xml:181
-#: C/glossary.xml:182
-#: C/glossary.xml:183
-msgid "Caja"
-msgstr ""
-
-#. (itstool) path: glossdef/para
-#: C/glossary.xml:50
-msgid "The file extension can identify the type of file. <_:application-1/> file manager uses this information when to determine what to do when you open a file. For more on this, see <_:xref-2/>."
+#: C/glossary.xml:55
+msgid "The file extension can identify the type of file. <application>Caja</application> file manager uses this information when to determine what to do when you open a file. For more on this, see <xref linkend=\"caja-open-file\"/>."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:54
+#: C/glossary.xml:59
 msgid "format"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:56
+#: C/glossary.xml:61
 msgid "To format media is to prepare the media for use with a particular file system. When you format media, you overwrite any existing information on the media."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:62
+#: C/glossary.xml:67
 msgid "MATE-compliant application"
 msgstr ""
 
-#. (itstool) path: para/application
-#: C/glossary.xml:65
-msgid "pluma"
-msgstr ""
-
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:64
-msgid "An application that uses the standard MATE programming libraries is called a MATE-compliant application. For example, <_:application-1/> file manager and <_:application-2/> text editor are MATE-compliant applications."
+#: C/glossary.xml:69
+msgid "An application that uses the standard MATE programming libraries is called a MATE-compliant application. For example, <application>Caja</application> file manager and <application>pluma</application> text editor are MATE-compliant applications."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:70
+#: C/glossary.xml:75
 msgid "IP address"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:72
+#: C/glossary.xml:77
 msgid "A unique numeric identifier for a computer on a network."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#. (itstool) path: para/firstterm
-#: C/glossary.xml:76
-#: C/glossary.xml:78
+#: C/glossary.xml:81
 msgid "keyboard shortcut"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:78
-msgid "A <_:firstterm-1/> is a key or combination of keys that provides an alternative to standard ways of performing an action."
+#: C/glossary.xml:83
+msgid "A <firstterm>keyboard shortcut</firstterm> is a key or combination of keys that provides an alternative to standard ways of performing an action."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:83
+#: C/glossary.xml:88
 msgid "launcher"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:85
+#: C/glossary.xml:90
 msgid "A launcher starts a particular application, executes a command, or opens a file. A launcher can reside in a panel or in a menu."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:90
+#: C/glossary.xml:95
 msgid "menubar"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:92
+#: C/glossary.xml:97
 msgid "A menubar is a bar at the top of an application window that contains the menus for the application."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:97
+#: C/glossary.xml:102
 msgid "MIME type"
 msgstr ""
 
-#. (itstool) path: para/literal
-#: C/glossary.xml:101
-msgid "image/png"
-msgstr ""
-
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:99
-msgid "A Multipurpose Internet Mail Extension (MIME) type identifies the format of a file. The MIME type enables applications to read the file. For example, an email application can use the <_:literal-1/> MIME type to detect that a Portable Networks Graphic (PNG) file is attached to an email."
+#: C/glossary.xml:104
+msgid "A Multipurpose Internet Mail Extension (MIME) type identifies the format of a file. The MIME type enables applications to read the file. For example, an email application can use the <literal>image/png</literal> MIME type to detect that a Portable Networks Graphic (PNG) file is attached to an email."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:107
+#: C/glossary.xml:112
 msgid "mount"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:109
+#: C/glossary.xml:114
 msgid "To mount is to make a file system available for access. When you mount a file system, the file system is attached as a subdirectory to your file system."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:115
+#: C/glossary.xml:120
 msgid "pane"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:117
-msgid "A pane is a subdivision of a window. For example, the <_:application-1/> window contains a side pane and a view pane."
+#: C/glossary.xml:122
+msgid "A pane is a subdivision of a window. For example, the <application>Caja</application> window contains a side pane and a view pane."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:121
+#: C/glossary.xml:126
 msgid "preference tool"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:123
+#: C/glossary.xml:128
 msgid "A dedicated software tool that controls a particular part of the behavior of the MATE Desktop."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:128
+#: C/glossary.xml:133
 msgid "shortcut keys"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:130
+#: C/glossary.xml:135
 msgid "Shortcut keys are keystrokes that provide a quick way to perform an action."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:135
+#: C/glossary.xml:140
 msgid "stacking order"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:137
+#: C/glossary.xml:142
 msgid "The stacking order is the order in which windows are stacked on top of each other on your screen."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:142
+#: C/glossary.xml:147
 msgid "statusbar"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:144
+#: C/glossary.xml:149
 msgid "A statusbar is a bar at the bottom of a window that provides information about the current state of what you are viewing in the window."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:149
+#: C/glossary.xml:154
 msgid "symbolic link"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:151
+#: C/glossary.xml:156
 msgid "A special type of file that points to another file or folder. When you perform an action on a symbolic link, the action is performed on the file or folder to which the symbolic link points."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:157
+#: C/glossary.xml:162
 msgid "toolbar"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:159
+#: C/glossary.xml:164
 msgid "A toolbar is a bar that contains buttons for the most commonly-used commands in an application. Typically, a toolbar appears under a menubar."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:164
+#: C/glossary.xml:169
 msgid "Uniform Resource Identifier"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:166
+#: C/glossary.xml:171
 msgid "A Uniform Resource Identifier (URI) is a string that identifies a particular location in a file system or on the Web. For example, the address of a web page is a URI."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:172
+#: C/glossary.xml:177
 msgid "Uniform Resource Locator"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:174
+#: C/glossary.xml:179
 msgid "A Uniform Resource Locator (URL) is the address of a particular location on the Web."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:179
+#: C/glossary.xml:184
 msgid "view"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:181
-msgid "A <_:application-1/> component that enables you to display a folder in a particular way. For example, <_:application-2/> contains an icon view which enables you to display the contents of a folder as icons. <_:application-3/> also contains a list view which enables you to display the contents of a folder as a list."
+#: C/glossary.xml:186
+msgid "A <application>Caja</application> component that enables you to display a folder in a particular way. For example, <application>Caja</application> contains an icon view which enables you to display the contents of a folder as icons. <application>Caja</application> also contains a list view which enables you to display the contents of a folder as a list."
 msgstr ""
 
 #. (itstool) path: glossentry/glossterm
-#: C/glossary.xml:188
+#: C/glossary.xml:193
 msgid "workspace"
 msgstr ""
 
 #. (itstool) path: glossdef/para
-#: C/glossary.xml:190
+#: C/glossary.xml:195
 msgid "A workspace is a discrete area in the MATE Desktop in which you can work."
 msgstr ""
 


### PR DESCRIPTION
To upgrade the manual:
sudo dnf install -y docbook5-schemas
xsltproc --output index-new.docbook /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl index.docbook
xsltproc --output legal-new.xml /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl legal.xml
(...)

To validate the manual:
xmllint --noout --relaxng /usr/share/xml/docbook5/schema/rng/5.0/docbookxi.rng mate-user-guide/C/index.docbook
jing /usr/share/xml/docbook5/schema/rng/5.0/docbookxi.rng mate-user-guide/C/index.docbook
yelp-check validate mate-user-guide/C/index.docbook

To view the manual:
yelp file:///full_path/index.docbook

Note: docbook5-schemas should be installed in your system in order to view the manual (DEPENDENCY)