### PR TITLE
build: allow users to disable gettext support (--disable-nls)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,19 @@
-SUBDIRS = po mate-user-guide
+if USE_NLS
+PO_SUBDIR = po
+endif
+
+SUBDIRS = $(PO_SUBDIR) mate-user-guide
 
 desktopdir = $(datadir)/applications
 desktop_in_files = mate-user-guide.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
 $(desktop_DATA): $(desktop_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 CLEANFILES = $(desktop_DATA)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,16 +2,18 @@ AC_INIT([mate-user-guide], [1.24.0], [https://github.com/mate-desktop/mate-user-
 AM_INIT_AUTOMAKE([1.11 dist-xz no-dist-gzip])
 AM_SILENT_RULES([yes])
 
-YELP_HELP_INIT
-
 AM_MAINTAINER_MODE([enable])
 
 GETTEXT_PACKAGE="mate-user-guide"
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [The gettext translation domain])
 AC_SUBST(GETTEXT_PACKAGE)
+
+AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
-AM_GNU_GETTEXT([external])
+AM_CONDITIONAL([USE_NLS], [test "x${USE_NLS}" = "xyes"])
+
+YELP_HELP_INIT
 
 AC_OUTPUT([
 Makefile
@@ -20,3 +22,13 @@ po/Makefile.in
 mate-user-guide/Makefile
 ])
 
+AC_OUTPUT
+
+echo "
+Configure summary:
+
+	${PACKAGE_STRING}
+	`echo $PACKAGE_STRING | sed "s/./=/g"`
+
+	Native Language support.....:  ${USE_NLS}
+"

--- a/mate-user-guide/Makefile.am
+++ b/mate-user-guide/Makefile.am
@@ -16,7 +16,7 @@ HELP_FILES = index.docbook	\
 	gosfeedback.xml		\
 	glossary.xml
 
-HELP_MEDIA =					\
+HELP_MEDIA = \
 	figures/ask_pointer.png \
 	figures/busy_pointer.png \
 	figures/caja_always_use_browser.png \
@@ -73,10 +73,14 @@ HELP_MEDIA =					\
 	figures/yelp_preferences.png \
 	figures/yelp_window.png
 
+if USE_NLS
 # Add linguas to be ignored, e.g. IGNORE_HELP_LINGUAS = ca de es fr
 IGNORE_HELP_LINGUAS =
 HELP_LINGUAS = $(if $(IGNORE_HELP_LINGUAS), \
 	$(filter-out $(IGNORE_HELP_LINGUAS),$(subst /,,$(dir $(wildcard */*.po)))), \
 	$(subst /,,$(dir $(wildcard */*.po))) )
+else
+HELP_LINGUAS =
+endif
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
### With NLS
```
$ find /usr/share/help -type d -name 'mate-user-guide' -exec sudo rm -fr {} +
$ ./autogen.sh --prefix=/usr && make && sudo make install
$ find /usr/share/help -type d -name 'mate-user-guide' -exec du -ch {} + | grep total
98M	total
```
### Without NLS
```
$ find /usr/share/help -type d -name 'mate-user-guide' -exec sudo rm -fr {} +
$ ./autogen.sh --prefix=/usr --disable-nls && make && sudo make install
$ find /usr/share/help -type d -name 'mate-user-guide' -exec du -ch {} + | grep total
1,7M	total
```
