### PR TITLE
replace docbook link with xref and fix a linkend attribute

### DIFF
--- a/mate-user-guide/C/goscaja.xml
+++ b/mate-user-guide/C/goscaja.xml
@@ -67,7 +67,7 @@ file manager to do the following:</para>
 lies behind all other visible items on your screen. The desktop
 is an active component of the way you use your computer.</para>
     <para>Every user has a Home Folder. The Home Folder contains all user's files. The desktop is another folder. The desktop contains special icons allowing easy access to the users Home Folder, Trash, and also removable media such as floppy disks, CDs and USB flash drives.</para>
-    <para><application>Caja</application> is always running while you are using MATE. To open a new <application>Caja</application> window, double-click on an appropriate icon on the desktop such as <guimenuitem>Home</guimenuitem> or <guimenuitem>Computer</guimenuitem>, or choose an item from <link linkend="places-menu"><guimenuitem>Places</guimenuitem> menu</link> on the top panel.</para>
+    <para><application>Caja</application> is always running while you are using MATE. To open a new <application>Caja</application> window, double-click on an appropriate icon on the desktop such as <guimenuitem>Home</guimenuitem> or <guimenuitem>Computer</guimenuitem>, or choose an item from <xref linkend="places-menu"/> on the top panel.</para>
     <para>In MATE many things are files, such as word processor documents, spreadsheets, photos, movies, and music.</para>
   </section>
 
@@ -154,7 +154,7 @@ is an active component of the way you use your computer.</para>
         <listitem><para>Double-click the folder's icon on the desktop or an existing window</para></listitem>
         <listitem><para>Select the folder, and press <keycombo><keycap>Ctrl</keycap><keycap>O</keycap></keycombo>.</para></listitem>
         <listitem><para>Select the folder, and press <keycombo><keycap>Alt</keycap><keycap>down arrow</keycap></keycombo></para></listitem>
-        <listitem><para>Choose an item from the <link linkend="places-menu"><guimenuitem>Places</guimenuitem> menu</link> on the top panel. Your Home Folder and folders you have bookmarked are listed here. For more on bookmarks, see <xref linkend="caja-bookmarks"/>.</para></listitem>
+        <listitem><para>Choose an item from the <xref linkend="places-menu"/> on the top panel. Your Home Folder and folders you have bookmarked are listed here. For more on bookmarks, see <xref linkend="caja-bookmarks"/>.</para></listitem>
       </itemizedlist>
       
       <para>To close the current folder while opening the new one, hold down <keycap>Shift</keycap> when double-clicking, or press <keycombo><keycap>Shift</keycap><keycap>Alt</keycap><keycap>down arrow</keycap></keycombo>.</para>
@@ -887,7 +887,7 @@ action for that file type.</para>
     <para>The file manager checks the contents of a file to determine the type
 of a file. If the first lines do not determine the type of the file, then
 the file manager checks the <glossterm>file extension</glossterm>.</para>
-    <note><para>If you open an executable text file, that is, one that Caja considers can be run as a program, then you will be asked what you want to do: run it, or display it in a text editor. You can modify this behavior in the <link linkend="caja-preferences">File Management preferences</link>.</para></note>
+    <note><para>If you open an executable text file, that is, one that Caja considers can be run as a program, then you will be asked what you want to do: run it, or display it in a text editor. You can modify this behavior in <xref linkend="caja-preferences"/>.</para></note>
 
     <section xml:id="goscaja-29"><info><title>Executing the Default Action</title></info>
       <indexterm>
@@ -2230,7 +2230,7 @@ or folder to which a symbolic link points.</para>
             <para>Select the folder that you want to change. </para>
           </listitem>
           <listitem>
-            <para>Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. The <link linkend="caja-properties">properties window</link> for the item is displayed.</para>
+            <para>Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. The <xref linkend="caja-properties"/> for the item is displayed.</para>
           </listitem>
           <listitem>
             <para>Click on the <guilabel>Permissions</guilabel> tab.</para>
@@ -2301,7 +2301,7 @@ to a file or folder, perform the following steps:</para>
             <para>Select the file or folder to which you want to add a note. </para>
           </listitem>
           <listitem>
