### PR TITLE
Change url project's website

### DIFF
--- a/mate-user-guide/C/gospanel.xml
+++ b/mate-user-guide/C/gospanel.xml
@@ -947,7 +947,7 @@ shows some sample locations and the actions that will happen if you click on the
               <row>
                 <entry valign="top">
                   <para>
-                    <command>http://www.mate-desktop.org</command>
+                    <command>https://mate-desktop.org</command>
                   </para>
                 </entry>
                 <entry valign="top">

--- a/mate-user-guide/C/gostools.xml
+++ b/mate-user-guide/C/gostools.xml
@@ -48,7 +48,7 @@
     <listitem>
       <para>Enter the command that you want to run in the blank field, or choose from the list of known applications.</para>
       <para>If you enter only the location of a file, an appropriate application will launch to open it.
-      If you enter a web page address, your default web browser will open the page. Prefix the web page address with http://, as in http://www.mate-desktop.org.
+      If you enter a web page address, your default web browser will open the page. Prefix the web page address with http://, as in https://mate-desktop.org.
       </para>
       <para>
         To choose a command that you ran previously, click the

--- a/mate-user-guide/C/gostools.xml
+++ b/mate-user-guide/C/gostools.xml
@@ -48,7 +48,7 @@
     <listitem>
       <para>Enter the command that you want to run in the blank field, or choose from the list of known applications.</para>
       <para>If you enter only the location of a file, an appropriate application will launch to open it.
-      If you enter a web page address, your default web browser will open the page. Prefix the web page address with http://, as in https://mate-desktop.org.
+      If you enter a web page address, your default web browser will open the page. Prefix the web page address with https://, as in https://mate-desktop.org.
       </para>
       <para>
         To choose a command that you ran previously, click the

--- a/mate-user-guide/mate-user-guide.pot
+++ b/mate-user-guide/mate-user-guide.pot
@@ -13684,7 +13684,7 @@ msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/gostools.xml:50
-msgid "If you enter only the location of a file, an appropriate application will launch to open it. If you enter a web page address, your default web browser will open the page. Prefix the web page address with http://, as in https://mate-desktop.org."
+msgid "If you enter only the location of a file, an appropriate application will launch to open it. If you enter a web page address, your default web browser will open the page. Prefix the web page address with https://, as in https://mate-desktop.org."
 msgstr ""
 
 #. (itstool) path: listitem/para

--- a/mate-user-guide/mate-user-guide.pot
+++ b/mate-user-guide/mate-user-guide.pot
@@ -12268,7 +12268,7 @@ msgstr ""
 
 #. (itstool) path: entry/para
 #: C/gospanel.xml:949
-msgid "<command>http://www.mate-desktop.org</command>"
+msgid "<command>https://mate-desktop.org</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
@@ -13684,7 +13684,7 @@ msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/gostools.xml:50
-msgid "If you enter only the location of a file, an appropriate application will launch to open it. If you enter a web page address, your default web browser will open the page. Prefix the web page address with http://, as in http://www.mate-desktop.org."
+msgid "If you enter only the location of a file, an appropriate application will launch to open it. If you enter a web page address, your default web browser will open the page. Prefix the web page address with http://, as in https://mate-desktop.org."
 msgstr ""
 
 #. (itstool) path: listitem/para


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.