-            <para>Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. The <link linkend="caja-properties">properties window</link> for the item is displayed.</para>
+            <para>Choose <menuchoice><guimenu>File</guimenu><guimenuitem>Properties</guimenuitem></menuchoice>. The <xref linkend="caja-properties"/> for the item is displayed.</para>
           </listitem>
           <listitem>
             <para>Click on the <guilabel>Notes</guilabel> tab. In the <guilabel>Notes</guilabel> tabbed section, type the note.</para>
@@ -2750,7 +2750,7 @@ icon</guilabel> dialog click <guibutton>Revert</guibutton>.</para>
           <para>Select the item to which you want to add an emblem.</para>
         </listitem>
         <listitem>
-          <para>Right-click on the item, then choose <guimenuitem>Properties</guimenuitem>. The <link linkend="caja-properties">properties window</link> for the item is displayed.</para>
+          <para>Right-click on the item, then choose <guimenuitem>Properties</guimenuitem>. The <xref linkend="caja-properties"/> for the item is displayed.</para>
         </listitem>
         <listitem>
           <para>Click on the <guilabel>Emblems</guilabel> tab to display the <guilabel>Emblems</guilabel> tabbed section.</para>

--- a/mate-user-guide/C/goscustdesk.xml
+++ b/mate-user-guide/C/goscustdesk.xml
@@ -129,7 +129,7 @@ keys that provides an alternative to standard ways of performing an action. For 
     
     <variablelist>
     	<varlistentry><term>Desktop</term>
-    	  <listitem><para>These are general shortcuts for the whole desktop, such as logging out, locing your screen (see <xref linkend="lock-screen"/>), opening the panel menubar (see <xref linkend="menubar"/>), or launching a web browser.</para></listitem>
+    	  <listitem><para>These are general shortcuts for the whole desktop, such as logging out, locking your screen (see <xref linkend="lock-screen"/>), opening the panel menubar (see <xref linkend="menubar"/>), or launching a web browser.</para></listitem>
     	</varlistentry>
     	<varlistentry><term>Sound</term>
     	  <listitem><para>Shortcuts for controlling your music player and the system volume.</para></listitem>

--- a/mate-user-guide/C/goscustdesk.xml
+++ b/mate-user-guide/C/goscustdesk.xml
@@ -129,7 +129,7 @@ keys that provides an alternative to standard ways of performing an action. For 
     
     <variablelist>
     	<varlistentry><term>Desktop</term>
-    	  <listitem><para>These are general shortcuts for the whole desktop, such as logging out, <link linkend="lock-screen">locking the screen</link>, opening the <link linkend="menubar">panel menubar</link>, or launching a web browser.</para></listitem>
+    	  <listitem><para>These are general shortcuts for the whole desktop, such as logging out, locing your screen (see <xref linkend="lock-screen"/>), opening the panel menubar (see <xref linkend="menubar"/>), or launching a web browser.</para></listitem>
     	</varlistentry>
     	<varlistentry><term>Sound</term>
     	  <listitem><para>Shortcuts for controlling your music player and the system volume.</para></listitem>
@@ -536,7 +536,7 @@ A <guilabel>Customize Theme</guilabel> dialog is displayed.</para>
       <primary>backgrounds</primary>
       <secondary>customizing desktop background</secondary>
     </indexterm>
-    <para>The <link linkend="overview-desktop">desktop</link> background is the image or color that is applied to your
+    <para>The <xref linkend="overview-desktop"/> background is the image or color that is applied to your
 desktop. You can open <guilabel>Background</guilabel> tabbed section in the <application>Appearance</application> preference tool by right-clicking on the desktop and choosing <guimenuitem>Change Desktop Background</guimenuitem>, as well as from the <menuchoice><guimenu>System</guimenu><guisubmenu>Preferences</guisubmenu></menuchoice> menu.</para>
     <para>You can customize the desktop background in the following ways:</para>
     <itemizedlist>
@@ -552,8 +552,8 @@ a solid color, or create a gradient effect with two colors. A gradient effect
 is a visual effect where one color blends gradually into another color. </para>
       </listitem>
     </itemizedlist>
-    <tip><para>You can also drag a color or a pattern to the desktop from the <link linkend="caja-backgrounds-and-emblems"><guilabel>Backgrounds
-and Emblems</guilabel> dialog</link> in the <application>Caja</application> file manager.</para></tip>
+    <tip><para>You can also drag a color or a pattern to the desktop from the <guilabel>Backgrounds
+and Emblems</guilabel> dialog in the <application>Caja</application> file manager (see <xref linkend="caja-backgrounds-and-emblems"/>).</para></tip>
     <para><xref linkend="goscustdesk-TBL-14"/> lists the background preferences
 that you can modify.</para>
     <table frame="topbot" xml:id="goscustdesk-TBL-14"><info><title>Desktop Background Preferences</title></info>
@@ -1447,7 +1447,7 @@ preference tool in the following functional areas:</para>
       </listitem>
     </itemizedlist>
     -->
-    <para>To open the <link linkend="prefs-keyboard-a11y"><application>Keyboard <emphasis>Accessibility</emphasis></application> preference tool</link>, click the <guibutton>Accessibility</guibutton> button.</para>    
+    <para>To open the <xref linkend="prefs-keyboard-a11y"/> tool, click the <guibutton>Accessibility</guibutton> button.</para>    
     <section xml:id="goscustdesk-40"><info><title>Keyboard Preferences</title></info>
       
       <para>Use the <guilabel>General</guilabel> tabbed section to set general

--- a/mate-user-guide/C/gosoverview.xml
+++ b/mate-user-guide/C/gosoverview.xml
@@ -122,7 +122,7 @@
     <para>As you work with your computer, the desktop becomes obscured by the windows you are working with. To quickly reveal the desktop by minimizing all windows, you can do one of the following:</para>
     
     <itemizedlist>
-	    <listitem><para>Click on the <guibutton>Show Desktop</guibutton> button at the far left of the <link linkend="bottom-panel">bottom panel</link>.</para></listitem>
+	    <listitem><para>Click on the <guibutton>Show Desktop</guibutton> button at the far left of the <xref linkend="bottom-panel"/>.</para></listitem>
 	    <listitem><para>Press <keycombo><keycap>Ctrl</keycap><keycap>Alt</keycap><keycap>D</keycap></keycombo>.</para></listitem>
     </itemizedlist>
  
@@ -233,7 +233,7 @@
       <varlistentry>
         <term>Resize the window</term>
         <listitem>
-            <para>Drag one of the borders to expand or contract the window on that side. Drag a corner to change two sides at once. The <link linkend="mouse-pointers">resize pointer</link> appears when your mouse is in the correct position to begin the drag action.</para>
+            <para>Drag one of the borders to expand or contract the window on that side. Drag a corner to change two sides at once. The resize pointer (see <xref linkend="mouse-pointers"/>) appears when your mouse is in the correct position to begin the drag action.</para>
 
             <para>You can also choose Resize from the Window Menu, or press <keycombo>
             <keycap>Alt</keycap><keycap>F8</keycap></keycombo>. The resize pointer appears. Move the mouse in the direction of the edge you want to resize, or press one of the keyboard arrows keys. The pointer changes to indicate the chosen edge. Now you can use the mouse or the arrow keys to move this edge of the window. Click the mouse or press <keycap>Return</keycap> to accept the change. Press <keycap>Escape</keycap> to cancel the resize action and return the window to its original size and shape.</para> 
@@ -242,7 +242,7 @@
       <varlistentry>
         <term>Minimize the window</term>
         <listitem>
-            <para>Click on the Minimize button in the titlebar, the leftmost of the group of three on the right. This removes the window from view. The window can be restored to its previous position and size on the screen from the <firstterm>window list</firstterm> on the <link linkend="gospanel-3">bottom edge panel</link> or the <firstterm>window selector</firstterm> in the top panel.</para>
+            <para>Click on the Minimize button in the titlebar, the leftmost of the group of three on the right. This removes the window from view. The window can be restored to its previous position and size on the screen from the <firstterm>window list</firstterm> on the <xref linkend="bottom-panel"/> or the <firstterm>window selector</firstterm> in the top panel.</para>
             
             <para>You can also choose Minimize from the Window Menu, or press <keycombo>
             <keycap>Alt</keycap><keycap>F9</keycap>
@@ -316,7 +316,7 @@
           With the keyboard, hold the <keycap>Alt</keycap> key and press the <keycap>Tab</keycap> key. A pop-up window appears with a list of icons representing each window. While still holding <keycap>Alt</keycap>, press <keycap>Tab</keycap> to move the selection along the list: a black rectangle frames the selected icon and the position of the window it corresponds to is highlighted with a black border. When the window you want to see is selected, release the <keycap>Alt</keycap> key. Using <keycombo><keycap>Shift</keycap><keycap>Tab</keycap></keycombo> instead of just <keycap>Tab</keycap> cycles through the icons in reverse order.      
           </para>
           <note><para>
-            You can customize the shortcut used to perform this action with the <link linkend="prefs-keyboard-shortcuts">Keyboard Shortcuts preference tool</link>.
+            You can customize the shortcut used to perform this action with the <xref linkend="prefs-keyboard-shortcuts"/> tool.
           </para></note>
         </listitem>      
       </itemizedlist>
@@ -333,7 +333,7 @@
     </indexterm>
     <para>Workspaces allow you to manage which windows are on your screen. You can imagine workspaces as being virtual screens, which you can switch between at any time. Every workspace contains the same desktop, the same panels, and the same menus. However, you can run different applications, and open different windows in each workspace. The applications in each workspace will remain there when you switch to other workspaces.</para>
 
-    <para>By default, four workspaces are available. You can switch between them with the <application>Workspace Switcher</application> applet at the right of the <link linkend="bottom-panel">bottom panel</link>. This shows a representation of your workspaces, by default a row of four rectangles. Click on one to switch to that workspace. In <xref linkend="gosoverview-FIG-42"/>, <application>Workspace Switcher</application> contains four workspaces. The first three workspaces contain open windows. The last workspace does not contain currently open windows. The currently active workspace is highlighted.</para>
+    <para>By default, four workspaces are available. You can switch between them with the <application>Workspace Switcher</application> applet at the right of the <xref linkend="bottom-panel"/>. This shows a representation of your workspaces, by default a row of four rectangles. Click on one to switch to that workspace. In <xref linkend="gosoverview-FIG-42"/>, <application>Workspace Switcher</application> contains four workspaces. The first three workspaces contain open windows. The last workspace does not contain currently open windows. The currently active workspace is highlighted.</para>
     
     <figure xml:id="gosoverview-FIG-42"><info><title>Workspaces Displayed in Workspace Switcher</title></info>
       <screenshot>
@@ -411,7 +411,7 @@ specify the number of workspaces that you require.</para>
       <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:mate-dictionary" type="help"><application>Dictionary</application></link> allows you to look up definitions of a word. </para></listitem>
       <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:eom" type="help"><application>Image Viewer</application></link> can display single image files, as well as large image collections.</para></listitem>
       <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:gucharmap" type="help"><application>Character Map</application></link> lets you choose letters and symbols from the <firstterm>Unicode</firstterm> character set and paste them into any application. If you are writing in several languages, not all the characters you need will be on your keyboard.</para></listitem>
-      <listitem><para><link linkend="caja"><application>Caja File Manager</application></link> displays your folders and their contents. Use this to copy, move and classify your files, and to access CDs, USB flash drives, and any other removable media. When you choose an item from the <link linkend="places-menu"><guimenu>Places</guimenu> menu</link>, a <application>Caja File Manager</application> window opens showing that location.</para></listitem>
+      <listitem><para><application>Caja File Manager</application> (see <xref linkend="caja"/>) displays your folders and their contents. Use this to copy, move and classify your files, and to access CDs, USB flash drives, and any other removable media. When you choose an item from the <xref linkend="places-menu"/>, a <application>Caja File Manager</application> window opens showing that location.</para></listitem>
       <listitem><para><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="help:mate-terminal" type="help"><application>Terminal</application></link> gives you access to the system command line.</para></listitem>
     </itemizedlist>
 
@@ -426,7 +426,7 @@ specify the number of workspaces that you require.</para>
       <itemizedlist>
         <listitem>
           <para>Consistent look-and-feel</para>
-          <para>MATE-compliant applications have a consistent look-and-feel. You can use the <link linkend="prefs-theme"><application>Appearance</application> preference tool</link> to change the look-and-feel of your MATE-compliant applications.</para>
+          <para>MATE-compliant applications have a consistent look-and-feel. You can use the <xref linkend="prefs-theme"/> tool to change the look-and-feel of your MATE-compliant applications.</para>
         </listitem>
         <listitem>
           <para>Menubars, toolbars, and statusbars</para>
@@ -474,7 +474,7 @@ specify the number of workspaces that you require.</para>
       <para>To change the location shown in the right-hand pane, do one of the following:</para>
       <itemizedlist>
 	      <listitem><para>Open a folder that is listed in the current location.</para></listitem>
-	      <listitem><para>Open an item in the left-hand pane. This pane lists places such as your Documents folder, your Home Folder, media such as CDs and flash drives, places on your network, and your <link linkend="caja-bookmarks">bookmarks</link>.</para></listitem>
+	      <listitem><para>Open an item in the left-hand pane. This pane lists places such as your Documents folder, your Home Folder, media such as CDs and flash drives, places on your network, and your bookmarks (see <xref linkend="caja-bookmarks"/> for more on bookmarks).</para></listitem>
 	      <listitem><para>Click one of the buttons in the path bar above the file listing pane. This shows the hierarchy of folders that contain your current location. Use the arrow buttons to either side of the button bar if the list of folders is too long to fit.</para></listitem>
       </itemizedlist>
       
@@ -524,7 +524,7 @@ specify the number of workspaces that you require.</para>
                           
         <section xml:id="filechooser-save-expanded"><info><title>Saving in another location</title></info>
           <para>To save the file in a location not listed in the drop-down list, click the <guilabel>Browse for other folders</guilabel> expansion label. This shows a file browser similar to the one in the <guilabel>Open File</guilabel> dialog.</para>
-          <tip><para>The expanded <guilabel>Save File</guilabel> dialog has the same features as the <link linkend="filechooser-open"><guilabel>Open File</guilabel> dialog</link>, such as filtering, find-as-you-type, and adding and removing bookmarks.</para></tip>
+          <tip><para>The expanded <guilabel>Save File</guilabel> dialog has the same features as the <guilabel>Open File</guilabel> dialog (see <xref linkend="filechooser-open"/>), such as filtering, find-as-you-type, and adding and removing bookmarks.</para></tip>
         </section>   
         
         <section xml:id="filechooser-save-overwrite"><info><title>Replacing an existing file</title></info>

--- a/mate-user-guide/C/gospanel.xml
+++ b/mate-user-guide/C/gospanel.xml
@@ -265,7 +265,7 @@ buttons, if the hide button is enabled.</para>
                   </para>
                 </entry>
                 <entry valign="top">
-                  <para>Select this option to have the panel use the settings in the <link linkend="prefs-theme"><application>Appearance</application> preference tool</link>. This keeps your panel's background looking the same as the rest of the desktop and applications.</para>
+                  <para>Select this option to have the panel use the settings in the <xref linkend="prefs-theme"/> tool. This keeps your panel's background looking the same as the rest of the desktop and applications.</para>
                 </entry>
               </row>
               <row>
@@ -319,8 +319,8 @@ many applications. For example:</para>
             <para>You can drag an image file from the <application>Caja</application> file manager to set it as the background of the panel.</para>     
           </listitem>
           <listitem>
-            <para>You can drag a color or a pattern from the <link linkend="caja-backgrounds-and-emblems"><guilabel>Backgrounds
-  and Emblems</guilabel> dialog</link> in <application>Caja</application> file manager to a panel to set it as the background.</para>         
+            <para>You can drag a color or a pattern from the <guilabel>Backgrounds
+  and Emblems</guilabel> dialog (see <xref linkend="caja-backgrounds-and-emblems"/>) in <application>Caja</application> file manager to a panel to set it as the background.</para>         
           </listitem>
         </itemizedlist>
         <para>Click <guibutton>Close</guibutton> to close the <guilabel>Panel Properties</guilabel> dialog.</para>
@@ -356,7 +356,7 @@ buttons are now visible.</para>
       <para>You can set a panel to autohide. When you set autohide, the panel hides
 automatically when the mouse is not pointing to the panel. The panel reappears
 when you point to the part of the screen where the panel resides. To set your
-panel to autohide, <link linkend="panel-properties">modify the properties</link> of the panel.</para>
+panel to autohide, modify the properties of the panel as per the instructions in <xref linkend="panel-properties"/>.</para>
     </section>
 
     <section xml:id="gospanel-10"><info><title>Adding a New Panel</title></info>
@@ -438,7 +438,7 @@ popup menu.</para>
           <listitem>
             <para>Some applets have popup menus of applet-specific commands
   that open when you right-click on particular parts of the applet. For example,
-  the <application><link linkend="windowlist">Window List</link></application> applet has a vertical handle on
+  the <application><xref linkend="windowlist"/></application> applet has a vertical handle on
   the left side, and buttons that represent your windows on the right side.
   To open the panel object popup menu for the <application>Window List</application>
   applet, you must right-click on the handle. If you right-click on a button
@@ -473,7 +473,7 @@ popup menu.</para>
         </para></listitem>
         <listitem><para>
           Choose <guisubmenu>Add to Panel</guisubmenu>.</para>
-          <para>The <guilabel>Add to Panel</guilabel> dialog opens.The available panel objects are listed alphabetically, with <link linkend="launchers">launchers</link> at the top.</para>
+          <para>The <guilabel>Add to Panel</guilabel> dialog opens.The available panel objects are listed alphabetically, with <xref linkend="launchers"/> at the top.</para>
           <tip><para>You can type a part of the name or description of an object in the <guilabel>find</guilabel> box. This will narrow the list to those objects that match what you type.</para>
           <para>To restore the full list, delete the text in the <guilabel>find</guilabel> box.</para>
           </tip>
@@ -739,7 +739,7 @@ ways:</para>
         <listitem>
           <para>From the panel popup menu</para>
           <para>Right-click on any vacant space on the panel,
-then choose <guimenu>Add to Panel</guimenu>. The <link linkend="panels-addobject"><guilabel>Add to Panel</guilabel> dialog</link> opens.</para>
+then choose <guimenu>Add to Panel</guimenu>. The <guilabel>Add to Panel</guilabel> dialog opens (see <xref linkend="panels-addobject"/>).</para>
           <para>To create a new launcher, select <guilabel>Custom Application Launcher</guilabel> from the list. A <guilabel>Create Launcher</guilabel>
 dialog is displayed. For more information on the properties in this dialog,
 see <xref linkend="launchers-properties"/>.</para>
@@ -1107,7 +1107,7 @@ the same function as when you click on the <guibutton>Lock Screen</guibutton> bu
                 </para>
               </entry>
               <entry valign="top">
-                <para>Opens the <link linkend="prefs-screensaver"><application>Screensaver</application> preference tool</link>, with which you can configure the type of screensaver that is displayed when you lock the screen.</para>
+                <para>Opens the <xref linkend="prefs-screensaver"/> tool, with which you can configure the type of screensaver that is displayed when you lock the screen.</para>
               </entry>
             </row>
           </tbody>

--- a/mate-user-guide/C/gosstartsession.xml
+++ b/mate-user-guide/C/gosstartsession.xml
@@ -324,7 +324,7 @@ panel, click on the <guibutton>Lock Screen</guibutton> button.</para>
     <para>When you end a session, applications with unsaved work will warn you. You can choose to save your work, or cancel the command to log out or shut down.</para>
 
     <para>Before you end a session, you might want to save your current
-settings so that you can restore the session later. In the <link linkend="prefs-sessions"><application>Sessions</application></link> preference tool, you can select an option to automatically
+settings so that you can restore the session later. In the <xref linkend="prefs-sessions"/> tool, you can select an option to automatically
 save your current settings.</para>
   </section>
 </chapter>

--- a/mate-user-guide/C/gostools.xml
+++ b/mate-user-guide/C/gostools.xml
@@ -37,8 +37,8 @@
             <para>
               Press <keycombo><keycap>Alt</keycap><keycap>F2</keycap></keycombo>. You can change 
               the shortcut keys that display the <guilabel>Run Application</guilabel> dialog
-              in the <link linkend="prefs-keyboard-shortcuts"><application>Keyboard Shortcuts</application> 
-            preference tool</link>.</para>
+              in the <application><xref linkend="prefs-keyboard-shortcuts"/></application> tool.
+            </para>
           </listitem>
           </varlistentry>
         </variablelist>
@@ -121,8 +121,7 @@ a screenshot of the entire screen.</para>
           </tbody>
         </tgroup>
       </informaltable>
-      <para>You can use the <link linkend="prefs-keyboard-shortcuts"><application>Keyboard Shortcuts</application> 
-      preference tool</link> to modify the default shortcut keys.</para>
+      <para>You can use the <application><xref linkend="prefs-keyboard-shortcuts"/></application> tool to modify the default shortcut keys.</para>
     </listitem>
     <listitem>
       <para>From the Menubar</para>


### PR DESCRIPTION
This commit replaces all ``link`` element with ``xref`` for working around the ``yelp`` bug that most probably makes all ``link`` links nonfunctional. Also corrects a ``linkend`` attribute: ``gospanel-3`` to ``bottom-panel`` in ``gosoverview.xml``.